### PR TITLE
fix(codex): drop the gpt-reserve pool instead of drawing it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,7 +80,10 @@ cookies — a deliberate scope boundary, not a coincidence.
 
 Codex reports `rate_limit.primary_window` / `secondary_window` — slots rather than lanes,
 each declaring its own length — plus a `code_review_rate_limit` of the same shape and named
-`additional_rate_limits[]`. The three are separate pools, not lengths of one.
+`additional_rate_limits[]`. The three are separate pools, not lengths of one. One extra
+pool is dropped rather than drawn: `metered_feature: "base_model_inference"`, shown by
+OpenAI as *gpt-reserve*, whose weekly window resets at `captured_at + 604800` on every
+poll and so measures nothing.
 Antigravity reports two model groups (Gemini, Claude+GPT) × two windows. "OpenAI" here
 means the ChatGPT/Codex subscription, not the API Platform billing dashboard — the latter
 has spend, not reset windows, and does not fit this model.

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -17,6 +17,18 @@
 //! `additional_rate_limits[]` all carry the same primary/secondary pair. They are different
 //! *pools* rather than different lengths of one pool, so each keeps its own key prefix and
 //! a weekly window in one cannot collide with a weekly window in another.
+//!
+//! # The pool that is not a quota
+//!
+//! One `additional_rate_limits[]` entry is a reserve rather than an allowance and is
+//! dropped: `metered_feature: "base_model_inference"`, displayed by OpenAI as
+//! *gpt-reserve*. Observed on 2026-08-22 on a `plus` account, its window declared
+//! `limit_window_seconds: 604800` at `used_percent: 0` with `reset_at` exactly
+//! `captured_at + 604800` — the whole account's `rate_limit` in the same response said
+//! 560287 seconds to its own weekly reset, so the reserve's seven days restart on every
+//! poll and can never elapse. A bar over that measures nothing: it would sit permanently
+//! empty beside the real weekly window with a pace mark pinned to zero, and read as a
+//! second week of headroom the account does not have. See [`RESERVE_FEATURE`].
 
 use super::{BoxFuture, Credential, Provider, ProviderError, http, length_title, title_case};
 use crate::oauth;
@@ -36,6 +48,16 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 /// The slug this provider's history is filed under. Never changes once shipped.
 pub const PROVIDER_ID: &str = "codex";
+
+/// The `metered_feature` of the reserve pool, dropped before it becomes a window.
+///
+/// Matched on the feature slug rather than on the `limit_name` OpenAI shows it under
+/// ("gpt-reserve"), for the same reason every pool here is keyed on the slug: the label
+/// is vendor copy and can be reworded between two responses, while the slug is what the
+/// limit is. Should OpenAI turn this feature into a real allowance, the bar comes back by
+/// deleting one line — and until it declares a window that actually elapses, there is
+/// nothing here to draw.
+const RESERVE_FEATURE: &str = "base_model_inference";
 
 const USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
 const REFRESH_URL: &str = "https://auth.openai.com/oauth/token";
@@ -418,6 +440,15 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
             serde_json::from_value(entry.clone()).map_err(|error| {
                 ProviderError::malformed(format!("an extra rate limit is not readable: {error}"))
             })?;
+        // Not a limit anyone spends against; see the module docs.
+        if extra
+            .metered_feature
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|feature| feature == RESERVE_FEATURE)
+        {
+            continue;
+        }
         let name = extra
             .limit_name
             .as_deref()

--- a/crates/tidemark-core/tests/codex_provider.rs
+++ b/crates/tidemark-core/tests/codex_provider.rs
@@ -202,6 +202,68 @@ fn additional_rate_limits_become_windows_named_after_their_own_pool() {
 }
 
 #[test]
