### PR TITLE
Notify users when a newer release is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,8 @@ dependencies = [
 name = "tidemarkd"
 version = "0.1.0"
 dependencies = [
+ "reqwest",
+ "semver",
  "serde_json",
  "thiserror",
  "tidemark-core",

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -62,6 +62,10 @@ impl MockDaemon {
         self.statuses.clone()
     }
 
+    async fn get_update(&self) -> String {
+        "0.2.0".into()
+    }
+
     async fn refresh(&self, provider: &str) -> fdo::Result<()> {
         println!("refresh({provider:?})");
         Ok(())
@@ -77,6 +81,9 @@ impl MockDaemon {
         emitter: &SignalEmitter<'_>,
         status: ProviderStatus,
     ) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    pub async fn update_changed(emitter: &SignalEmitter<'_>, version: &str) -> zbus::Result<()>;
 }
 
 fn window(title: &str, length: u64, used: f64, resets_in: Option<i64>) -> Window {

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -51,6 +51,9 @@ pub trait Daemon {
     /// Every account the daemon watches.
     fn get_status(&self) -> zbus::Result<Vec<ProviderStatus>>;
 
+    /// A newer published application release, or an empty string when none is known.
+    fn get_update(&self) -> zbus::Result<String>;
+
     /// Stored points in the current segment of one window, oldest first.
     fn current_segment(
         &self,
@@ -106,6 +109,10 @@ pub trait Daemon {
     /// One configured account was removed.
     #[zbus(signal)]
     fn provider_removed(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Availability of a newer published application release changed.
+    #[zbus(signal)]
+    fn update_changed(&self, version: &str) -> zbus::Result<()>;
 }
 
 /// What the window is told.
@@ -119,6 +126,7 @@ pub enum Update {
     Connected(
         DaemonProxy<'static>,
         Option<String>,
+        String,
         Vec<ProviderDefinition>,
         Vec<ProviderStatus>,
     ),
@@ -126,6 +134,8 @@ pub enum Update {
     Changed(ProviderStatus),
     /// One configured account was removed.
     Removed { provider: String, account: String },
+    /// Availability of a newer published application release changed.
+    Available(String),
     /// There is nothing to show, with the reason to put on the screen.
     Waiting(String),
 }
@@ -165,6 +175,7 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
     let mut owner = pin!(proxy.inner().receive_owner_changed().await?);
     let mut changes = pin!(proxy.receive_provider_changed().await?);
     let mut removals = pin!(proxy.receive_provider_removed().await?);
+    let mut updates = pin!(proxy.receive_update_changed().await?);
 
     load(&proxy, on).await;
 
@@ -178,6 +189,9 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
             }
             if let Poll::Ready(removal) = removals.as_mut().poll_next(context) {
                 return Poll::Ready(Event::Removed(removal));
+            }
+            if let Poll::Ready(update) = updates.as_mut().poll_next(context) {
+                return Poll::Ready(Event::Available(update));
             }
             Poll::Pending
         })
@@ -205,8 +219,15 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
                 }),
                 Err(error) => tracing::warn!(%error, "a ProviderRemoved signal did not parse"),
             },
-            // Either stream ending means the connection is finished with.
-            Event::Owner(None) | Event::Changed(None) | Event::Removed(None) => return Ok(()),
+            Event::Available(Some(signal)) => match signal.args() {
+                Ok(args) => on(Update::Available(args.version.to_owned())),
+                Err(error) => tracing::warn!(%error, "an UpdateChanged signal did not parse"),
+            },
+            // Any stream ending means the connection is finished with.
+            Event::Owner(None)
+            | Event::Changed(None)
+            | Event::Removed(None)
+            | Event::Available(None) => return Ok(()),
         }
     }
 }
@@ -222,10 +243,15 @@ async fn load(proxy: &DaemonProxy<'static>, on: &impl Fn(Update)) {
     };
     let definitions = proxy.list_providers().await;
     let statuses = proxy.get_status().await;
