### PR TITLE
ci: skip CI run for unrelated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: CI
 
 on:
   pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Don't waste CI time on unimportant non-code changes (README or docs)