### PR TITLE
Notify when Tidemark needs a restart after updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "gtk4",
  "ksni",
  "libadwaita",
+ "semver",
  "tidemark-types",
  "tracing",
  "tracing-subscriber",

--- a/crates/tidemark/Cargo.toml
+++ b/crates/tidemark/Cargo.toml
@@ -24,6 +24,7 @@ gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }
 # libayatana-appindicator-glib it can be linked into an MIT project; and it is built on the
 # same zbus 5 with the same async-io backend this crate already talks to the daemon over.
 ksni = { version = "0.3.6", default-features = false, features = ["async-io"] }
+semver = "1.0.28"
 tidemark-types = { path = "../tidemark-types" }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -67,9 +67,9 @@ impl MockDaemon {
         Ok(())
     }
 
-    #[zbus(property)]
+    #[zbus(property(emits_changed_signal = "false"))]
     async fn version(&self) -> String {
-        format!("{} (mock)", env!("CARGO_PKG_VERSION"))
+        env!("CARGO_PKG_VERSION").to_owned()
     }
 
     #[zbus(signal)]

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -96,7 +96,7 @@ pub trait Daemon {
     ) -> zbus::Result<()>;
 
     /// What the daemon on the other end is.
-    #[zbus(property)]
+    #[zbus(property(emits_changed_signal = "false"))]
     fn version(&self) -> zbus::Result<String>;
 
     /// One account changed.