+fn the_gpt_reserve_pool_is_dropped_instead_of_drawn_as_a_second_week() {
+    // The body the live endpoint returned on 2026-08-22, identifiers replaced. The
+    // reserve's reset is `captured_at + 604800` to the second, so its seven days restart
+    // on every poll while the account's own weekly window counts down beside it.
+    let body = r#"{
+      "plan_type": "plus",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {"used_percent": 40, "limit_window_seconds": 604800,
+                           "reset_after_seconds": 560287, "reset_at": 1787815811},
+        "secondary_window": null
+      },
+      "additional_rate_limits": [
+        {"limit_name": "gpt-reserve", "metered_feature": "base_model_inference",
+         "rate_limit": {
+           "allowed": true,
+           "limit_reached": false,
+           "primary_window": {"used_percent": 0, "limit_window_seconds": 604800,
+                              "reset_after_seconds": 604800, "reset_at": 1787860324},
+           "secondary_window": null}}
+      ]
+    }"#;
+
+    let snapshot = codex::parse(body, captured_at()).expect("the live body parses");
+
+    let keys: Vec<&str> = snapshot.windows.iter().map(|w| w.key.as_str()).collect();
+    assert_eq!(
+        keys,
+        ["w604800"],
+        "the account's own weekly window is the only quota in this body"
+    );
+}
+
+#[test]
+fn the_reserve_is_known_by_its_feature_slug_and_not_by_the_name_it_is_shown_under() {
+    // Same entry with the display name reworded: the slug still identifies it. And a
+    // pool that merely calls itself gpt-reserve while metering something else is a real
+    // limit, drawn like any other.
+    let reworded = r#"{
+      "rate_limit": {"primary_window": {"used_percent": 40, "limit_window_seconds": 604800}},
+      "additional_rate_limits": [
+        {"limit_name": "GPT Reserve", "metered_feature": "base_model_inference",
+         "rate_limit": {"primary_window": {"used_percent": 0, "limit_window_seconds": 604800}}}
+      ]
+    }"#;
+    let snapshot = codex::parse(reworded, captured_at()).expect("parses");
+    assert_eq!(snapshot.windows.len(), 1);
+
+    let borrowed_name = r#"{
+      "rate_limit": {"primary_window": {"used_percent": 40, "limit_window_seconds": 604800}},
+      "additional_rate_limits": [
+        {"limit_name": "gpt-reserve", "metered_feature": "some_new_pool",
+         "rate_limit": {"primary_window": {"used_percent": 7, "limit_window_seconds": 18000}}}
+      ]
+    }"#;
+    let snapshot = codex::parse(borrowed_name, captured_at()).expect("parses");
+    let keys: Vec<&str> = snapshot.windows.iter().map(|w| w.key.as_str()).collect();
+    assert_eq!(keys, ["w604800", "some_new_pool/w18000"]);
+}
+
+#[test]
 fn an_extra_pool_with_no_name_at_all_fails_rather_than_colliding_with_the_main_one() {
     let body = r#"{
       "rate_limit": {"primary_window": {"used_percent": 19, "limit_window_seconds": 604800}},


### PR DESCRIPTION
## What

The Codex card drew a second seven-day bar next to the real weekly window. It came from the one `additional_rate_limits[]` entry that is not a quota. This filters it out.

## Why

Live body from `GET chatgpt.com/backend-api/wham/usage`, 2026-08-22, `plus` account:

```json
"rate_limit": {
  "primary_window": {"used_percent": 40, "limit_window_seconds": 604800,
                     "reset_after_seconds": 560287, "reset_at": 1787988533}
},
"additional_rate_limits": [{
  "limit_name": "gpt-reserve",
  "metered_feature": "base_model_inference",
  "rate_limit": {"primary_window": {
    "used_percent": 0, "limit_window_seconds": 604800,
    "reset_after_seconds": 604800, "reset_at": 1788033047}}
}]
```

`1788033047 - 604800 = 1787428247`, which is `captured_at` to the second — while the account's own weekly window had 560287 seconds left. The reserve's seven days restart on every poll and can never elapse, so it measures nothing: a permanently empty bar with its pace mark pinned to zero, reading as a second week of headroom the account does not have. It is the pool a banked rate-limit reset draws on, not an allowance anyone spends against.

No upstream filters it. `openai/codex` maps every element of the array into its own snapshot ([`backend-client/src/client.rs:554-560`](https://github.com/openai/codex/blob/343074d4207d572809bd8cea15f4be1d09d98e0b/codex-rs/backend-client/src/client.rs)), and CodexBar's `CodexAdditionalRateLimitMapper` renders any entry with a usable window. Neither has a reserved/banked case. This is ours.

## How

- `RESERVE_FEATURE = "base_model_inference"` in `providers/codex.rs`; the entry is skipped in the `additional_rate_limits[]` loop before a window is built.
- Matched on the feature slug, not on `limit_name`, for the same reason every pool here is keyed on the slug: the label is vendor copy and can be reworded between two responses, while the slug is what the limit is.
- Module docs carry the observed evidence; `CONTEXT.md` § Providers in v1 gains a sentence.

## Verification

Real endpoint, real credentials, through the actual provider:

```
WINDOW w604800 | 7 days | 42% | resets Some(1787988534)
DETAIL Plan [Subscription: Plus]
```

One bar. Two new tests in `crates/tidemark-core/tests/codex_provider.rs`: the live body yields exactly `["w604800"]`; a reworded `limit_name` is still filtered, and a different pool that merely calls itself `gpt-reserve` is drawn like any other. `cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean.

## Risk

If OpenAI turns `base_model_inference` into a real allowance we hide it silently. The signal is the inverse — a quota missing from the card — and the fix is deleting the `continue`. Existing history rows under `base_model_inference/w604800` are left orphaned; the engine treats a vanished window as movement (a redraw), not a notification.