+    let available = proxy.get_update().await.unwrap_or_else(|error| {
+        tracing::info!(%error, "the daemon did not answer GetUpdate; hiding update availability");
+        String::new()
+    });
     match (definitions, statuses) {
         (Ok(definitions), Ok(statuses)) => on(Update::Connected(
             proxy.clone(),
             version,
+            available,
             definitions,
             statuses,
         )),
@@ -241,6 +267,7 @@ enum Event {
     Owner(Option<Option<zbus::names::UniqueName<'static>>>),
     Changed(Option<ProviderChanged>),
     Removed(Option<ProviderRemoved>),
+    Available(Option<UpdateChanged>),
 }
 
 #[cfg(test)]
@@ -359,8 +386,9 @@ mod tests {
             .await;
 
             match seen.into_inner() {
-                Some(Update::Connected(_, version, definitions, statuses)) => {
+                Some(Update::Connected(_, version, available, definitions, statuses)) => {
                     assert_eq!(version, None);
+                    assert_eq!(available, "");
                     assert!(definitions.is_empty());
                     assert!(statuses.is_empty());
                 }

--- a/crates/tidemark/src/update.rs
+++ b/crates/tidemark/src/update.rs
@@ -5,6 +5,12 @@ use std::process::Command;
 
 use semver::{Error, Version};
 
+pub(crate) const RELEASES_URL: &str = "https://github.com/zbndev/tidemark/releases";
+
+pub(crate) fn update_tooltip(version: &str) -> Option<String> {
+    (!version.is_empty()).then(|| format!("Tidemark {version} is available"))
+}
+
 /// Remembers which daemon release this client has already offered to restart into.
 #[derive(Debug)]
 pub struct UpdateNotice {
@@ -61,7 +67,20 @@ pub fn restart() -> io::Error {
 mod tests {
     use std::ffi::OsStr;
 
-    use super::{UpdateNotice, restart_command};
+    use super::{UpdateNotice, restart_command, update_tooltip};
+
+    #[test]
+    fn an_empty_update_has_no_button_copy() {
+        assert_eq!(update_tooltip(""), None);
+    }
+
+    #[test]
+    fn an_available_update_names_the_daemon_selected_version() {
+        assert_eq!(
+            update_tooltip("0.12.3").as_deref(),
+            Some("Tidemark 0.12.3 is available")
+        );
+    }
 
     #[test]
     fn a_newer_daemon_is_offered_even_when_lexical_order_would_disagree() {

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -84,6 +84,7 @@ pub struct MainWindow {
     message: adw::StatusPage,
     grid: gtk::FlowBox,
     refresh: gtk::Button,
+    release: gtk::Button,
     providers: gtk::Button,
     cards: RefCell<Vec<Rc<Card>>>,
     definitions: RefCell<Vec<ProviderDefinition>>,
@@ -148,6 +149,10 @@ impl MainWindow {
             .tooltip_text("Check every provider now")
             .sensitive(false)
             .build();
+        let release = gtk::Button::builder()
+            .icon_name("software-update-available-symbolic")
+            .visible(false)
+            .build();
         let providers = gtk::Button::builder()
             .icon_name("dialog-password-symbolic")
             .tooltip_text("Providers and credentials")
@@ -156,6 +161,7 @@ impl MainWindow {
 
         let header = adw::HeaderBar::new();
         header.pack_end(&refresh);
+        header.pack_end(&release);
         header.pack_start(&providers);
 
         let view = adw::ToolbarView::builder().content(&stack).build();
@@ -175,6 +181,7 @@ impl MainWindow {
             message,
             grid,
             refresh,
+            release,
             providers,
             cards: RefCell::new(Vec::new()),
             definitions: RefCell::new(Vec::new()),
@@ -187,6 +194,7 @@ impl MainWindow {
 
         main.install_sort();
         main.connect_refresh_button();
+        main.connect_update_button();
         main.connect_providers_button();
         main.start_clock();
         main.start_tray(background);
@@ -205,11 +213,12 @@ impl MainWindow {
     /// Acts on one message from the daemon.
     fn handle(self: &Rc<Self>, update: Update) {
         match update {
-            Update::Connected(proxy, daemon_version, definitions, statuses) => {
+            Update::Connected(proxy, daemon_version, available, definitions, statuses) => {
                 *self.daemon.borrow_mut() = Some(proxy);
                 *self.definitions.borrow_mut() = definitions;
                 self.refresh.set_sensitive(true);
                 self.providers.set_sensitive(true);
+                self.show_update(&available);
                 self.show_all(statuses);
 
                 let offer_restart = daemon_version.as_deref().is_some_and(|version| {
@@ -251,10 +260,12 @@ impl MainWindow {
             }
             Update::Changed(status) => self.show_one(status),
             Update::Removed { provider, account } => self.show_removed(&provider, &account),
+            Update::Available(version) => self.show_update(&version),
             Update::Waiting(reason) => {
                 *self.daemon.borrow_mut() = None;
                 self.refresh.set_sensitive(false);
                 self.providers.set_sensitive(false);
+                self.show_update("");
                 self.show_message("network-offline-symbolic", "Waiting for Tidemark", &reason);
             }
         }
@@ -515,6 +526,29 @@ impl MainWindow {
                 main.refresh_now();
             }
         });
+    }
+
+    /// Opens the fixed release list; the daemon-provided value controls visibility only.
+    fn connect_update_button(self: &Rc<Self>) {
+        let weak: Weak<Self> = Rc::downgrade(self);
+        self.release.connect_clicked(move |_| {
+            let Some(main) = weak.upgrade() else {
+                return;
+            };
+            let parent = main.window.clone();
+            glib::spawn_future_local(async move {
+                let launcher = gtk::UriLauncher::new(update::RELEASES_URL);
+                if let Err(error) = launcher.launch_future(Some(&parent)).await {
+                    tracing::warn!(%error, "could not open the Tidemark releases page");
+                }
+            });
+        });
+    }
+
+    fn show_update(&self, version: &str) {
+        let tooltip = update::update_tooltip(version);
+        self.release.set_tooltip_text(tooltip.as_deref());
+        self.release.set_visible(tooltip.is_some());
     }
 
     /// Polls every account now. The header button and the tray menu both mean this, and

--- a/crates/tidemarkd/Cargo.toml
+++ b/crates/tidemarkd/Cargo.toml
@@ -14,9 +14,11 @@ workspace = true
 [dependencies]
 tidemark-types = { path = "../tidemark-types" }
 tidemark-core = { version = "0.1.0", path = "../tidemark-core" }
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "signal", "time", "net", "io-util"] }
 zbus = "5.13.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 serde_json = "1.0.151"
 thiserror = "2.0.20"
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy"] }
+semver = "1.0.27"

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -31,7 +31,7 @@ use tokio::sync::mpsc;
 use zbus::object_server::SignalEmitter;
 
 use crate::engine::{Command, Engine, Publication};
-use crate::service::{Daemon, Published};
+use crate::service::{Daemon, Published, PublishedUpdate};
 
 /// Commands from D-Bus clients. Small: a burst of refreshes is a user hammering a button,
 /// and the loop collapses them into one poll anyway.
@@ -39,6 +39,18 @@ const COMMAND_QUEUE: usize = 16;
 
 /// Finished statuses waiting to be published. One per account per poll.
 const UPDATE_QUEUE: usize = 64;
+
+/// Applies one successful check and returns the signal payload only when state changed.
+async fn publish_result(
+    published: &PublishedUpdate,
+    result: Result<Option<String>, update::CheckError>,
+) -> Result<Option<String>, update::CheckError> {
+    let next = result?;
+    Ok(published
+        .replace(next.clone())
+        .await
+        .then(|| next.unwrap_or_default()))
+}
 
 fn main() -> std::process::ExitCode {
     tracing_subscriber::fmt()
@@ -108,6 +120,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let (commands, mut command_queue) = mpsc::channel(COMMAND_QUEUE);
     let (updates, mut update_queue) = mpsc::channel::<Publication>(UPDATE_QUEUE);
     let published = Published::default();
+    let published_update = PublishedUpdate::default();
 
     let connection = zbus::connection::Builder::session()?
         .name(ids::DAEMON_BUS_NAME)?
@@ -115,6 +128,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
             ids::OBJECT_PATH,
             Daemon::new(
                 published.clone(),
+                published_update.clone(),
                 catalog,
                 configured,
                 commands.clone(),
@@ -160,6 +174,32 @@ async fn run() -> Result<(), Box<dyn Error>> {
         }
     });
 
+    let release_checker = match update::Checker::production() {
+        Ok(checker) => {
+            let published_update = published_update.clone();
+            let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH)?;
+            Some(tokio::spawn(async move {
+                tokio::time::sleep(update::INITIAL_DELAY).await;
+                loop {
+                    match publish_result(&published_update, checker.check().await).await {
+                        Ok(Some(version)) => {
+                            if let Err(error) = Daemon::update_changed(&emitter, &version).await {
+                                tracing::warn!(%error, "could not announce update availability");
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(error) => tracing::info!(%error, "release check failed"),
+                    }
+                    tokio::time::sleep(update::INTERVAL).await;
+                }
+            }))
+        }
+        Err(error) => {
+            tracing::info!(%error, "release checker is unavailable");
+            None
+        }
+    };
+
     let mut term = signal(SignalKind::terminate())?;
     let mut interrupt = signal(SignalKind::interrupt())?;
     let signals = tokio::spawn({
@@ -195,6 +235,47 @@ async fn run() -> Result<(), Box<dyn Error>> {
     // ordering is what makes the last status of the session reach its clients.
     drop(engine);
     let _ = publisher.await;
+    if let Some(release_checker) = release_checker {
+        release_checker.abort();
+    }
     signals.abort();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_failed_release_check_preserves_the_previous_update() {
+        let published = PublishedUpdate::default();
+        assert!(published.replace(Some("0.2.0".into())).await);
+
+        let result = publish_result(&published, Err(update::CheckError::Version)).await;
+
+        assert!(result.is_err());
+        assert_eq!(published.get().await, "0.2.0");
+    }
+
+    #[tokio::test]
+    async fn only_a_changed_release_result_needs_a_signal() {
+        let published = PublishedUpdate::default();
+
+        assert_eq!(
+            publish_result(&published, Ok(Some("0.3.0".into())))
+                .await
+                .unwrap(),
+            Some("0.3.0".into())
+        );
+        assert_eq!(
+            publish_result(&published, Ok(Some("0.3.0".into())))
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            publish_result(&published, Ok(None)).await.unwrap(),
+            Some(String::new())
+        );
+    }
 }

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -16,6 +16,7 @@ mod notify;
 mod registry;
 mod scheduler;
 mod service;
+mod update;
 
 use std::error::Error;
 use std::sync::Arc;

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -97,6 +97,27 @@ impl Published {
     }
 }
 
+/// The newer application release, when a successful check found one.
+#[derive(Debug, Clone, Default)]
+pub struct PublishedUpdate(Arc<RwLock<Option<String>>>);
+
+impl PublishedUpdate {
+    /// The D-Bus representation: an empty string means no newer release is known.
+    pub async fn get(&self) -> String {
+        self.0.read().await.clone().unwrap_or_default()
+    }
+
+    /// Replaces the known release and reports whether clients need a signal.
+    pub async fn replace(&self, next: Option<String>) -> bool {
+        let mut held = self.0.write().await;
+        if *held == next {
+            return false;
+        }
+        *held = next;
+        true
+    }
+}
+
 /// A login that has been started and not yet finished.
 ///
 /// The task owns the listener and the exchange; this is the handle `AwaitLogin` takes to
@@ -122,6 +143,7 @@ impl Pending {
 #[derive(Debug)]
 pub struct Daemon {
     statuses: Published,
+    update: PublishedUpdate,
     catalog: Vec<ProviderDefinition>,
     configured: RwLock<HashSet<AccountKey>>,
     commands: mpsc::Sender<Command>,
@@ -134,6 +156,7 @@ impl Daemon {
     /// Wires the interface to the published state, the poll loop and the keyring.
     pub fn new(
         statuses: Published,
+        update: PublishedUpdate,
         catalog: Vec<ProviderDefinition>,
         configured: Vec<AccountKey>,
         commands: mpsc::Sender<Command>,
@@ -141,6 +164,7 @@ impl Daemon {
     ) -> Self {
         Self {
             statuses,
+            update,
             catalog,
             configured: RwLock::new(configured.into_iter().collect()),
             commands,
@@ -348,6 +372,11 @@ impl Daemon {
     /// the first poll, so a client can tell "nothing configured" from "nothing yet".
     async fn get_status(&self) -> Vec<ProviderStatus> {
         self.statuses.all().await
+    }
+
+    /// The newer published application release, or an empty string when none is known.
+    async fn get_update(&self) -> String {
+        self.update.get().await
     }
 
     /// Stored points in the open segment of one window.
@@ -655,6 +684,10 @@ impl Daemon {
         provider: &str,
         account: &str,
     ) -> zbus::Result<()>;
+
+    /// Availability of a newer published release changed; empty means there is none.
+    #[zbus(signal)]
+    pub async fn update_changed(emitter: &SignalEmitter<'_>, version: &str) -> zbus::Result<()>;
 }
 
 /// The pair an in-progress login is filed under.
@@ -793,6 +826,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_publication_changes_only_when_the_value_changes() {
+        let update = PublishedUpdate::default();
+        assert_eq!(update.get().await, "");
+        assert!(update.replace(Some("0.2.0".into())).await);
+        assert!(!update.replace(Some("0.2.0".into())).await);
+        assert_eq!(update.get().await, "0.2.0");
+        assert!(update.replace(None).await);
+        assert_eq!(update.get().await, "");
+    }
+
+    #[tokio::test]
     async fn removing_a_published_account_does_not_reorder_the_rest() {
         let published = Published::default();
         published.upsert(status("zai")).await;
@@ -849,6 +893,7 @@ mod tests {
         (
             Daemon::new(
                 published,
+                PublishedUpdate::default(),
                 catalog,
                 configured,
                 tx,
@@ -931,6 +976,7 @@ mod tests {
         let (commands, mut command_queue) = mpsc::channel(4);
         let daemon = Daemon::new(
             published,
+            PublishedUpdate::default(),
             catalog(),
             vec![("zai".into(), "default".into())],
             commands,
@@ -1322,6 +1368,7 @@ mod tests {
         let (commands, mut command_queue) = mpsc::channel(4);
         let daemon = Daemon::new(
             published,
+            PublishedUpdate::default(),
             catalog(),
             vec![("zai".into(), "default".into())],
             commands,
@@ -1606,6 +1653,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         let daemon = Daemon::new(
             published,
+            PublishedUpdate::default(),
             Vec::new(),
             vec![("zai".into(), "default".into())],
             tx,
@@ -1646,10 +1694,13 @@ mod tests {
 
         let published = Published::default();
         published.upsert(status("zai")).await;
+        let published_update = PublishedUpdate::default();
+        assert!(published_update.replace(Some("0.2.0".into())).await);
         let (commands, mut command_queue) = mpsc::channel(4);
 
         let Ok(server) = serve(Daemon::new(
             published,
+            published_update.clone(),
             Vec::new(),
             vec![("zai".into(), "default".into())],
             commands,
@@ -1694,6 +1745,22 @@ mod tests {
         assert_eq!(statuses[0].provider, "zai");
         assert_eq!(statuses[0].state, "pending");
 
+        let reply = client
+            .call_method(
+                Some(TEST_BUS_NAME),
+                ids::OBJECT_PATH,
+                Some(ids::DAEMON_INTERFACE),
+                "GetUpdate",
+                &(),
+            )
+            .await
+            .expect("GetUpdate answers");
+        let update: String = reply
+            .body()
+            .deserialize()
+            .expect("the available version is a string");
+        assert_eq!(update, "0.2.0");
+
         call("Refresh", "zai")
             .await
             .expect("a known provider refreshes");
@@ -1713,6 +1780,50 @@ mod tests {
             .msg_type(zbus::message::Type::Signal)
             .interface(ids::DAEMON_INTERFACE)
             .expect("a valid interface name")
+            .member("UpdateChanged")
+            .expect("a valid member name")
+            .build();
+        let update_signals = MessageStream::for_match_rule(rule, &client, Some(4))
+            .await
+            .expect("the bus accepts the update match rule");
+        let mut update_signals = pin!(update_signals);
+        let emitter = SignalEmitter::new(&server, ids::OBJECT_PATH).expect("a valid path");
+
+        assert!(published_update.replace(None).await);
+        Daemon::update_changed(&emitter, "")
+            .await
+            .expect("the update signal goes out");
+        let next = std::future::poll_fn(|cx| update_signals.as_mut().poll_next(cx));
+        let received = tokio::time::timeout(Duration::from_secs(5), next)
+            .await
+            .expect("the update signal arrives")
+            .expect("the stream is alive")
+            .expect("the message is well formed");
+        let carried: String = received
+            .body()
+            .deserialize()
+            .expect("the update signal carries a string");
+        assert_eq!(carried, "");
+        let reply = client
+            .call_method(
+                Some(TEST_BUS_NAME),
+                ids::OBJECT_PATH,
+                Some(ids::DAEMON_INTERFACE),
+                "GetUpdate",
+                &(),
+            )
+            .await
+            .expect("GetUpdate still answers after the signal");
+        let update: String = reply
+            .body()
+            .deserialize()
+            .expect("the update stays a string");
+        assert_eq!(update, "", "state was cleared before the signal");
+
+        let rule = MatchRule::builder()
+            .msg_type(zbus::message::Type::Signal)
+            .interface(ids::DAEMON_INTERFACE)
+            .expect("a valid interface name")
             .member("ProviderChanged")
             .expect("a valid member name")
             .build();
@@ -1721,7 +1832,6 @@ mod tests {
             .expect("the bus accepts the match rule");
         let mut signals = pin!(signals);
 
-        let emitter = SignalEmitter::new(&server, ids::OBJECT_PATH).expect("a valid path");
         let mut announced = status("zai");
         announced.captured_at = Some(1_785_700_000);
         Daemon::provider_changed(&emitter, announced)

--- a/crates/tidemarkd/src/update.rs
+++ b/crates/tidemarkd/src/update.rs
@@ -1,0 +1,226 @@
+//! Discovery of a newer published Tidemark release.
+
+use std::time::Duration;
+
+use reqwest::header::{ACCEPT, HeaderMap, HeaderName, HeaderValue};
+use semver::Version;
+
+pub(crate) const INITIAL_DELAY: Duration = Duration::from_secs(60);
+pub(crate) const INTERVAL: Duration = Duration::from_secs(60 * 60);
+const MAX_BODY: usize = 64 * 1024;
+const ENDPOINT: &str = "https://api.github.com/repos/zbndev/tidemark/releases/latest";
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckError {
+    #[error("could not build or send the release request")]
+    Http(#[source] reqwest::Error),
+    #[error("the release endpoint returned HTTP {0}")]
+    Status(reqwest::StatusCode),
+    #[error("the release response exceeded the size limit")]
+    TooLarge,
+    #[error("the release response was not valid JSON")]
+    Json(#[source] serde_json::Error),
+    #[error("the release or daemon version was not canonical X.X.X")]
+    Version,
+}
+
+#[derive(Debug)]
+pub(crate) struct Checker {
+    client: reqwest::Client,
+    endpoint: String,
+    current: String,
+}
+
+impl Checker {
+    pub(crate) fn production() -> Result<Self, CheckError> {
+        Self::at(ENDPOINT, env!("CARGO_PKG_VERSION"))
+    }
+
+    fn at(endpoint: impl Into<String>, current: impl Into<String>) -> Result<Self, CheckError> {
+        let current = current.into();
+        version(&current)?;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-github-api-version"),
+            HeaderValue::from_static("2026-03-10"),
+        );
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(tidemark_types::user_agent())
+            .default_headers(headers)
+            .build()
+            .map_err(CheckError::Http)?;
+
+        Ok(Self {
+            client,
+            endpoint: endpoint.into(),
+            current,
+        })
+    }
+
+    pub(crate) async fn check(&self) -> Result<Option<String>, CheckError> {
+        let mut response = self
+            .client
+            .get(&self.endpoint)
+            .send()
+            .await
+            .map_err(CheckError::Http)?;
+        if !response.status().is_success() {
+            return Err(CheckError::Status(response.status()));
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(CheckError::Http)? {
+            if body.len().saturating_add(chunk.len()) > MAX_BODY {
+                return Err(CheckError::TooLarge);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let response: serde_json::Value =
+            serde_json::from_slice(&body).map_err(CheckError::Json)?;
+        let tag = response
+            .get("tag_name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(CheckError::Version)?;
+        newer(tag, &self.current)
+    }
+}
+
+fn version(text: &str) -> Result<Version, CheckError> {
+    let parts: Vec<_> = text.split('.').collect();
+    if parts.len() != 3
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || !part.bytes().all(|byte| byte.is_ascii_digit())
+                || (part.len() > 1 && part.starts_with('0'))
+        })
+    {
+        return Err(CheckError::Version);
+    }
+    Version::parse(text).map_err(|_| CheckError::Version)
+}
+
+fn newer(tag: &str, current: &str) -> Result<Option<String>, CheckError> {
+    let release = version(tag.strip_prefix('v').ok_or(CheckError::Version)?)?;
+    let current = version(current)?;
+    Ok((release > current).then(|| release.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn serve_once(status: &str, body: &[u8]) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("the test can bind loopback");
+        let address = listener.local_addr().expect("the listener has an address");
+        let status = status.to_owned();
+        let body = body.to_vec();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("the checker connects");
+            let mut request = [0_u8; 4096];
+            let read = stream
+                .read(&mut request)
+                .await
+                .expect("the request can be read");
+            assert!(
+                request[..read].starts_with(b"GET /latest HTTP/1.1\r\n"),
+                "the checker requested the configured endpoint"
+            );
+            let head = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream
+                .write_all(head.as_bytes())
+                .await
+                .expect("the response headers can be written");
+            stream
+                .write_all(&body)
+                .await
+                .expect("the response body can be written");
+        });
+        format!("http://{address}/latest")
+    }
+
+    async fn check_response(status: &str, body: &[u8]) -> Result<Option<String>, CheckError> {
+        let endpoint = serve_once(status, body).await;
+        Checker::at(endpoint, "0.1.0").unwrap().check().await
+    }
+
+    #[test]
+    fn a_newer_canonical_release_is_available() {
+        assert_eq!(newer("v0.12.3", "0.9.9").unwrap(), Some("0.12.3".into()));
+    }
+
+    #[test]
+    fn equal_and_older_releases_are_not_available() {
+        assert_eq!(newer("v1.2.3", "1.2.3").unwrap(), None);
+        assert_eq!(newer("v1.2.2", "1.2.3").unwrap(), None);
+    }
+
+    #[test]
+    fn only_v_followed_by_a_canonical_three_part_version_is_accepted() {
+        for tag in [
+            "1.2.3",
+            "v1.2",
+            "v1.2.3.4",
+            "v01.2.3",
+            "v1.02.3",
+            "v1.2.03",
+            "v1.2.3-beta.2",
+            "v1.2.3+build",
+            "latest",
+        ] {
+            assert!(newer(tag, "0.1.0").is_err(), "accepted {tag}");
+        }
+    }
+
+    #[tokio::test]
+    async fn the_latest_tag_is_read_from_a_small_success_response() {
+        assert_eq!(
+            check_response("200 OK", br#"{"tag_name":"v0.2.0"}"#)
+                .await
+                .unwrap(),
+            Some("0.2.0".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_success_status_fails_the_check() {
+        assert!(
+            check_response("429 Too Many Requests", br#"{}"#)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_json_fails_the_check() {
+        assert!(check_response("200 OK", br#"{"#).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn a_noncanonical_release_tag_fails_the_check() {
+        assert!(
+            check_response("200 OK", br#"{"tag_name":"v0.2.0-beta.1"}"#)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_response_over_the_limit_fails_the_check() {
+        let body = vec![b'x'; MAX_BODY + 1];
+        assert!(check_response("200 OK", &body).await.is_err());
+    }
+}

--- a/docs/superpowers/plans/2026-08-22-update-notification.md
+++ b/docs/superpowers/plans/2026-08-22-update-notification.md
@@ -1,0 +1,473 @@
+# Update Availability Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `tidemarkd` check GitHub hourly and make the GTK client show a releases-page button when that daemon is older than the latest release.
+
+**Architecture:** A focused daemon module performs the bounded GitHub request and strict version comparison. Transient availability is published through one D-Bus getter and one change signal; the GUI remains network-free and only renders daemon-owned state.
+
+**Tech Stack:** Rust 2024, Tokio, reqwest with rustls, semver, serde_json, zbus 5, GTK 4/libadwaita.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-update-notification-design.md`
+
+## Global Constraints
+
+- Compare only with `tidemarkd`'s `CARGO_PKG_VERSION`, never the GUI version.
+- Accept only canonical tags `vX.X.X`: no prereleases, metadata, leading zeroes, or arbitrary names.
+- Wait 60 seconds before the first request and 3,600 seconds between later requests.
+- A failed check leaves prior availability unchanged and creates no user-visible error.
+- The GUI must not gain HTTP, database, or `tidemark-core` dependencies.
+- Open only `https://github.com/zbndev/tidemark/releases`, never a response-provided URL.
+- Do not download packages, install updates, or distinguish DEB from RPM.
+- Keep Rust 1.92, GTK 4.22, and libadwaita 1.9 as the minimum versions.
+
+---
+
+### Task 1: Strict, bounded GitHub release checker
+
+**Files:**
+- Create: `crates/tidemarkd/src/update.rs`
+- Modify: `crates/tidemarkd/src/main.rs:13-18`
+- Modify: `crates/tidemarkd/Cargo.toml:14-25`
+- Modify: `Cargo.lock`
+
+**Interfaces:**
+- Consumes: `env!("CARGO_PKG_VERSION")` and `tidemark_types::user_agent()`.
+- Produces: `Checker::production() -> Result<Checker, CheckError>`.
+- Produces: `Checker::check(&self) -> Result<Option<String>, CheckError>`.
+- Produces: crate-visible `INITIAL_DELAY` and `INTERVAL` constants.
+
+- [ ] **Step 1: Write failing strict-version tests**
+
+Create `update.rs`, register it as `mod update;`, and add:
+
+```rust
+#[test]
+fn a_newer_canonical_release_is_available() {
+    assert_eq!(newer("v0.12.3", "0.9.9").unwrap(), Some("0.12.3".into()));
+}
+
+#[test]
+fn equal_and_older_releases_are_not_available() {
+    assert_eq!(newer("v1.2.3", "1.2.3").unwrap(), None);
+    assert_eq!(newer("v1.2.2", "1.2.3").unwrap(), None);
+}
+
+#[test]
+fn only_v_followed_by_a_canonical_three_part_version_is_accepted() {
+    for tag in ["1.2.3", "v1.2", "v1.2.3.4", "v01.2.3", "v1.02.3",
+                "v1.2.03", "v1.2.3-beta.2", "v1.2.3+build", "latest"] {
+        assert!(newer(tag, "0.1.0").is_err(), "accepted {tag}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to prove they fail**
+
+Run: `cargo test -p tidemarkd update::tests --no-run`
+
+Expected: compilation fails because `newer` is not defined.
+
+- [ ] **Step 3: Add dependencies and the minimal strict comparison**
+
+Add direct `reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy"] }` and `semver = "1.0.27"` dependencies. Add `time`, `net`, and `io-util` to the existing Tokio features; the latter two are used only by the local HTTP fixture. Implement:
+
+```rust
+fn version(text: &str) -> Result<Version, CheckError> {
+    let parts: Vec<_> = text.split('.').collect();
+    if parts.len() != 3
+        || parts.iter().any(|part| part.is_empty()
+            || !part.bytes().all(|byte| byte.is_ascii_digit())
+            || (part.len() > 1 && part.starts_with('0')))
+    {
+        return Err(CheckError::Version);
+    }
+    Version::parse(text).map_err(|_| CheckError::Version)
+}
+
+fn newer(tag: &str, current: &str) -> Result<Option<String>, CheckError> {
+    let release = version(tag.strip_prefix('v').ok_or(CheckError::Version)?)?;
+    let current = version(current)?;
+    Ok((release > current).then(|| release.to_string()))
+}
+```
+
+Run: `cargo test -p tidemarkd update::tests`
+
+Expected: the three strict-version tests pass.
+
+- [ ] **Step 4: Write failing HTTP, JSON, status, and size-limit tests**
+
+Use a test-only `tokio::net::TcpListener` helper that serves one supplied raw HTTP response. Test these exact outcomes through `Checker::at(endpoint, "0.1.0")`:
+
+```rust
+assert_eq!(check("200 OK", br#"{"tag_name":"v0.2.0"}"#).await.unwrap(),
+           Some("0.2.0".into()));
+assert!(check("429 Too Many Requests", br#"{}"#).await.is_err());
+assert!(check("200 OK", br#"{"#).await.is_err());
+assert!(check("200 OK", br#"{"tag_name":"v0.2.0-beta.1"}"#).await.is_err());
+assert!(check("200 OK", &vec![b'x'; MAX_BODY + 1]).await.is_err());
+```
+
+Run: `cargo test -p tidemarkd update::tests`
+
+Expected: compilation fails because `Checker`, `MAX_BODY`, and bounded fetching are absent.
+
+- [ ] **Step 5: Implement the bounded checker**
+
+Define:
+
+```rust
+pub(crate) const INITIAL_DELAY: Duration = Duration::from_secs(60);
+pub(crate) const INTERVAL: Duration = Duration::from_secs(60 * 60);
+const MAX_BODY: usize = 64 * 1024;
+const ENDPOINT: &str = "https://api.github.com/repos/zbndev/tidemark/releases/latest";
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckError {
+    #[error("could not build or send the release request")]
+    Http(#[source] reqwest::Error),
+    #[error("the release endpoint returned HTTP {0}")]
+    Status(reqwest::StatusCode),
+    #[error("the release response exceeded the size limit")]
+    TooLarge,
+    #[error("the release response was not valid JSON")]
+    Json(#[source] serde_json::Error),
+    #[error("the release or daemon version was not canonical X.X.X")]
+    Version,
+}
+
+#[derive(Debug)]
+pub(crate) struct Checker {
+    client: reqwest::Client,
+    endpoint: String,
+    current: String,
+}
+```
+
+`production()` calls `at(ENDPOINT, env!("CARGO_PKG_VERSION"))`. `at` builds a client with a 15-second timeout and default headers for Tidemark's user agent, `Accept: application/vnd.github+json`, and `X-GitHub-Api-Version: 2026-03-10`. `check` rejects non-success status, reads `response.chunk().await` until EOF while rejecting accumulation beyond `MAX_BODY`, decodes a `serde_json::Value`, extracts only string `tag_name`, and calls `newer`.
+
+Run:
+
+```bash
+cargo test -p tidemarkd update::tests
+cargo clippy -p tidemarkd --all-targets -- -D warnings
+```
+
+Expected: all checker tests and clippy pass.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add crates/tidemarkd/src/update.rs crates/tidemarkd/src/main.rs \
+  crates/tidemarkd/Cargo.toml Cargo.lock
+git commit -m "feat: check the latest Tidemark release"
+```
+
+---
+
+### Task 2: Publish availability through D-Bus
+
+**Files:**
+- Modify: `crates/tidemarkd/src/service.rs:54-151, 640-660, 1640-1780`
+- Modify: `crates/tidemarkd/src/main.rs:107-198`
+
+**Interfaces:**
+- Consumes: `Checker`, `INITIAL_DELAY`, and `INTERVAL` from Task 1.
+- Produces: `PublishedUpdate::get(&self) -> String` and `replace(&self, Option<String>) -> bool`.
+- Produces: `publish_result(&PublishedUpdate, Result<Option<String>, CheckError>) -> Result<Option<String>, CheckError>`; `Some(payload)` means emit a signal.
+- Produces D-Bus: `GetUpdate() -> String` and `UpdateChanged(String)`.
+
+- [ ] **Step 1: Write a failing publication-state test**
+
+```rust
+#[tokio::test]
+async fn update_publication_changes_only_when_the_value_changes() {
+    let update = PublishedUpdate::default();
+    assert_eq!(update.get().await, "");
+    assert!(update.replace(Some("0.2.0".into())).await);
+    assert!(!update.replace(Some("0.2.0".into())).await);
+    assert_eq!(update.get().await, "0.2.0");
+    assert!(update.replace(None).await);
+    assert_eq!(update.get().await, "");
+}
+```
+
+Run: `cargo test -p tidemarkd service::tests::update_publication_changes_only_when_the_value_changes`
+
+Expected: compilation fails because `PublishedUpdate` is absent.
+
+- [ ] **Step 2: Implement state and pass it into every `Daemon::new` call**
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct PublishedUpdate(Arc<RwLock<Option<String>>>);
+
+impl PublishedUpdate {
+    pub async fn get(&self) -> String {
+        self.0.read().await.clone().unwrap_or_default()
+    }
+    pub async fn replace(&self, next: Option<String>) -> bool {
+        let mut held = self.0.write().await;
+        if *held == next { return false; }
+        *held = next;
+        true
+    }
+}
+```
+
+Add it as a `Daemon` field and constructor argument. Update the main constructor and all five service-test constructors.
+
+Run: `cargo test -p tidemarkd service::tests::update_publication_changes_only_when_the_value_changes`
+
+Expected: PASS.
+
+- [ ] **Step 3: Write failing real-D-Bus assertions**
+
+Extend `a_client_reads_the_daemon_over_a_real_session_bus`: seed `PublishedUpdate` with `0.2.0`, call `GetUpdate`, and assert the returned string. Subscribe to `UpdateChanged`, replace state with `None`, emit `""`, then assert both signal payload and a following `GetUpdate` are empty. This pins state-before-signal ordering.
+
+Run: `dbus-run-session -- cargo test -p tidemarkd service::tests::a_client_reads_the_daemon_over_a_real_session_bus`
+
+Expected: failure because the two D-Bus members do not exist.
+
+- [ ] **Step 4: Add the getter and signal**
+
+```rust
+async fn get_update(&self) -> String {
+    self.update.get().await
+}
+
+#[zbus(signal)]
+pub async fn update_changed(
+    emitter: &SignalEmitter<'_>,
+    version: &str,
+) -> zbus::Result<()>;
+```
+
+Run: `dbus-run-session -- cargo test -p tidemarkd service::tests::a_client_reads_the_daemon_over_a_real_session_bus`
+
+Expected: PASS.
+
+- [ ] **Step 5: Pin failure preservation, then spawn and stop the hourly task**
+
+Add `publish_result` in `main.rs` and first write a test which seeds `0.2.0`, passes an `Err(CheckError::Version)`, and asserts both that the result is an error and `PublishedUpdate::get()` still returns `0.2.0`. Add success assertions showing a changed value returns `Some("0.3.0")` and a repeat returns `None`.
+
+Run: `cargo test -p tidemarkd tests::a_failed_release_check_preserves_the_previous_update`
+
+Expected: FAIL before `publish_result` exists, then PASS after implementing:
+
+```rust
+async fn publish_result(
+    update: &PublishedUpdate,
+    result: Result<Option<String>, update::CheckError>,
+) -> Result<Option<String>, update::CheckError> {
+    let next = result?;
+    Ok(update
+        .replace(next.clone())
+        .await
+        .then(|| next.unwrap_or_default()))
+}
+```
+
+Construct the checker and shared state before serving D-Bus. After the connection exists, spawn:
+
+```rust
+tokio::time::sleep(update::INITIAL_DELAY).await;
+loop {
+    match publish_result(&published_update, checker.check().await).await {
+        Ok(Some(version)) => {
+            if let Err(error) = Daemon::update_changed(&emitter, &version).await {
+                tracing::warn!(%error, "could not announce update availability");
+            }
+        }
+        Ok(None) => {}
+        Err(error) => tracing::info!(%error, "release check failed"),
+    }
+    tokio::time::sleep(update::INTERVAL).await;
+}
+```
+
+The helper's `?` must run before `replace`. Abort the task during normal shutdown beside the signal task.
+
+Run:
+
+```bash
+cargo fmt --all --check
+dbus-run-session -- cargo test -p tidemarkd
+cargo clippy -p tidemarkd --all-targets -- -D warnings
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add crates/tidemarkd/src/service.rs crates/tidemarkd/src/main.rs
+git commit -m "feat: publish available updates from the daemon"
+```
+
+---
+
+### Task 3: Render the GTK update link
+
+**Files:**
+- Modify: `crates/tidemark/src/bus.rs:36-250`
+- Modify: `crates/tidemark/src/window.rs:78-225, 470-510, 588-640`
+- Modify: `crates/tidemark/examples/mock-daemon.rs:30-80`
+
+**Interfaces:**
+- Consumes D-Bus: `GetUpdate() -> String` and `UpdateChanged(String)`.
+- Produces GUI events: a fourth `String` on `Update::Connected` and `Update::Available(String)`.
+- Produces: `update_tooltip(&str) -> Option<String>`.
+
+- [ ] **Step 1: Write failing tooltip/visibility tests**
+
+```rust
+#[test]
+fn an_empty_update_has_no_button_copy() {
+    assert_eq!(update_tooltip(""), None);
+}
+
+#[test]
+fn an_available_update_names_the_daemon_selected_version() {
+    assert_eq!(update_tooltip("0.12.3").as_deref(),
+               Some("Tidemark 0.12.3 is available"));
+}
+```
+
+Run: `cargo test -p tidemark window::tests::an_empty_update_has_no_button_copy window::tests::an_available_update_names_the_daemon_selected_version`
+
+Expected: compilation fails because `update_tooltip` is absent.
+
+- [ ] **Step 2: Implement the pure decision**
+
+```rust
+const RELEASES_URL: &str = "https://github.com/zbndev/tidemark/releases";
+
+fn update_tooltip(version: &str) -> Option<String> {
+    (!version.is_empty()).then(|| format!("Tidemark {version} is available"))
+}
+```
+
+Run the tests again; expect PASS.
+
+- [ ] **Step 3: Extend the proxy and bus event loop**
+
+Add `get_update` and `update_changed` to the proxy trait. Subscribe before `load`, poll the new stream beside owner/provider/removal, and add `Event::Available(Option<UpdateChanged>)`. Convert its payload to `Update::Available(args.version.to_owned())`.
+
+Keep the update getter auxiliary:
+
+```rust
+let available = proxy.get_update().await.unwrap_or_else(|error| {
+    tracing::info!(%error, "the daemon did not answer GetUpdate; hiding update availability");
+    String::new()
+});
+```
+
+Pass `available` as the fourth `Update::Connected` field. A closed update signal stream ends `serve` like the existing streams.
+
+Run: `cargo test -p tidemark bus::tests window::tests`
+
+Expected: PASS after all enum matches compile.
+
+- [ ] **Step 4: Build and drive the hidden header button**
+
+Add `update: gtk::Button` to `MainWindow`. Build it with icon `software-update-available-symbolic` and `visible(false)`. Pack refresh first and update second at the header end so update is immediately left of refresh.
+
+```rust
+fn show_update(&self, version: &str) {
+    let tooltip = update_tooltip(version);
+    self.update.set_tooltip_text(tooltip.as_deref());
+    self.update.set_visible(tooltip.is_some());
+}
+```
+
+Call it from Connected, Available, and Waiting (empty string). Connect the button through a weak `MainWindow`, create `gtk::UriLauncher::new(RELEASES_URL)`, and call `launch_future(Some(&main.window))`; only log launch errors and leave the button enabled.
+
+Run:
+
+```bash
+cargo test -p tidemark
+cargo clippy -p tidemark --all-targets -- -D warnings
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Publish `0.2.0` from the mock daemon**
+
+```rust
+async fn get_update(&self) -> String { "0.2.0".into() }
+
+#[zbus(signal)]
+pub async fn update_changed(
+    emitter: &SignalEmitter<'_>,
+    version: &str,
+) -> zbus::Result<()>;
+```
+
+Run: `cargo build -p tidemark --examples`
+
+Expected: the mock daemon and GUI compile.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add crates/tidemark/src/bus.rs crates/tidemark/src/window.rs \
+  crates/tidemark/examples/mock-daemon.rs
+git commit -m "feat: show an available-update link in the header"
+```
+
+---
+
+### Task 4: Full and installed acceptance verification
+
+**Files:**
+- Verify: all Task 1-3 files.
+- Modify only if verification finds a scoped defect.
+
+**Interfaces:**
+- Consumes the completed checker, D-Bus contract, GTK control, and mock daemon.
+- Produces verified installed behavior and no additional API.
+
+- [ ] **Step 1: Run full static and workspace checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+dbus-run-session -- cargo test --workspace
+scripts/check-layering.sh
+scripts/check-desktop-integration.sh
+git diff --check
+```
+
+Expected: every command exits 0 and the GUI layering guard confirms no HTTP dependency.
+
+- [ ] **Step 2: Verify the mock D-Bus contract**
+
+Stop the installed daemon, run the mock daemon, and call:
+
+```bash
+busctl --user call io.github.zbndev.Tidemark.Daemon \
+  /io/github/zbndev/Tidemark io.github.zbndev.Tidemark.Daemon1 GetUpdate
+```
+
+Expected: signature `s`, value `"0.2.0"`.
+
+- [ ] **Step 3: Inspect the real GTK window**
+
+Launch the real GUI against the mock. Verify the update icon is immediately left of quota refresh, the tooltip is `Tidemark 0.2.0 is available`, and activation targets the fixed releases page. Capture visual or accessibility evidence without adding a production debug switch.
+
+- [ ] **Step 4: Perform installed-package acceptance**
+
+Read `/home/herald/.codex/memories/skills/tidemark-installed-verification/SKILL.md` completely and follow it. Rebuild/install the package, restart through the packaged helper, and verify installed versions, package integrity, daemon service health, D-Bus introspection, normal status, and installed GUI startup.
+
+- [ ] **Step 5: Review the scoped diff**
+
+```bash
+git status --short
+git diff --stat main...HEAD
+git diff --check main...HEAD
+git log --oneline main..HEAD
+```
+
+If acceptance required a correction, commit only its scoped files with `fix: correct update availability verification finding`. Do not create an empty commit.

--- a/docs/superpowers/plans/2026-08-22-update-notification.md
+++ b/docs/superpowers/plans/2026-08-22-update-notification.md
@@ -151,10 +151,11 @@ Run:
 
 ```bash
 cargo test -p tidemarkd update::tests
-cargo clippy -p tidemarkd --all-targets -- -D warnings
 ```
 
-Expected: all checker tests and clippy pass.
+Expected: all checker tests pass. The checker is intentionally dead code until Task 2 wires it into
+the daemon; warnings-denied clippy therefore runs at the end of Task 2, not at this intermediate
+commit.
 
 - [ ] **Step 6: Commit Task 1**
 
@@ -312,15 +313,22 @@ git commit -m "feat: publish available updates from the daemon"
 
 **Files:**
 - Modify: `crates/tidemark/src/bus.rs:36-250`
-- Modify: `crates/tidemark/src/window.rs:78-225, 470-510, 588-640`
+- Modify: `crates/tidemark/src/update.rs`
+- Modify: `crates/tidemark/src/window.rs:78-265, 510-550, 625-680`
 - Modify: `crates/tidemark/examples/mock-daemon.rs:30-80`
 
 **Interfaces:**
 - Consumes D-Bus: `GetUpdate() -> String` and `UpdateChanged(String)`.
-- Produces GUI events: a fourth `String` on `Update::Connected` and `Update::Available(String)`.
+- Preserves the existing daemon-newer-than-GUI restart notice driven by the optional daemon-version
+  field on `Update::Connected`.
+- Produces GUI events: a new available-release `String` on `Update::Connected` and
+  `Update::Available(String)`.
 - Produces: `update_tooltip(&str) -> Option<String>`.
 
 - [ ] **Step 1: Write failing tooltip/visibility tests**
+
+Add these to the existing test module in `crates/tidemark/src/update.rs`; they extend rather than
+replace the package-upgrade restart tests merged from `main`:
 
 ```rust
 #[test]
@@ -344,7 +352,7 @@ Expected: compilation fails because `update_tooltip` is absent.
 ```rust
 const RELEASES_URL: &str = "https://github.com/zbndev/tidemark/releases";
 
-fn update_tooltip(version: &str) -> Option<String> {
+pub(crate) fn update_tooltip(version: &str) -> Option<String> {
     (!version.is_empty()).then(|| format!("Tidemark {version} is available"))
 }
 ```
@@ -353,7 +361,10 @@ Run the tests again; expect PASS.
 
 - [ ] **Step 3: Extend the proxy and bus event loop**
 
-Add `get_update` and `update_changed` to the proxy trait. Subscribe before `load`, poll the new stream beside owner/provider/removal, and add `Event::Available(Option<UpdateChanged>)`. Convert its payload to `Update::Available(args.version.to_owned())`.
+Add `get_update` and `update_changed` to the proxy trait. Subscribe before `load`, poll the new
+stream beside owner/provider/removal, and add `Event::Available(Option<UpdateChanged>)`. Convert its
+payload to `Update::Available(args.version.to_owned())`. Do not alter the existing daemon `Version`
+property subscription/reload behavior used by the restart notice.
 
 Keep the update getter auxiliary:
 
@@ -364,7 +375,8 @@ let available = proxy.get_update().await.unwrap_or_else(|error| {
 });
 ```
 
-Pass `available` as the fourth `Update::Connected` field. A closed update signal stream ends `serve` like the existing streams.
+Pass `available` immediately after the existing optional daemon-version field on
+`Update::Connected`. A closed update signal stream ends `serve` like the existing streams.
 
 Run: `cargo test -p tidemark bus::tests window::tests`
 
@@ -372,13 +384,16 @@ Expected: PASS after all enum matches compile.
 
 - [ ] **Step 4: Build and drive the hidden header button**
 
-Add `update: gtk::Button` to `MainWindow`. Build it with icon `software-update-available-symbolic` and `visible(false)`. Pack refresh first and update second at the header end so update is immediately left of refresh.
+Add `release: gtk::Button` to `MainWindow`; keep the existing `update_notice: RefCell<UpdateNotice>`
+unchanged because it solves package-upgrade GUI restart, a separate problem. Build the button with
+icon `software-update-available-symbolic` and `visible(false)`. Pack refresh first and release second
+at the header end so the new control is immediately left of refresh.
 
 ```rust
 fn show_update(&self, version: &str) {
     let tooltip = update_tooltip(version);
-    self.update.set_tooltip_text(tooltip.as_deref());
-    self.update.set_visible(tooltip.is_some());
+    self.release.set_tooltip_text(tooltip.as_deref());
+    self.release.set_visible(tooltip.is_some());
 }
 ```
 
@@ -413,7 +428,7 @@ Expected: the mock daemon and GUI compile.
 
 ```bash
 git add crates/tidemark/src/bus.rs crates/tidemark/src/window.rs \
-  crates/tidemark/examples/mock-daemon.rs
+  crates/tidemark/src/update.rs crates/tidemark/examples/mock-daemon.rs
 git commit -m "feat: show an available-update link in the header"
 ```
 

--- a/docs/superpowers/specs/2026-08-22-update-notification-design.md
+++ b/docs/superpowers/specs/2026-08-22-update-notification-design.md
@@ -1,0 +1,121 @@
+# Update availability notification design
+
+## Goal
+
+Tidemark does not install updates. It periodically discovers the latest published GitHub
+release and, when that release is newer than the running daemon, exposes a single unobtrusive
+link to the releases page in the main window. A failed check must not change anything the user
+can see.
+
+The daemon version is authoritative. The GUI binary's version is never used for the decision.
+
+## Release contract
+
+- Releases come from `zbndev/tidemark` through GitHub's public `releases/latest` REST endpoint.
+- Only published full releases participate. GitHub's endpoint already excludes drafts and
+  prereleases.
+- Release tags have exactly the form `vX.X.X`, where each component is a semantic-version
+  integer in canonical decimal notation (zero itself is allowed; leading zeroes are not).
+  Tidemark does not support prerelease suffixes, build metadata, or arbitrary tag names.
+- The tag without its leading `v` is compared as a semantic version with
+  `tidemarkd`'s `CARGO_PKG_VERSION`.
+
+An invalid response, invalid tag, invalid daemon version, non-success response, timeout, JSON
+error, rate limit, or any other network failure is a failed check.
+
+## Ownership and components
+
+### Daemon release checker
+
+A focused module in `tidemarkd` owns the GitHub request, response decoding, strict tag parsing,
+and version comparison. It uses a small dedicated HTTP client with Tidemark's user agent, GitHub's
+recommended media type and API-version headers, and a finite timeout.
+
+The daemon starts one background checker task after its D-Bus object is available. The task waits
+one minute before the first request and then checks once per hour. The initial delay keeps release
+discovery outside the daemon's startup path and prevents rapid development restarts from issuing an
+immediate burst of requests. No timestamp or response is persisted: the running daemon is the sole
+owner of this transient information.
+
+The checker holds an `Option<String>` containing the newer version. Each successful check derives a
+new value:
+
+- `Some(version)` when the latest release is newer than the running daemon;
+- `None` when the latest release is equal to or older than the running daemon.
+
+A failed check leaves the previous value unchanged. Failures may be written to the daemon log but
+never become provider state, notifications, D-Bus errors delivered asynchronously to the GUI, or
+visible messages. When a successful check changes the value, the daemon updates shared state before
+emitting its D-Bus signal. The task is aborted during orderly daemon shutdown.
+
+### D-Bus contract
+
+The existing daemon interface gains:
+
+- `GetUpdate() -> String`, returning the newer `X.X.X` version or an empty string when none is
+  known;
+- `UpdateChanged(String version)`, carrying the same representation whenever a successful check
+  changes the value.
+
+The empty string keeps the interface simple for `busctl` and permits a later successful check to
+withdraw stale availability. As with provider publication, state is written before the signal, so a
+client reacting to the signal cannot read an older value.
+
+The GUI subscribes to `UpdateChanged` before its initial load. `GetUpdate` is auxiliary: if an older
+daemon does not implement it or this one call fails, quota status still loads normally and the update
+button remains hidden. Losing and regaining the daemon bus owner causes the GUI to reload update
+availability along with the provider catalog and statuses.
+
+### GUI
+
+The main window creates a `software-update-available-symbolic` button in the header bar, packed
+immediately to the left of the existing quota-refresh button. It starts hidden. A non-empty update
+version shows it and sets a tooltip that names the available version; an empty value hides it.
+
+Clicking the button opens `https://github.com/zbndev/tidemark/releases` with `gtk::UriLauncher`, using
+the main window as the parent. Tidemark never downloads a package or chooses between DEB and RPM.
+Failure to launch the browser is logged and leaves the button available for another attempt.
+
+Disconnecting from the daemon hides the button because availability belonged to that daemon
+instance. Reconnection restores it from `GetUpdate` if the newly connected daemon has already found
+a newer release.
+
+## Error handling and security
+
+- The request is unauthenticated and sends no GitHub token, account identity, provider credential,
+  machine identifier, or operating-system details.
+- Only the fixed HTTPS API endpoint is requested; response URLs are not followed for application
+  navigation.
+- Only the fixed GitHub releases page is opened by the GUI. The response cannot supply a browser URL.
+- The checker reads the response through an explicit small byte limit before decoding only the
+  release tag, so a response cannot cause an unbounded allocation.
+- Automatic-check failures remain silent in the interface. Logs contain error categories and status
+  codes, never response bodies.
+- There is no retry loop inside one interval. A failure waits until the next hourly check.
+
+## Testing
+
+Implementation follows test-driven development.
+
+- Pure unit tests pin strict `vX.X.X` parsing and semantic ordering, including multi-digit
+  components, equality, older releases, malformed tags, prerelease suffixes, and build metadata.
+- Checker tests use a local HTTP fixture to cover success, non-success status, malformed JSON,
+  malformed tags, and preservation of the previous state on failure. Production constants remain
+  fixed; test construction injects the endpoint and timing where needed.
+- D-Bus tests cover `GetUpdate`, state-before-signal ordering, a transition to an available version,
+  and withdrawal through an empty `UpdateChanged` payload.
+- GUI-side tests cover the empty/non-empty visibility decision and bus-event mapping. The mock daemon
+  publishes a newer version so the real GTK window can be inspected with the button present.
+- Final verification includes formatting, clippy with warnings denied, the full D-Bus workspace test
+  suite, layering checks, installed-package verification, live installed daemon introspection, and a
+  live GUI check that the update control appears in the required header position and opens the fixed
+  releases page.
+
+## Non-goals
+
+- Downloading or installing DEB/RPM packages.
+- Package-manager integration or detecting which package format installed Tidemark.
+- Desktop notifications, badges on the tray icon, dismissing an available release, or manual
+  "check for application updates" controls.
+- Configurable channels, prereleases, arbitrary version names, or a user-configurable interval.
+- Persisting release-check state across daemon restarts.


### PR DESCRIPTION
## Summary

- check the latest published GitHub release one minute after daemon startup and hourly afterwards
- accept only canonical `vX.X.X` tags, compare against the daemon version, and keep all check failures out of the UI
- publish update availability over D-Bus and show a header button linking to GitHub Releases
- preserve the independent daemon/client restart notice added on `main`

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `dbus-run-session -- cargo test --workspace` (888 tests)
- `scripts/check-layering.sh`
- `scripts/check-desktop-integration.sh`
- `git diff --check`
- `makepkg -sif --noconfirm`
- installed daemon active, D-Bus contract exercised, `pacman -Qkk tidemark` reports 0 altered files
- installed GUI update button verified against the mock daemon