@@ -114,14 +114,11 @@ pub trait Daemon {
 /// status — and that is deliberate rather than an oversight worth boxing away: this value
 /// is constructed a handful of times a minute and consumed immediately.
 #[derive(Debug)]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "constructed a handful of times a minute and consumed immediately; boxing would buy nothing"
-)]
 pub enum Update {
     /// The daemon answered. Carries everything it knows, and the handle to ask it for more.
     Connected(
         DaemonProxy<'static>,
+        Option<String>,
         Vec<ProviderDefinition>,
         Vec<ProviderStatus>,
     ),
@@ -216,12 +213,22 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
 
 /// Asks for the whole picture, and reports what came back.
 async fn load(proxy: &DaemonProxy<'static>, on: &impl Fn(Update)) {
+    let version = match proxy.version().await {
+        Ok(version) => Some(version),
+        Err(error) => {
+            tracing::warn!(%error, "the daemon did not answer Version");
+            None
+        }
+    };
     let definitions = proxy.list_providers().await;
     let statuses = proxy.get_status().await;
     match (definitions, statuses) {
-        (Ok(definitions), Ok(statuses)) => {
-            on(Update::Connected(proxy.clone(), definitions, statuses))
-        }
+        (Ok(definitions), Ok(statuses)) => on(Update::Connected(
+            proxy.clone(),
+            version,
+            definitions,
+            statuses,
+        )),
         (Err(error), _) | (_, Err(error)) => {
             tracing::info!(%error, "the daemon did not answer ListProviders or GetStatus");
             on(Update::Waiting("The daemon is not running.".into()));
@@ -238,7 +245,37 @@ enum Event {
 
 #[cfg(test)]
 mod tests {
-    use tidemark_types::ids;
+    use std::cell::RefCell;
+    use std::process;
+
+    use tidemark_types::{ProviderDefinition, ProviderStatus, ids};
+
+    use super::{DaemonProxy, Update, load};
+
+    #[derive(Debug)]
+    struct VersionService(&'static str);
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl VersionService {
+        #[zbus(property)]
+        fn version(&self) -> String {
+            self.0.to_owned()
+        }
+    }
+
+    #[derive(Debug)]
+    struct StatusService;
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl StatusService {
+        fn list_providers(&self) -> Vec<ProviderDefinition> {
+            Vec::new()
+        }
+
+        fn get_status(&self) -> Vec<ProviderStatus> {
+            Vec::new()
+        }
+    }
 
     #[test]
     fn the_proxy_is_pointed_at_the_interface_the_daemon_serves() {
@@ -246,5 +283,89 @@ mod tests {
         assert_eq!(ids::DAEMON_INTERFACE, "io.github.zbndev.Tidemark.Daemon1");
         assert_eq!(ids::DAEMON_BUS_NAME, "io.github.zbndev.Tidemark.Daemon");
         assert_eq!(ids::OBJECT_PATH, "/io/github/zbndev/Tidemark");
+    }
+
+    #[test]
+    fn version_is_read_from_a_replacement_daemon_owner() {
+        zbus::block_on(async {
+            let Ok(client_connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus is reachable");
+                return;
+            };
+            let name = format!("io.github.zbndev.Tidemark.Test.p{}", process::id());
+            let first = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(name.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, VersionService("0.1.0"))
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("first test service");
+            let proxy = DaemonProxy::builder(&client_connection)
+                .destination(name.as_str())
+                .expect("test destination")
+                .build()
+                .await
+                .expect("daemon proxy");
+
+            assert_eq!(proxy.version().await.unwrap(), "0.1.0");
+            assert!(first.release_name(name.as_str()).await.unwrap());
+
+            let _second = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(name.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, VersionService("0.2.0"))
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("replacement test service");
+
+            assert_eq!(proxy.version().await.unwrap(), "0.2.0");
+        });
+    }
+
+    #[test]
+    fn an_unavailable_version_does_not_hide_the_daemons_status() {
+        zbus::block_on(async {
+            let Ok(client_connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus is reachable");
+                return;
+            };
+            let name = format!("io.github.zbndev.Tidemark.StatusTest.p{}", process::id());
+            let _service = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(name.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, StatusService)
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("test service");
+            let destination = zbus::names::OwnedBusName::try_from(name.as_str())
+                .expect("valid owned test destination");
+            let proxy = DaemonProxy::builder(&client_connection)
+                .destination(destination)
+                .expect("test destination")
+                .build()
+                .await
+                .expect("daemon proxy");
+            let seen = RefCell::new(None);
+
+            load(&proxy, &|update| {
+                seen.replace(Some(update));
+            })
+            .await;
+
+            match seen.into_inner() {
+                Some(Update::Connected(_, version, definitions, statuses)) => {
+                    assert_eq!(version, None);
+                    assert!(definitions.is_empty());
+                    assert!(statuses.is_empty());
+                }
+                other => panic!("expected connected status, got {other:?}"),
+            }
+        });
     }
 }

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -21,6 +21,7 @@ mod model;
 mod provider_settings;
 mod style;
 mod tray;
+mod update;
 mod window;
 
 use adw::prelude::*;

--- a/crates/tidemark/src/update.rs
+++ b/crates/tidemark/src/update.rs
@@ -1,0 +1,101 @@
+use std::ffi::OsStr;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use semver::{Error, Version};
+
+/// Remembers which daemon release this client has already offered to restart into.
+#[derive(Debug)]
+pub struct UpdateNotice {
+    client: Version,
+    offered: Option<Version>,
+}
+
+impl UpdateNotice {
+    pub fn new(client: &str) -> Self {
+        Self {
+            client: Version::parse(client).expect("Cargo always supplies a SemVer package version"),
+            offered: None,
+        }
+    }
+
+    /// Returns true once for each successively newer daemon release.
+    pub fn consider(&mut self, daemon: &str) -> Result<bool, Error> {
+        let daemon = Version::parse(daemon)?;
+        let newer_than_client = daemon > self.client;
+        let newer_than_offer = self
+            .offered
+            .as_ref()
+            .is_none_or(|offered| daemon > *offered);
+        if newer_than_client && newer_than_offer {
+            self.offered = Some(daemon);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+fn restart_command<I, S>(args: I) -> Option<Command>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut args = args.into_iter();
+    let program = args.next()?;
+    let mut command = Command::new(program);
+    command.args(args);
+    Some(command)
+}
+
+/// Replaces this process with the same command, avoiding a race with GTK's single instance.
+pub fn restart() -> io::Error {
+    let Some(mut command) = restart_command(std::env::args_os()) else {
+        return io::Error::new(io::ErrorKind::NotFound, "the program name is unavailable");
+    };
+    command.exec()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::{UpdateNotice, restart_command};
+
+    #[test]
+    fn a_newer_daemon_is_offered_even_when_lexical_order_would_disagree() {
+        let mut notice = UpdateNotice::new("0.9.0");
+
+        assert!(notice.consider("0.10.0").unwrap());
+    }
+
+    #[test]
+    fn the_same_daemon_release_is_only_offered_once() {
+        let mut notice = UpdateNotice::new("0.1.0");
+
+        assert!(notice.consider("0.2.0").unwrap());
+        assert!(!notice.consider("0.2.0").unwrap());
+        assert!(notice.consider("0.3.0").unwrap());
+    }
+
+    #[test]
+    fn equal_older_and_invalid_daemon_versions_are_not_updates() {
+        let mut notice = UpdateNotice::new("1.2.3");
+
+        assert!(!notice.consider("1.2.3").unwrap());
+        assert!(!notice.consider("1.2.2").unwrap());
+        assert!(notice.consider("development build").is_err());
+    }
+
+    #[test]
+    fn restart_reuses_the_original_program_and_arguments() {
+        let command = restart_command(["tidemark", "--background"]).unwrap();
+
+        assert_eq!(command.get_program(), OsStr::new("tidemark"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("--background")]
+        );
+    }
+}

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -27,6 +27,7 @@ use crate::detail::DetailDialog;
 use crate::model;
 use crate::provider_settings::ProviderSettings;
 use crate::tray::{self, Tray};
+use crate::update::{self, UpdateNotice};
 
 /// How often the clock-dependent parts of every card are redrawn. Half a minute is well
 /// inside the resolution of everything shown — the coarsest unit on a card is a minute —
@@ -87,6 +88,7 @@ pub struct MainWindow {
     cards: RefCell<Vec<Rc<Card>>>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     daemon: RefCell<Option<DaemonProxy<'static>>>,
+    update_notice: RefCell<UpdateNotice>,
     /// The provider dialog while it is open, so live catalog and status changes reach it.
     provider_settings: DialogSlot<ProviderSettings>,
     /// The account detail dialog while it is open, so its chart follows daemon updates.
@@ -177,6 +179,7 @@ impl MainWindow {
             cards: RefCell::new(Vec::new()),
             definitions: RefCell::new(Vec::new()),
             daemon: RefCell::new(None),
+            update_notice: RefCell::new(UpdateNotice::new(env!("CARGO_PKG_VERSION"))),
             provider_settings: DialogSlot::default(),
             detail_dialog: DialogSlot::default(),
             tray: RefCell::new(None),
@@ -202,12 +205,49 @@ impl MainWindow {
     /// Acts on one message from the daemon.
     fn handle(self: &Rc<Self>, update: Update) {
         match update {
-            Update::Connected(proxy, definitions, statuses) => {
+            Update::Connected(proxy, daemon_version, definitions, statuses) => {
                 *self.daemon.borrow_mut() = Some(proxy);
                 *self.definitions.borrow_mut() = definitions;
                 self.refresh.set_sensitive(true);
                 self.providers.set_sensitive(true);
                 self.show_all(statuses);
+
+                let offer_restart = daemon_version.as_deref().is_some_and(|version| {
+                    match self.update_notice.borrow_mut().consider(version) {
+                        Ok(offer) => offer,
+                        Err(error) => {
+                            tracing::warn!(version, %error, "the daemon reported an invalid version");
+                            false
+                        }
+                    }
+                });
+                if offer_restart {
+                    self.window.present();
+                    let parent = self.window.clone();
+                    glib::spawn_future_local(async move {
+                        let notice = adw::AlertDialog::builder()
+                            .heading("Tidemark has been updated")
+                            .body("Restart the app to finish the update.")
+                            .build();
+                        notice.add_responses(&[("later", "Later"), ("restart", "Restart")]);
+                        notice.set_default_response(Some("restart"));
+                        notice.set_close_response("later");
+                        notice
+                            .set_response_appearance("restart", adw::ResponseAppearance::Suggested);
+                        if notice.choose_future(Some(&parent)).await == "restart" {
+                            let error = update::restart();
+                            tracing::error!(%error, "could not restart the desktop client");
+
+                            let failure = adw::AlertDialog::builder()
+                                .heading("Tidemark could not restart")
+                                .body(format!("Restart the app manually. {error}"))
+                                .build();
+                            failure.add_response("close", "Close");
+                            failure.set_close_response("close");
+                            failure.choose_future(Some(&parent)).await;
+                        }
+                    });
+                }
             }
             Update::Changed(status) => self.show_one(status),
             Update::Removed { provider, account } => self.show_removed(&provider, &account),

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -635,7 +635,7 @@ impl Daemon {
     }
 
     /// The daemon's version, so a client can tell what it is talking to.
-    #[zbus(property)]
+    #[zbus(property(emits_changed_signal = "false"))]
     async fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_owned()
     }


### PR DESCRIPTION
## Summary

- compare the running frontend version with the daemon version after every full D-Bus connection, including daemon owner replacement
- show a Restart/Later alert when the daemon is newer and suppress repeat alerts for the same release
- restart in place with the original command and keep status loading available when Version cannot be read
- mark Version uncached and cover daemon replacement and fallback behavior with real D-Bus regression tests

## Verification

- `cargo test --workspace`
- `dbus-run-session -- cargo test -p tidemark --bin tidemark bus::tests`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `scripts/check-layering.sh`
- `makepkg -sif --noconfirm`
- installed `/usr/bin/tidemark` Xvfb smoke: daemon `0.1.0` replaced by `0.2.0`, alert appeared, Later suppressed the same release, and Restart re-execed with the same PID