### PR TITLE
Add the release version bump script

### DIFF
--- a/docs/superpowers/plans/2026-08-22-release-bump-script.md
+++ b/docs/superpowers/plans/2026-08-22-release-bump-script.md
@@ -72,8 +72,9 @@ trap cleanup EXIT
 make_fixture() {
     fixture=$(mktemp -d "${TMPDIR:-/tmp}/tidemark-release-test.XXXXXX")
 
-    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types" \
-        "$fixture/crates/tidemark-core" "$fixture/crates/tidemarkd" "$fixture/crates/tidemark"
+    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types/src" \
+        "$fixture/crates/tidemark-core/src" "$fixture/crates/tidemarkd/src" \
+        "$fixture/crates/tidemark/src"
     cp "$project_root/Cargo.toml" "$project_root/Cargo.lock" \
         "$project_root/rust-toolchain.toml" "$project_root/PKGBUILD" "$fixture/"
     cp "$project_root/crates/tidemark-types/Cargo.toml" "$fixture/crates/tidemark-types/"
@@ -84,6 +85,12 @@ make_fixture() {
         "$fixture/data/metainfo/"
     cp "$project_root/scripts/release.sh" "$project_root/scripts/check-tag-version.sh" \
         "$fixture/scripts/"
+    # `cargo update` must be able to load the workspace, and target auto-discovery needs
+    # these; empty stubs do — nothing ever compiles in the fixture.
+    : >"$fixture/crates/tidemark-types/src/lib.rs"
+    : >"$fixture/crates/tidemark-core/src/lib.rs"
+    : >"$fixture/crates/tidemarkd/src/main.rs"
+    : >"$fixture/crates/tidemark/src/main.rs"
 
     git -C "$fixture" init -q -b main
     git -C "$fixture" config user.name fixture
@@ -329,7 +336,7 @@ metainfo=data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
 
 printf 'cutting a full release\n'
 make_fixture
-(cd "$fixture" && scripts/release.sh "$next_version") >/dev/null
+(cd "$fixture" && scripts/release.sh "$next_version") >/dev/null 2>&1
 
 [ "$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' \
     "$fixture/Cargo.toml")" = "$next_version" ]
@@ -365,7 +372,8 @@ make_fixture
 sed -i "/^\[workspace\.package\]/,/^\[/ s/^version = \"\(.*\)\"\$/version = \"0.1.9\"/" \
     "$fixture/Cargo.toml"
 git -C "$fixture" commit -qam 'fixture at 0.1.9'
-(cd "$fixture" && scripts/release.sh 0.1.10) >/dev/null
+git -C "$fixture" push -q origin main
+(cd "$fixture" && scripts/release.sh 0.1.10) >/dev/null 2>&1
 [ "$(git -C "$fixture" log -1 --format=%s)" = 'chore: bump to v0.1.10' ]
 cleanup
 
@@ -537,6 +545,11 @@ Expected: empty (every task committed; nothing stray introduced).
   empty porcelain after a rejection, which the dirty-tree scenario (a deliberately dirty
   fixture) can never satisfy; the spec's invariant is "changed nothing", so the helper now
   asserts before/after equality.
+- Corrected during execution (coordinator, 2026-08-22): the fixture needs empty target
+  stubs (src/lib.rs, src/main.rs) or `cargo update` cannot load the workspace ("no targets
+  specified"); happy-path invocations redirect stderr too so git push's summary does not
+  pollute test output; the numeric-order scenario syncs its `fixture at 0.1.9` commit to
+  the fixture origin before releasing, or the stale-main guard correctly fires.
 - Spec coverage: canonical-argument gate (Task 1), main/clean/stale/newer/tag guards
   (Task 2), six-file edit set, `check-tag-version.sh` self-check, best-effort
   `appstreamcli`, explicit `git add`, `chore: bump to vX.X.X`, annotated tag, single push

--- a/docs/superpowers/plans/2026-08-22-release-bump-script.md
+++ b/docs/superpowers/plans/2026-08-22-release-bump-script.md
@@ -4,7 +4,7 @@
 
 **Goal:** `scripts/release.sh X.X.X` turns the state of `main` into a pushed release tag by bumping every version-carrying file, committing, tagging and pushing, with all guards running before the first edit.
 
-**Architecture:** One POSIX sh script in the house style of the sibling check scripts, plus one hermetic smoke-test script (`scripts/test-release.sh`) that drives it against a throwaway git fixture whose `origin` is a bare repository in a temp directory. Two workflow files gain one explicit test step each.
+**Architecture:** One POSIX sh script in the house style of the sibling check scripts, plus one hermetic smoke-test script (`scripts/test-release.sh`) that drives it against a throwaway git fixture whose `origin` is a bare repository in a temp directory.
 
 **Tech Stack:** POSIX sh (`#!/bin/sh`, `set -eu`), git, cargo, GNU sed, `date`. No new dependencies.
 
@@ -175,7 +175,7 @@ die() {
 # zeroes (a lone zero is fine) — the same form check-tag-version.sh and tidemarkd's update
 # checker accept.
 canonical() {
-    case $1 in *[!0-9.]*) return 1 ;; esac
+    case $1 in *[!0-9.]* | .* | *.) return 1 ;; esac
 
     old_ifs=$IFS
     IFS=.
@@ -509,6 +509,10 @@ Expected: empty (every task committed; nothing stray introduced).
 
 ## Self-Review Notes
 
+- Final-review fix (2026-08-22): canonical() originally accepted a trailing dot (the IFS
+  word split drops a trailing null field under bash-as-/bin/sh), letting a typo like
+  `0.2.0.` past the front gate to a late cargo failure after edits; the charset case now
+  rejects leading and trailing dots, with two reject() pins in the smoke test.
 - Owner decision (2026-08-22): Task 4's CI wiring was reverted — `scripts/test-release.sh`
   runs by hand only; the pre-existing shellcheck steps still cover both new scripts.
 - Corrected during execution (coordinator, 2026-08-22): reject() originally asserted an

--- a/docs/superpowers/plans/2026-08-22-release-bump-script.md
+++ b/docs/superpowers/plans/2026-08-22-release-bump-script.md
@@ -1,0 +1,541 @@
+# Release Version Bump Script Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `scripts/release.sh X.X.X` turns the state of `main` into a pushed release tag by bumping every version-carrying file, committing, tagging and pushing, with all guards running before the first edit.
+
+**Architecture:** One POSIX sh script in the house style of the sibling check scripts, plus one hermetic smoke-test script (`scripts/test-release.sh`) that drives it against a throwaway git fixture whose `origin` is a bare repository in a temp directory. Two workflow files gain one explicit test step each.
+
+**Tech Stack:** POSIX sh (`#!/bin/sh`, `set -eu`), git, cargo, GNU sed, `date`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-release-bump-script-design.md`
+
+## Global Constraints
+
+- Scripts are `#!/bin/sh` with `set -eu`, shellcheck-clean (CI runs `shellcheck scripts/*.sh` on both `ci.yml` and `release.yml`).
+- GNU sed `-i` is acceptable: the project is Linux-only (systemd user units, makepkg).
+- Comments are English, terse, and say why — the house style of `scripts/check-tag-version.sh`.
+- The version is canonical: exactly three dot-separated ASCII-digit groups, no leading zeroes (a lone `0` is fine) — the same rules as `scripts/check-tag-version.sh` and `crates/tidemarkd/src/update.rs`.
+- The commit message is exactly `chore: bump to vX.X.X`; the tag is annotated `vX.X.X`.
+- Nothing but git, cargo, sed, `date` and (best-effort) `appstreamcli` is invoked.
+- The smoke test never touches the real repository's files, remotes or tags.
+
+## File Structure
+
+- Create: `scripts/release.sh` — the whole release flow: guards, edits, verification, commit/tag/push.
+- Create: `scripts/test-release.sh` — hermetic smoke test: fixture builder, rejection helpers, happy-path assertions.
+- Modify: `.github/workflows/ci.yml` — one step running `scripts/test-release.sh`.
+- Modify: `.github/workflows/release.yml` — one step running `scripts/test-release.sh`.
+
+---
+
+### Task 1: The version argument gate
+
+**Files:**
+- Create: `scripts/release.sh`
+- Create: `scripts/test-release.sh`
+
+**Interfaces:**
+- Consumes: `scripts/check-tag-version.sh` (copied into the fixture; first used in Task 3).
+- Produces: `canonical()` and `die()` in `scripts/release.sh` (used by later tasks);
+  `make_fixture`, `reject`, `cleanup` in `scripts/test-release.sh` (used by later tasks).
+
+- [ ] **Step 1: Write the failing smoke test**
+
+Create `scripts/test-release.sh` with exactly this content, then `chmod +x scripts/test-release.sh`:
+
+```sh
+#!/bin/sh
+set -eu
+
+# Proves scripts/release.sh: every precondition rejection, and a full happy path against a
+# throwaway bare repository playing origin — nothing here touches the real repository or
+# the real origin.
+#
+#   scripts/test-release.sh
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+current_version=$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' \
+    "$project_root/Cargo.toml")
+next_version=${current_version%.*}.$(( ${current_version##*.} + 1 ))
+
+fixture=
+cleanup() {
+    [ -n "$fixture" ] && rm -rf "$fixture" "$fixture.origin.git"
+    fixture=
+}
+trap cleanup EXIT
+
+# A miniature copy of the version-carrying files plus the two scripts under test, with its
+# own bare repository as origin, so even the push step of a happy path runs for real.
+make_fixture() {
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/tidemark-release-test.XXXXXX")
+
+    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types" \
+        "$fixture/crates/tidemark-core" "$fixture/crates/tidemarkd" "$fixture/crates/tidemark"
+    cp "$project_root/Cargo.toml" "$project_root/Cargo.lock" \
+        "$project_root/rust-toolchain.toml" "$project_root/PKGBUILD" "$fixture/"
+    cp "$project_root/crates/tidemark-types/Cargo.toml" "$fixture/crates/tidemark-types/"
+    cp "$project_root/crates/tidemark-core/Cargo.toml" "$fixture/crates/tidemark-core/"
+    cp "$project_root/crates/tidemarkd/Cargo.toml" "$fixture/crates/tidemarkd/"
+    cp "$project_root/crates/tidemark/Cargo.toml" "$fixture/crates/tidemark/"
+    cp "$project_root/data/metainfo/io.github.zbndev.Tidemark.metainfo.xml" \
+        "$fixture/data/metainfo/"
+    cp "$project_root/scripts/release.sh" "$project_root/scripts/check-tag-version.sh" \
+        "$fixture/scripts/"
+
+    git -C "$fixture" init -q -b main
+    git -C "$fixture" config user.name fixture
+    git -C "$fixture" config user.email fixture@invalid
+    git -C "$fixture" add -A
+    git -C "$fixture" commit -q -m fixture
+
+    git init -q --bare "$fixture.origin.git"
+    git -C "$fixture" remote add origin "$fixture.origin.git"
+    git -C "$fixture" push -q origin main
+}
+
+# Runs the fixture's release.sh expecting failure, and proving it edited nothing.
+reject() {
+    if (cd "$fixture" && scripts/release.sh "$@" >/dev/null 2>&1); then
+        printf 'expected scripts/release.sh %s to fail\n' "$*" >&2
+        exit 1
+    fi
+    [ -z "$(git -C "$fixture" status --porcelain)" ] || {
+        printf 'scripts/release.sh %s failed but edited the tree\n' "$*" >&2
+        exit 1
+    }
+}
+
+printf 'rejecting malformed versions\n'
+make_fixture
+reject
+reject 1.2 1.3
+reject 1.2
+reject 1.2.3.4
+reject "v$next_version"
+reject 1.2.3-beta
+reject 01.2.3
+reject 1.02.3
+reject 1.2.03
+reject 1..2
+reject .1.2
+cleanup
+
+printf 'argument validation holds\n'
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `scripts/test-release.sh`
+Expected: FAIL — `cp: cannot stat .../scripts/release.sh: No such file or directory` (the
+fixture builder copies a script that does not exist yet).
+
+- [ ] **Step 3: Write the minimal script**
+
+Create `scripts/release.sh` with exactly this content, then `chmod +x scripts/release.sh`:
+
+```sh
+#!/bin/sh
+set -eu
+
+# Turns the state of main into a pushed release tag: bumps every version-carrying file,
+# commits, tags, pushes. Every guard runs before the first edit; a failure between the
+# first edit and the commit leaves the edits in the tree on purpose — inspect, then revert
+# with `git checkout -- .`.
+#
+#   scripts/release.sh X.X.X
+#
+# No fmt, clippy or tests run here: the tag push triggers the Release workflow, which runs
+# the whole suite before building anything.
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$project_root"
+
+die() {
+    printf 'release.sh: %s\n' "$1" >&2
+    exit 1
+}
+
+# A canonical version: exactly three dot-separated groups of ASCII digits, no leading
+# zeroes (a lone zero is fine) — the same form check-tag-version.sh and tidemarkd's update
+# checker accept.
+canonical() {
+    case $1 in *[!0-9.]*) return 1 ;; esac
+
+    old_ifs=$IFS
+    IFS=.
+    set -f
+    set -- $1
+    set +f
+    IFS=$old_ifs
+    [ $# -eq 3 ] || return 1
+
+    for component in "$@"; do
+        case $component in
+            0 | [1-9] | [1-9][0-9]*) ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+[ $# -eq 1 ] || die 'usage: scripts/release.sh X.X.X'
+new=$1
+canonical "$new" || die "$new is not a canonical version (X.X.X, no leading zeroes)"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `scripts/test-release.sh`
+Expected: PASS — prints `rejecting malformed versions` then `argument validation holds`,
+exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release.sh scripts/test-release.sh
+git commit -m "feat: validate the release script's version argument"
+```
+
+---
+
+### Task 2: The precondition guards
+
+**Files:**
+- Modify: `scripts/release.sh` (append after the argument gate)
+- Modify: `scripts/test-release.sh` (append before the final `printf`)
+
+**Interfaces:**
+- Consumes: `canonical()` from Task 1; `make_fixture`, `reject` from Task 1.
+- Produces: `greater()` in `scripts/release.sh` (reused by Task 3's numeric-order case).
+
+- [ ] **Step 1: Add the failing rejection scenarios**
+
+In `scripts/test-release.sh`, replace the trailing `printf 'argument validation holds\n'`
+line with:
+
+```sh
+printf 'rejecting a release cut outside main\n'
+make_fixture
+git -C "$fixture" switch -q -c side
+reject "$next_version"
+git -C "$fixture" switch -q main
+
+printf 'rejecting a dirty tree\n'
+echo stray >>"$fixture/PKGBUILD"
+reject "$next_version"
+
+printf 'rejecting stale main\n'
+git -C "$fixture" commit -qam stale
+reject "$next_version"
+git -C "$fixture" push -q origin main
+
+printf 'rejecting a version that is not newer\n'
+reject "$current_version"
+
+printf 'rejecting a tag that exists locally\n'
+git -C "$fixture" tag "v$next_version"
+reject "$next_version"
+
+printf 'rejecting a tag that exists on origin only\n'
+git -C "$fixture" push -q origin "v$next_version"
+git -C "$fixture" tag -d "v$next_version" >/dev/null
+reject "$next_version"
+cleanup
+
+printf 'precondition guards hold\n'
+```
+
+- [ ] **Step 2: Run it to verify the new scenarios fail**
+
+Run: `scripts/test-release.sh`
+Expected: FAIL — `expected scripts/release.sh <next_version> to fail` on the
+outside-main scenario: the script has no branch guard yet, so it succeeds (and, having no
+edits either, exits 0).
+
+- [ ] **Step 3: Implement the guards**
+
+Append to `scripts/release.sh`, after the `canonical "$new" || die ...` line:
+
+```sh
+# True when canonical $1 is strictly greater than canonical $2. Numeric, not
+# lexicographic: 0.1.10 is newer than 0.1.9.
+greater() {
+    a_head=${1%%.*}
+    b_head=${2%%.*}
+    [ "$a_head" -lt "$b_head" ] && return 1
+    [ "$a_head" -gt "$b_head" ] && return 0
+    [ "$1" = "$a_head" ] && return 1
+    greater "${1#*.}" "${2#*.}"
+}
+
+[ "$(git rev-parse --abbrev-ref HEAD)" = main ] || die 'releases are cut from main'
+
+[ -z "$(git status --porcelain)" ] || die 'the working tree is not clean'
+
+git fetch -q origin main
+[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] \
+    || die 'main is not up to date with origin/main; merge or rebase first'
+
+current=$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' Cargo.toml)
+[ -n "$current" ] || die 'no version found under [workspace.package] in Cargo.toml'
+canonical "$current" || die "the manifest version $current is not canonical"
+greater "$new" "$current" || die "$new is not newer than the manifest's $current"
+
+if git rev-parse -q --verify "refs/tags/v$new" >/dev/null; then
+    die "tag v$new already exists locally"
+fi
+if git ls-remote --tags --exit-code origin "refs/tags/v$new" >/dev/null 2>&1; then
+    die "tag v$new already exists on origin"
+fi
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `scripts/test-release.sh`
+Expected: PASS — all rejection scenarios run, ending with `precondition guards hold`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release.sh scripts/test-release.sh
+git commit -m "feat: guard the release script's preconditions"
+```
+
+---
+
+### Task 3: Edits, verification, commit, tag, push
+
+**Files:**
+- Modify: `scripts/release.sh` (append after the tag guards)
+- Modify: `scripts/test-release.sh` (replace the trailing `printf` line)
+
+**Interfaces:**
+- Consumes: `greater()` from Task 2; `scripts/check-tag-version.sh` via the fixture.
+- Produces: the complete `scripts/release.sh`.
+
+- [ ] **Step 1: Add the failing happy-path scenarios**
+
+In `scripts/test-release.sh`, replace the trailing `printf 'precondition guards hold\n'`
+line with:
+
+```sh
+metainfo=data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+
+printf 'cutting a full release\n'
+make_fixture
+(cd "$fixture" && scripts/release.sh "$next_version") >/dev/null
+
+[ "$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' \
+    "$fixture/Cargo.toml")" = "$next_version" ]
+grep -q "^tidemark-types = { version = \"$next_version\", path = \"../tidemark-types\" }\$" \
+    "$fixture/crates/tidemark-core/Cargo.toml"
+grep -q "^tidemark-core = { version = \"$next_version\", path = \"../tidemark-core\" }\$" \
+    "$fixture/crates/tidemarkd/Cargo.toml"
+for crate in tidemark-types tidemark-core tidemarkd tidemark; do
+    grep -A1 "^name = \"$crate\"$" "$fixture/Cargo.lock" \
+        | grep -q "^version = \"$next_version\"\$"
+done
+release_line=$(sed -n '/^  <releases>$/{
+n
+p
+}' "$fixture/$metainfo")
+[ "$release_line" = "    <release version=\"$next_version\" date=\"$(date +%F)\" />" ]
+grep -q "^pkgver=$next_version\$" "$fixture/PKGBUILD"
+grep -q '^pkgrel=1$' "$fixture/PKGBUILD"
+
+[ "$(git -C "$fixture" log -1 --format=%s)" = "chore: bump to v$next_version" ]
+[ "$(git -C "$fixture" diff --name-only HEAD~1 HEAD | sort)" = "$(printf '%s\n' \
+    Cargo.lock Cargo.toml PKGBUILD \
+    crates/tidemark-core/Cargo.toml crates/tidemarkd/Cargo.toml \
+    "$metainfo" | sort)" ]
+[ "$(git -C "$fixture" for-each-ref "refs/tags/v$next_version" \
+    --format='%(objecttype)')" = tag ]
+[ "$(git --git-dir="$fixture.origin.git" rev-parse "v$next_version^{commit}")" \
+    = "$(git -C "$fixture" rev-parse HEAD)" ]
+cleanup
+
+printf '0.1.10 is newer than 0.1.9, numerically\n'
+make_fixture
+sed -i "/^\[workspace\.package\]/,/^\[/ s/^version = \"\(.*\)\"\$/version = \"0.1.9\"/" \
+    "$fixture/Cargo.toml"
+git -C "$fixture" commit -qam 'fixture at 0.1.9'
+(cd "$fixture" && scripts/release.sh 0.1.10) >/dev/null
+[ "$(git -C "$fixture" log -1 --format=%s)" = 'chore: bump to v0.1.10' ]
+cleanup
+
+printf 'the happy paths hold\n'
+```
+
+- [ ] **Step 2: Run it to verify the new scenarios fail**
+
+Run: `scripts/test-release.sh`
+Expected: FAIL — the first `[ ... = "$next_version" ]` manifest assertion fails: the
+script has no edits yet, so the fixture's `Cargo.toml` still says the old version.
+
+- [ ] **Step 3: Implement the rest of the script**
+
+Append to `scripts/release.sh`, after the remote-tag guard, and add the trap after the
+`cd "$project_root"` line:
+
+After `cd "$project_root"` (Task 1's file), insert:
+
+```sh
+edited=
+committed=
+trap 'if [ -n "$edited" ] && [ -z "$committed" ]; then
+        printf "release.sh: edits are still in the working tree; revert with: git checkout -- .\n" >&2
+    fi' EXIT
+```
+
+After the remote-tag guard (Task 2's addition), append:
+
+```sh
+edited=1
+
+# The one number everything else derives from.
+sed -i "/^\[workspace\.package\]/,/^\[/ s/^version = \".*\"\$/version = \"$new\"/" Cargo.toml
+
+# ^0.1.0 does not match 0.2.0: the inter-crate requirements move with the workspace or
+# the build breaks.
+sed -i '/^tidemark-types = { version = /s/version = "[^"]*"/version = "'"$new"'"/' \
+    crates/tidemark-core/Cargo.toml
+sed -i '/^tidemark-core = { version = /s/version = "[^"]*"/version = "'"$new"'"/' \
+    crates/tidemarkd/Cargo.toml
+
+# release.yml builds with --locked, so members' lock entries must move with the manifests.
+# --offline: external dependencies are untouched, the registry is never consulted.
+cargo update --workspace --offline --quiet
+
+# AppStream wants the newest release first. Notes prose is human work, added by hand.
+entry="    <release version=\"$new\" date=\"$(date +%F)\" />"
+sed -i "/^  <releases>$/a\\$entry" \
+    data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+
+# The PKGBUILD's header comment says the version comes from the workspace manifest and is
+# bumped alongside it.
+sed -i "s/^pkgver=.*/pkgver=$new/; s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+# A sed that matched nothing becomes a loud failure here, not a broken release.
+grep -q "^version = \"$new\"\$" Cargo.toml
+grep -q "^tidemark-types = { version = \"$new\"" crates/tidemark-core/Cargo.toml
+grep -q "^tidemark-core = { version = \"$new\"" crates/tidemarkd/Cargo.toml
+grep -q "<release version=\"$new\" date=" data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+grep -q "^pkgver=$new\$" PKGBUILD
+
+# The exact contract the tag push is about to be judged by in CI.
+scripts/check-tag-version.sh "v$new"
+if command -v appstreamcli >/dev/null 2>&1; then
+    appstreamcli validate --pedantic --no-net \
+        data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+fi
+
+git add Cargo.toml Cargo.lock crates/tidemark-core/Cargo.toml crates/tidemarkd/Cargo.toml \
+    data/metainfo/io.github.zbndev.Tidemark.metainfo.xml PKGBUILD
+git commit -m "chore: bump to v$new"
+git tag -a "v$new" -m "Tidemark v$new"
+committed=1
+
+if ! git push origin main "v$new"; then
+    printf 'release.sh: the push failed, but the commit and tag are local; push them, e.g.: git push origin main v%s\n' \
+        "$new" >&2
+    exit 1
+fi
+
+printf 'release.sh: v%s is pushed; the Release workflow is drafting the release\n' "$new"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `scripts/test-release.sh`
+Expected: PASS — `cutting a full release` runs against the fixture (the push lands on the
+throwaway bare remote, which exceeds the spec's "up to but not including the push" while
+staying hermetic), then the numeric-order case, ending with `the happy paths hold`.
+
+- [ ] **Step 5: Run shellcheck on both scripts**
+
+Run: `shellcheck scripts/release.sh scripts/test-release.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/release.sh scripts/test-release.sh
+git commit -m "feat: bump, commit, tag and push from the release script"
+```
+
+---
+
+### Task 4: CI wiring
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (after the "The user-daemon restart helper" step)
+- Modify: `.github/workflows/release.yml` (after the "The user-daemon restart helper" run)
+
+**Interfaces:**
+- Consumes: `scripts/test-release.sh` from Tasks 1–3.
+- Produces: nothing consumed later.
+
+- [ ] **Step 1: Add the step to ci.yml**
+
+In `.github/workflows/ci.yml`, directly after the `scripts/test-restart-user-daemon.sh`
+step, add:
+
+```yaml
+      - name: The release helper
+        run: scripts/test-release.sh
+```
+
+- [ ] **Step 2: Add the step to release.yml**
+
+In `.github/workflows/release.yml`, directly after the
+`- run: scripts/test-restart-user-daemon.sh` line in the `checks` job, add:
+
+```yaml
+      - run: scripts/test-release.sh
+```
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/release.yml')); print('ok')"`
+Expected: `ok`. (If `python3` or `yaml` is unavailable, `git diff` review of indentation
+against the neighbouring steps is an acceptable substitute.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/release.yml
+git commit -m "ci: run the release script tests"
+```
+
+---
+
+### Task 5: Full-suite verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the project's own gates**
+
+Run: `cargo fmt --all --check && shellcheck scripts/*.sh data/restart-user-daemon data/packaging/deb/postinst data/packaging/rpm/post-install.sh && scripts/test-release.sh`
+Expected: all pass, ending with `the happy paths hold`.
+
+- [ ] **Step 2: Confirm the working tree is clean**
+
+Run: `git status --porcelain`
+Expected: empty (every task committed; nothing stray introduced).
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: canonical-argument gate (Task 1), main/clean/stale/newer/tag guards
+  (Task 2), six-file edit set, `check-tag-version.sh` self-check, best-effort
+  `appstreamcli`, explicit `git add`, `chore: bump to vX.X.X`, annotated tag, single push
+  with recovery hint, edits-remain-hint trap (Task 3), shellcheck plus fixture smoke test
+  (Tasks 1–4). Non-goals need no tasks.
+- The happy-path push runs against the fixture's bare remote — beyond the spec's "up to but
+  not including the push", hermetically, and asserted on the remote side.
+- `v0.1.0` is a lightweight tag; the script creates annotated tags, per the spec.
+- If `cargo update --workspace --offline` ever fails in CI's clean environment, dropping
+  `--offline` is the fallback; it was verified to work offline on the development machine.

--- a/docs/superpowers/plans/2026-08-22-release-bump-script.md
+++ b/docs/superpowers/plans/2026-08-22-release-bump-script.md
@@ -24,8 +24,10 @@
 
 - Create: `scripts/release.sh` — the whole release flow: guards, edits, verification, commit/tag/push.
 - Create: `scripts/test-release.sh` — hermetic smoke test: fixture builder, rejection helpers, happy-path assertions.
-- Modify: `.github/workflows/ci.yml` — one step running `scripts/test-release.sh`.
-- Modify: `.github/workflows/release.yml` — one step running `scripts/test-release.sh`.
+
+`scripts/test-release.sh` is a run-by-hand test, like `scripts/test-package-upgrade.sh`: the
+project's owner declined a CI trigger for it (2026-08-22). The pre-existing `shellcheck
+scripts/*.sh` steps in both workflows still lint the two new scripts.
 
 ---
 
@@ -479,47 +481,13 @@ git commit -m "feat: bump, commit, tag and push from the release script"
 
 ---
 
-### Task 4: CI wiring
+### Task 4: CI wiring — dropped by the owner
 
-**Files:**
-- Modify: `.github/workflows/ci.yml` (after the "The user-daemon restart helper" step)
-- Modify: `.github/workflows/release.yml` (after the "The user-daemon restart helper" run)
-
-**Interfaces:**
-- Consumes: `scripts/test-release.sh` from Tasks 1–3.
-- Produces: nothing consumed later.
-
-- [ ] **Step 1: Add the step to ci.yml**
-
-In `.github/workflows/ci.yml`, directly after the `scripts/test-restart-user-daemon.sh`
-step, add:
-
-```yaml
-      - name: The release helper
-        run: scripts/test-release.sh
-```
-
-- [ ] **Step 2: Add the step to release.yml**
-
-In `.github/workflows/release.yml`, directly after the
-`- run: scripts/test-restart-user-daemon.sh` line in the `checks` job, add:
-
-```yaml
-      - run: scripts/test-release.sh
-```
-
-- [ ] **Step 3: Verify the YAML parses**
-
-Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/release.yml')); print('ok')"`
-Expected: `ok`. (If `python3` or `yaml` is unavailable, `git diff` review of indentation
-against the neighbouring steps is an acceptable substitute.)
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add .github/workflows/ci.yml .github/workflows/release.yml
-git commit -m "ci: run the release script tests"
-```
+The plan originally added a `scripts/test-release.sh` step to both `ci.yml` and
+`release.yml`. The project's owner declined CI triggers for this test (2026-08-22): it is
+run by hand, like `scripts/test-package-upgrade.sh`, whose header documents the same
+choice. The commit was reverted from the branch; the pre-existing `shellcheck scripts/*.sh`
+steps in both workflows still lint the new scripts. Nothing to implement.
 
 ---
 
@@ -541,6 +509,8 @@ Expected: empty (every task committed; nothing stray introduced).
 
 ## Self-Review Notes
 
+- Owner decision (2026-08-22): Task 4's CI wiring was reverted — `scripts/test-release.sh`
+  runs by hand only; the pre-existing shellcheck steps still cover both new scripts.
 - Corrected during execution (coordinator, 2026-08-22): reject() originally asserted an
   empty porcelain after a rejection, which the dirty-tree scenario (a deliberately dirty
   fixture) can never satisfy; the spec's invariant is "changed nothing", so the helper now

--- a/docs/superpowers/plans/2026-08-22-release-bump-script.md
+++ b/docs/superpowers/plans/2026-08-22-release-bump-script.md
@@ -96,14 +96,18 @@ make_fixture() {
     git -C "$fixture" push -q origin main
 }
 
-# Runs the fixture's release.sh expecting failure, and proving it edited nothing.
+# Runs the fixture's release.sh expecting failure, and proving it changed nothing: the
+# tree may already be dirty (the dirty-tree scenario dirties it on purpose), so the
+# invariant is before/after equality, not emptiness.
 reject() {
+    before=$(git -C "$fixture" status --porcelain)
     if (cd "$fixture" && scripts/release.sh "$@" >/dev/null 2>&1); then
         printf 'expected scripts/release.sh %s to fail\n' "$*" >&2
         exit 1
     fi
-    [ -z "$(git -C "$fixture" status --porcelain)" ] || {
-        printf 'scripts/release.sh %s failed but edited the tree\n' "$*" >&2
+    after=$(git -C "$fixture" status --porcelain)
+    [ "$before" = "$after" ] || {
+        printf 'scripts/release.sh %s failed but changed the tree\n' "$*" >&2
         exit 1
     }
 }
@@ -529,6 +533,10 @@ Expected: empty (every task committed; nothing stray introduced).
 
 ## Self-Review Notes
 
+- Corrected during execution (coordinator, 2026-08-22): reject() originally asserted an
+  empty porcelain after a rejection, which the dirty-tree scenario (a deliberately dirty
+  fixture) can never satisfy; the spec's invariant is "changed nothing", so the helper now
+  asserts before/after equality.
 - Spec coverage: canonical-argument gate (Task 1), main/clean/stale/newer/tag guards
   (Task 2), six-file edit set, `check-tag-version.sh` self-check, best-effort
   `appstreamcli`, explicit `git add`, `chore: bump to vX.X.X`, annotated tag, single push

--- a/docs/superpowers/specs/2026-08-22-release-bump-script-design.md
+++ b/docs/superpowers/specs/2026-08-22-release-bump-script-design.md
@@ -1,0 +1,87 @@
+# Release version bump script design
+
+## Goal
+
+One command turns the state of `main` into a pushed release tag: bump every version-carrying
+file, commit, tag, push. The release workflow already refuses a tag that disagrees with the
+workspace manifest (`scripts/check-tag-version.sh`); the script makes that refusal unreachable
+by construction and extends the same discipline to two files no CI job gates: the AppStream
+release list and the PKGBUILD.
+
+## Interface and shape
+
+`scripts/release.sh X.X.X` — POSIX sh with `set -eu`, styled after the sibling check scripts:
+short comments say why, `project_root` is computed from the script's location, and the only
+tools used are git, cargo, sed and `date`. `release.yml` already shellchecks every
+`scripts/*.sh`, so
+the new script is linted in CI for free.
+
+## Preconditions
+
+Every check runs before any file is edited:
+
+- Exactly one argument, a canonical `X.X.X`: three dot-separated groups of ASCII digits with
+  no leading zeroes — the same rules `check-tag-version.sh` and `tidemarkd`'s update checker
+  enforce, so the script never accepts a version the rest of the system would reject.
+- The current branch is `main`.
+- The working tree is clean: `git status --porcelain` is empty. `.gitignore` already hides
+  makepkg output and local scratch, so leftover artifacts do not block a release.
+- After `git fetch origin main`, local `main` equals `origin/main`. A release is never cut
+  from stale `main`.
+- The requested version is strictly greater, component-wise, than the current
+  `[workspace.package]` version — typo and downgrade protection.
+- Tag `vX.X.X` exists neither locally nor on the remote.
+
+## Edits
+
+Six files, in this order:
+
+1. Root `Cargo.toml`: `version` under `[workspace.package]`, edited with the same sed section
+   range `check-tag-version.sh` uses to read it.
+2. `crates/tidemark-core/Cargo.toml`: the `version` requirement of the `tidemark-types` path
+   dependency. `^0.1.0` does not match `0.2.0`, so the build breaks unless this moves with the
+   workspace.
+3. `crates/tidemarkd/Cargo.toml`: the `version` requirement of the `tidemark-core` path
+   dependency, for the same reason.
+4. `Cargo.lock`: `cargo update --workspace`, which rewrites only workspace members' entries
+   and leaves external dependencies alone. Required because `release.yml` builds with
+   `--locked`, which fails on a stale lockfile.
+5. `data/metainfo/io.github.zbndev.Tidemark.metainfo.xml`: a new
+   `<release version="X.X.X" date="<today>" />` inserted as the first — newest — entry of
+   `<releases>`. Release notes prose stays human work, added by hand when there is something
+   to say.
+6. `PKGBUILD`: `pkgver=X.X.X` and `pkgrel=1`. The PKGBUILD's own header comment already says
+   the version comes from the workspace manifest and is bumped alongside it.
+
+## Pre-commit verification
+
+- `scripts/check-tag-version.sh "vX.X.X"` must agree — proving, before anything is committed,
+  the exact contract the tag push is about to be judged by in CI.
+- `appstreamcli validate --pedantic --no-net` on the metainfo when the binary is installed
+  locally. Best effort: CI validates it regardless.
+
+## Commit, tag, push
+
+An explicit `git add` of the six files — never `-A`. One commit, `chore: bump to vX.X.X`;
+one annotated tag, `vX.X.X`; one push of both refs, `git push origin main vX.X.X`. A failed
+push prints the recovery hint instead of failing silently: the commit and tag are already
+local, push them manually.
+
+## Failure behaviour
+
+`set -eu` aborts on the first failed step. Before the commit this deliberately leaves the
+edits in the working tree — inspectable, and revertible with `git checkout -- .`, a hint the
+script prints. No automatic rollback: a half-executed release is something to look at, not
+to hide.
+
+## Non-goals
+
+The script runs no fmt, clippy or tests — the tag push triggers `release.yml`, which runs the
+full suite before building anything. It generates no changelog and publishes no GitHub
+release; `release.yml` drafts one. There is no dry-run mode.
+
+## Testing
+
+shellcheck locally and in CI. A smoke test drives the script against a throwaway git fixture
+seeded with copies of the six files: every precondition rejection, the happy path up to but
+not including the push, and the content of the resulting edits.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+# Turns the state of main into a pushed release tag: bumps every version-carrying file,
+# commits, tags, pushes. Every guard runs before the first edit; a failure between the
+# first edit and the commit leaves the edits in the tree on purpose — inspect, then revert
+# with `git checkout -- .`.
+#
+#   scripts/release.sh X.X.X
+#
+# No fmt, clippy or tests run here: the tag push triggers the Release workflow, which runs
+# the whole suite before building anything.
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$project_root"
+
+die() {
+    printf 'release.sh: %s\n' "$1" >&2
+    exit 1
+}
+
+# A canonical version: exactly three dot-separated groups of ASCII digits, no leading
+# zeroes (a lone zero is fine) — the same form check-tag-version.sh and tidemarkd's update
+# checker accept.
+canonical() {
+    case $1 in *[!0-9.]*) return 1 ;; esac
+
+    old_ifs=$IFS
+    IFS=.
+    set -f
+    # shellcheck disable=SC2086  # splitting on '.' is the point; set -f guards globbing
+    set -- $1
+    set +f
+    IFS=$old_ifs
+    [ $# -eq 3 ] || return 1
+
+    for component in "$@"; do
+        case $component in
+            0 | [1-9] | [1-9][0-9]*) ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+[ $# -eq 1 ] || die 'usage: scripts/release.sh X.X.X'
+new=$1
+canonical "$new" || die "$new is not a canonical version (X.X.X, no leading zeroes)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,6 +14,12 @@ set -eu
 project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$project_root"
 
+edited=
+committed=
+trap 'if [ -n "$edited" ] && [ -z "$committed" ]; then
+        printf "release.sh: edits are still in the working tree; revert with: git checkout -- .\n" >&2
+    fi' EXIT
+
 die() {
     printf 'release.sh: %s\n' "$1" >&2
     exit 1
@@ -76,3 +82,56 @@ fi
 if git ls-remote --tags --exit-code origin "refs/tags/v$new" >/dev/null 2>&1; then
     die "tag v$new already exists on origin"
 fi
+
+edited=1
+
+# The one number everything else derives from.
+sed -i "/^\[workspace\.package\]/,/^\[/ s/^version = \".*\"\$/version = \"$new\"/" Cargo.toml
+
+# ^0.1.0 does not match 0.2.0: the inter-crate requirements move with the workspace or
+# the build breaks.
+sed -i '/^tidemark-types = { version = /s/version = "[^"]*"/version = "'"$new"'"/' \
+    crates/tidemark-core/Cargo.toml
+sed -i '/^tidemark-core = { version = /s/version = "[^"]*"/version = "'"$new"'"/' \
+    crates/tidemarkd/Cargo.toml
+
+# release.yml builds with --locked, so members' lock entries must move with the manifests.
+# --offline: external dependencies are untouched, the registry is never consulted.
+cargo update --workspace --offline --quiet
+
+# AppStream wants the newest release first. Notes prose is human work, added by hand.
+entry="    <release version=\"$new\" date=\"$(date +%F)\" />"
+sed -i "/^  <releases>$/a\\$entry" \
+    data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+
+# The PKGBUILD's header comment says the version comes from the workspace manifest and is
+# bumped alongside it.
+sed -i "s/^pkgver=.*/pkgver=$new/; s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+# A sed that matched nothing becomes a loud failure here, not a broken release.
+grep -q "^version = \"$new\"\$" Cargo.toml
+grep -q "^tidemark-types = { version = \"$new\"" crates/tidemark-core/Cargo.toml
+grep -q "^tidemark-core = { version = \"$new\"" crates/tidemarkd/Cargo.toml
+grep -q "<release version=\"$new\" date=" data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+grep -q "^pkgver=$new\$" PKGBUILD
+
+# The exact contract the tag push is about to be judged by in CI.
+scripts/check-tag-version.sh "v$new"
+if command -v appstreamcli >/dev/null 2>&1; then
+    appstreamcli validate --pedantic --no-net \
+        data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+fi
+
+git add Cargo.toml Cargo.lock crates/tidemark-core/Cargo.toml crates/tidemarkd/Cargo.toml \
+    data/metainfo/io.github.zbndev.Tidemark.metainfo.xml PKGBUILD
+git commit -m "chore: bump to v$new"
+git tag -a "v$new" -m "Tidemark v$new"
+committed=1
+
+if ! git push origin main "v$new"; then
+    printf 'release.sh: the push failed, but the commit and tag are local; push them, e.g.: git push origin main v%s\n' \
+        "$new" >&2
+    exit 1
+fi
+
+printf 'release.sh: v%s is pushed; the Release workflow is drafting the release\n' "$new"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,7 +29,7 @@ die() {
 # zeroes (a lone zero is fine) — the same form check-tag-version.sh and tidemarkd's update
 # checker accept.
 canonical() {
-    case $1 in *[!0-9.]*) return 1 ;; esac
+    case $1 in *[!0-9.]* | .* | *.) return 1 ;; esac
 
     old_ifs=$IFS
     IFS=.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -45,3 +45,34 @@ canonical() {
 [ $# -eq 1 ] || die 'usage: scripts/release.sh X.X.X'
 new=$1
 canonical "$new" || die "$new is not a canonical version (X.X.X, no leading zeroes)"
+
+# True when canonical $1 is strictly greater than canonical $2. Numeric, not
+# lexicographic: 0.1.10 is newer than 0.1.9.
+greater() {
+    a_head=${1%%.*}
+    b_head=${2%%.*}
+    [ "$a_head" -lt "$b_head" ] && return 1
+    [ "$a_head" -gt "$b_head" ] && return 0
+    [ "$1" = "$a_head" ] && return 1
+    greater "${1#*.}" "${2#*.}"
+}
+
+[ "$(git rev-parse --abbrev-ref HEAD)" = main ] || die 'releases are cut from main'
+
+[ -z "$(git status --porcelain)" ] || die 'the working tree is not clean'
+
+git fetch -q origin main
+[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] \
+    || die 'main is not up to date with origin/main; merge or rebase first'
+
+current=$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' Cargo.toml)
+[ -n "$current" ] || die 'no version found under [workspace.package] in Cargo.toml'
+canonical "$current" || die "the manifest version $current is not canonical"
+greater "$new" "$current" || die "$new is not newer than the manifest's $current"
+
+if git rev-parse -q --verify "refs/tags/v$new" >/dev/null; then
+    die "tag v$new already exists locally"
+fi
+if git ls-remote --tags --exit-code origin "refs/tags/v$new" >/dev/null 2>&1; then
+    die "tag v$new already exists on origin"
+fi

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -84,6 +84,8 @@ reject 1.02.3
 reject 1.2.03
 reject 1..2
 reject .1.2
+reject ".$next_version"
+reject "$next_version."
 cleanup
 
 printf 'rejecting a release cut outside main\n'

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -25,8 +25,9 @@ trap cleanup EXIT
 make_fixture() {
     fixture=$(mktemp -d "${TMPDIR:-/tmp}/tidemark-release-test.XXXXXX")
 
-    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types" \
-        "$fixture/crates/tidemark-core" "$fixture/crates/tidemarkd" "$fixture/crates/tidemark"
+    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types/src" \
+        "$fixture/crates/tidemark-core/src" "$fixture/crates/tidemarkd/src" \
+        "$fixture/crates/tidemark/src"
     cp "$project_root/Cargo.toml" "$project_root/Cargo.lock" \
         "$project_root/rust-toolchain.toml" "$project_root/PKGBUILD" "$fixture/"
     cp "$project_root/crates/tidemark-types/Cargo.toml" "$fixture/crates/tidemark-types/"
@@ -37,6 +38,13 @@ make_fixture() {
         "$fixture/data/metainfo/"
     cp "$project_root/scripts/release.sh" "$project_root/scripts/check-tag-version.sh" \
         "$fixture/scripts/"
+
+    # `cargo update` must be able to load the workspace, and target auto-discovery needs
+    # these; empty stubs do — nothing ever compiles in the fixture.
+    : >"$fixture/crates/tidemark-types/src/lib.rs"
+    : >"$fixture/crates/tidemark-core/src/lib.rs"
+    : >"$fixture/crates/tidemarkd/src/main.rs"
+    : >"$fixture/crates/tidemark/src/main.rs"
 
     git -C "$fixture" init -q -b main
     git -C "$fixture" config user.name fixture
@@ -106,4 +114,49 @@ git -C "$fixture" tag -d "v$next_version" >/dev/null
 reject "$next_version"
 cleanup
 
-printf 'precondition guards hold\n'
+metainfo=data/metainfo/io.github.zbndev.Tidemark.metainfo.xml
+
+printf 'cutting a full release\n'
+make_fixture
+(cd "$fixture" && scripts/release.sh "$next_version") >/dev/null 2>&1
+
+[ "$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' \
+    "$fixture/Cargo.toml")" = "$next_version" ]
+grep -q "^tidemark-types = { version = \"$next_version\", path = \"../tidemark-types\" }\$" \
+    "$fixture/crates/tidemark-core/Cargo.toml"
+grep -q "^tidemark-core = { version = \"$next_version\", path = \"../tidemark-core\" }\$" \
+    "$fixture/crates/tidemarkd/Cargo.toml"
+for crate in tidemark-types tidemark-core tidemarkd tidemark; do
+    grep -A1 "^name = \"$crate\"$" "$fixture/Cargo.lock" \
+        | grep -q "^version = \"$next_version\"\$"
+done
+release_line=$(sed -n '/^  <releases>$/{
+n
+p
+}' "$fixture/$metainfo")
+[ "$release_line" = "    <release version=\"$next_version\" date=\"$(date +%F)\" />" ]
+grep -q "^pkgver=$next_version\$" "$fixture/PKGBUILD"
+grep -q '^pkgrel=1$' "$fixture/PKGBUILD"
+
+[ "$(git -C "$fixture" log -1 --format=%s)" = "chore: bump to v$next_version" ]
+[ "$(git -C "$fixture" diff --name-only HEAD~1 HEAD | sort)" = "$(printf '%s\n' \
+    Cargo.lock Cargo.toml PKGBUILD \
+    crates/tidemark-core/Cargo.toml crates/tidemarkd/Cargo.toml \
+    "$metainfo" | sort)" ]
+[ "$(git -C "$fixture" for-each-ref "refs/tags/v$next_version" \
+    --format='%(objecttype)')" = tag ]
+[ "$(git --git-dir="$fixture.origin.git" rev-parse "v$next_version^{commit}")" \
+    = "$(git -C "$fixture" rev-parse HEAD)" ]
+cleanup
+
+printf '0.1.10 is newer than 0.1.9, numerically\n'
+make_fixture
+sed -i "/^\[workspace\.package\]/,/^\[/ s/^version = \"\(.*\)\"\$/version = \"0.1.9\"/" \
+    "$fixture/Cargo.toml"
+git -C "$fixture" commit -qam 'fixture at 0.1.9'
+git -C "$fixture" push -q origin main
+(cd "$fixture" && scripts/release.sh 0.1.10) >/dev/null 2>&1
+[ "$(git -C "$fixture" log -1 --format=%s)" = 'chore: bump to v0.1.10' ]
+cleanup
+
+printf 'the happy paths hold\n'

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -51,12 +51,14 @@ make_fixture() {
 
 # Runs the fixture's release.sh expecting failure, and proving it edited nothing.
 reject() {
+    before=$(git -C "$fixture" status --porcelain)
     if (cd "$fixture" && scripts/release.sh "$@" >/dev/null 2>&1); then
         printf 'expected scripts/release.sh %s to fail\n' "$*" >&2
         exit 1
     fi
-    [ -z "$(git -C "$fixture" status --porcelain)" ] || {
-        printf 'scripts/release.sh %s failed but edited the tree\n' "$*" >&2
+    after=$(git -C "$fixture" status --porcelain)
+    [ "$before" = "$after" ] || {
+        printf 'scripts/release.sh %s failed but changed the tree\n' "$*" >&2
         exit 1
     }
 }
@@ -76,4 +78,32 @@ reject 1..2
 reject .1.2
 cleanup
 
-printf 'argument validation holds\n'
+printf 'rejecting a release cut outside main\n'
+make_fixture
+git -C "$fixture" switch -q -c side
+reject "$next_version"
+git -C "$fixture" switch -q main
+
+printf 'rejecting a dirty tree\n'
+echo stray >>"$fixture/PKGBUILD"
+reject "$next_version"
+
+printf 'rejecting stale main\n'
+git -C "$fixture" commit -qam stale
+reject "$next_version"
+git -C "$fixture" push -q origin main
+
+printf 'rejecting a version that is not newer\n'
+reject "$current_version"
+
+printf 'rejecting a tag that exists locally\n'
+git -C "$fixture" tag "v$next_version"
+reject "$next_version"
+
+printf 'rejecting a tag that exists on origin only\n'
+git -C "$fixture" push -q origin "v$next_version"
+git -C "$fixture" tag -d "v$next_version" >/dev/null
+reject "$next_version"
+cleanup
+
+printf 'precondition guards hold\n'

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -eu
+
+# Proves scripts/release.sh: every precondition rejection, and a full happy path against a
+# throwaway bare repository playing origin — nothing here touches the real repository or
+# the real origin.
+#
+#   scripts/test-release.sh
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+current_version=$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"$/\1/p' \
+    "$project_root/Cargo.toml")
+next_version=${current_version%.*}.$(( ${current_version##*.} + 1 ))
+
+fixture=
+cleanup() {
+    [ -n "$fixture" ] && rm -rf "$fixture" "$fixture.origin.git"
+    fixture=
+}
+trap cleanup EXIT
+
+# A miniature copy of the version-carrying files plus the two scripts under test, with its
+# own bare repository as origin, so even the push step of a happy path runs for real.
+make_fixture() {
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/tidemark-release-test.XXXXXX")
+
+    mkdir -p "$fixture/scripts" "$fixture/data/metainfo" "$fixture/crates/tidemark-types" \
+        "$fixture/crates/tidemark-core" "$fixture/crates/tidemarkd" "$fixture/crates/tidemark"
+    cp "$project_root/Cargo.toml" "$project_root/Cargo.lock" \
+        "$project_root/rust-toolchain.toml" "$project_root/PKGBUILD" "$fixture/"
+    cp "$project_root/crates/tidemark-types/Cargo.toml" "$fixture/crates/tidemark-types/"
+    cp "$project_root/crates/tidemark-core/Cargo.toml" "$fixture/crates/tidemark-core/"
+    cp "$project_root/crates/tidemarkd/Cargo.toml" "$fixture/crates/tidemarkd/"
+    cp "$project_root/crates/tidemark/Cargo.toml" "$fixture/crates/tidemark/"
+    cp "$project_root/data/metainfo/io.github.zbndev.Tidemark.metainfo.xml" \
+        "$fixture/data/metainfo/"
+    cp "$project_root/scripts/release.sh" "$project_root/scripts/check-tag-version.sh" \
+        "$fixture/scripts/"
+
+    git -C "$fixture" init -q -b main
+    git -C "$fixture" config user.name fixture
+    git -C "$fixture" config user.email fixture@invalid
+    git -C "$fixture" add -A
+    git -C "$fixture" commit -q -m fixture
+
+    git init -q --bare "$fixture.origin.git"
+    git -C "$fixture" remote add origin "$fixture.origin.git"
+    git -C "$fixture" push -q origin main
+}
+
+# Runs the fixture's release.sh expecting failure, and proving it edited nothing.
+reject() {
+    if (cd "$fixture" && scripts/release.sh "$@" >/dev/null 2>&1); then
+        printf 'expected scripts/release.sh %s to fail\n' "$*" >&2
+        exit 1
+    fi
+    [ -z "$(git -C "$fixture" status --porcelain)" ] || {
+        printf 'scripts/release.sh %s failed but edited the tree\n' "$*" >&2
+        exit 1
+    }
+}
+
+printf 'rejecting malformed versions\n'
+make_fixture
+reject
+reject 1.2 1.3
+reject 1.2
+reject 1.2.3.4
+reject "v$next_version"
+reject 1.2.3-beta
+reject 01.2.3
+reject 1.02.3
+reject 1.2.03
+reject 1..2
+reject .1.2
+cleanup
+
+printf 'argument validation holds\n'


### PR DESCRIPTION
## Summary

`scripts/release.sh X.X.X` turns the state of `main` into a pushed release tag: it bumps every version-carrying file, commits `chore: bump to vX.X.X`, creates an annotated tag and pushes both refs. Every guard runs before the first edit; a failure between the first edit and the commit leaves the edits in the working tree on purpose, with a printed revert hint.

## Changes

- **`scripts/release.sh`** — the whole flow:
  - canonical-version argument gate (three digit groups, no leading zeroes, no leading/trailing dots — the same form `tidemarkd`'s update checker enforces);
  - precondition guards: `main` only, clean tree, `main` == `origin/main` after fetch, requested version strictly newer than the manifest's (numeric, not lexicographic), tag free both locally and on the remote;
  - the six-file bump: workspace version, both inter-crate dependency requirements (`^0.1.0` would not match `0.2.0`), `Cargo.lock` via `cargo update --workspace --offline`, a new AppStream `<release>` entry dated today, and PKGBUILD `pkgver`/`pkgrel=1`;
  - self-verification through `scripts/check-tag-version.sh` — the exact contract the Release workflow enforces on the tag — plus best-effort `appstreamcli validate`;
  - explicit `git add` of the six files, commit, annotated tag, single `git push origin main vX.X.X` with a recovery hint if the push fails.
- **`scripts/test-release.sh`** — hermetic smoke test: a mktemp fixture (copies of the real version-carrying files plus empty target stubs) with a bare temp repository as origin, so even the push runs for real. Covers every rejection scenario and two happy paths, including the numeric-order regression (`0.1.10` > `0.1.9`).
- **Docs** — the design spec and implementation plan under `docs/superpowers/`, recording the execution-time corrections.

No workflow changes: `test-release.sh` runs by hand, and the existing `shellcheck scripts/*.sh` steps in both workflows already lint the new scripts.

## Testing

- `scripts/test-release.sh` — full pass (all rejection scenarios + both happy paths), pristine output
- `shellcheck` on all `scripts/*.sh` — clean
- `cargo fmt --all --check` — clean (no Rust code changed)
