### PR TITLE
feat(credentials): let the user pick which of two logins an account uses

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,16 @@ cookies — a deliberate scope boundary, not a coincidence.
 | Kimi | `GET https://api.kimi.com/coding/v1/usages` | user-supplied key from Kimi Code Console |
 | Antigravity | Cloud Code Assist `fetchAvailableModels`; optional local `agy` fallback | Tidemark Google OAuth, or an existing `agy` session |
 
+Three of them have **two** credentials rather than one, and which of the two an account
+uses is the user's choice, not a rule hidden in the daemon. It is stored as
+`[provider.<slug>] source = "oauth" | "cli"`, published with the provider so a client can
+draw it without knowing what either credential is, and drawn in the authentication group
+as a two-part control — Tidemark's own login on the left, the local program's on the right.
+**A pinned credential that is not there is `no-credential`, never a quiet fall back to the
+other one**: falling back would show quota for an account the user did not choose. An
+account whose `source` has never been set behaves exactly as it always did — the daemon
+publishes which credential that resolves to, so the control still shows the truth.
+
 Codex reports `rate_limit.primary_window` / `secondary_window` — slots rather than lanes,
 each declaring its own length — plus a `code_review_rate_limit` of the same shape and named
 `additional_rate_limits[]`. The three are separate pools, not lengths of one. One extra
@@ -136,8 +146,9 @@ and persists the provider's `default` account; `RemoveProvider(provider, account
 one. `ProviderChanged` carries the same status shape as `GetStatus` for an account that was
 added or updated, while `ProviderRemoved(provider, account)` tells long-running clients to
 drop its settings row and card. `Refresh(provider)` polls now, with an empty string meaning
-everything, and re-reads the credential on the way. `Version` says what is on the other
-end.
+everything, re-reads the credential on the way, and looks again for the vendor login a
+provider can read instead of ours — a refresh is what a user reaches for straight after
+running `claude` in a terminal. `Version` says what is on the other end.
 
 Credentials are the daemon's, so changing them is the daemon's too: `SetKey`, `SignOut`,
 `SetOption`, `SetWindowNotify`, and the two halves of a login. Nothing there is specific to the GUI — a
@@ -385,6 +396,16 @@ history that does not exist yet.
   a new one. Removal is destructive and confirmed: it deletes Tidemark-owned credentials,
   provider settings and the current card, but keeps quota history. Closing the preferences
   dialog cancels pending OAuth work, and the dialog can then be opened again.
+- **A provider with two credentials names both of them.** Its authentication group leads
+  with a two-part control — Tidemark's own login, and the login the vendor's program keeps
+  on this machine — and the rows below it are the half that is selected. The Tidemark half
+  is the sign-in button and what it is signed in as. The local half is the three things
+  somebody with a problem needs, in that order: whether the login is there and where
+  Tidemark looked for it, what to run if it is not, and — where it is true — that Tidemark
+  refreshes that credential in place and writes the rotated token back into a file it does
+  not own. That last sentence is ADR 0001, and it is stated in the open next to the choice
+  rather than left to be discovered: a program that edits another program's credentials
+  says so where the decision is made.
 - **Tray** — a static StatusNotifierItem, owned by the interface process rather than by the
   daemon. Left click shows the window; the menu lists the configured accounts with the
   percentage of their shortest window, in the order the grid uses, and ends with Open,

--- a/crates/tidemark-core/src/providers/antigravity/mod.rs
+++ b/crates/tidemark-core/src/providers/antigravity/mod.rs
@@ -47,7 +47,9 @@ use tidemark_types::{
 };
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-use super::{BoxFuture, Credential, Provider, ProviderError, http, length_title, title_case};
+use super::{
+    BoxFuture, Credential, Provider, ProviderError, Source, http, length_title, title_case,
+};
 use crate::secrets::{self, Secrets};
 use agy::Agy;
 
@@ -106,48 +108,13 @@ impl LocalQuota for AgyQuota {
     }
 }
 
-/// Which of Antigravity's two quota sources this account reads.
+/// An Antigravity account, reading whichever of its two sources [`Source`] selects.
 ///
 /// Two sources rather than a source and a fallback, because neither subsumes the other.
 /// The local `agy` server is the vendor's own live session and needs `agy` installed and
 /// logged in; the login is Tidemark's own and works on a machine with no `agy` at all —
 /// but only for an account Google entitles to the Cloud Code quota RPCs, which it answers
-/// `RESOURCE_EXHAUSTED` for accounts it does not. Neither is the right default everywhere,
-/// so the choice is the user's and [`Source::Auto`] is what it does when they have not made
-/// one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Source {
-    /// The local server first, the login when it cannot answer.
-    #[default]
-    Auto,
-    /// Only the login Tidemark performed.
-    OAuth,
-    /// Only the local `agy` server.
-    Cli,
-}
-
-impl Source {
-    /// The mode a stored setting names, defaulting to [`Source::Auto`].
-    ///
-    /// An unrecognised value is the default rather than an error: the settings file is
-    /// hand-editable, and a typo should cost the default rather than the account.
-    pub fn from_value(value: Option<&str>) -> Self {
-        match value {
-            Some(OAUTH_SOURCE) => Self::OAuth,
-            Some(CLI_SOURCE) => Self::Cli,
-            _ => Self::Auto,
-        }
-    }
-}
-
-/// The stored spelling of [`Source::Auto`].
-pub const AUTO_SOURCE: &str = "auto";
-/// The stored spelling of [`Source::OAuth`].
-pub const OAUTH_SOURCE: &str = "oauth";
-/// The stored spelling of [`Source::Cli`].
-pub const CLI_SOURCE: &str = "cli";
-
-/// An Antigravity account, reading whichever of its two sources [`Source`] selects.
+/// `RESOURCE_EXHAUSTED` for accounts it does not.
 #[derive(Debug)]
 pub struct Antigravity {
     client: reqwest::Client,
@@ -1328,16 +1295,6 @@ mod tests {
 
         let error = block_on(provider.fetch_inner()).expect_err("nothing to ask");
         assert!(matches!(error, ProviderError::NoCredential), "{error:?}");
-    }
-
-    #[test]
-    fn a_source_is_read_from_its_stored_spelling_and_an_unknown_one_is_auto() {
-        assert_eq!(Source::from_value(Some("oauth")), Source::OAuth);
-        assert_eq!(Source::from_value(Some("cli")), Source::Cli);
-        assert_eq!(Source::from_value(Some("auto")), Source::Auto);
-        // Hand-editable file: a typo costs the default, not a card that will not start.
-        assert_eq!(Source::from_value(Some("nonsense")), Source::Auto);
-        assert_eq!(Source::from_value(None), Source::Auto);
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/claude.rs
+++ b/crates/tidemark-core/src/providers/claude.rs
@@ -1,27 +1,35 @@
 //! Claude subscription quota, over one of two credentials.
 //!
-//! # Two sources, and which one wins
+//! # Two sources, and the one this account reads
 //!
-//! Normally the account is Claude Code's: `~/.claude/.credentials.json`, read in place and
-//! refreshed back into it under the CLI's own lock protocol, per ADR 0001. That file is
-//! never created here and never replaced wholesale — Tidemark only ever updates the token
+//! One is Claude Code's own: `~/.claude/.credentials.json`, read in place and refreshed
+//! back into it under the CLI's own lock protocol, per ADR 0001. That file is never
+//! created here and never replaced wholesale — Tidemark only ever updates the token
 //! fields of a file the CLI already owns.
 //!
-//! The other source is a login the user performed **from Tidemark**, whose tokens live in
-//! the Secret Service under [`crate::secrets::Kind::Token`]. It is checked first, and the
-//! order is deliberate: it exists only because the user explicitly signed in here, so it
-//! is the more recent statement of intent, and signing out removes it and hands the
-//! account straight back to the CLI file. The stored document has the *same shape* as the
-//! CLI's, which is why one parser reads both.
+//! The other is a login the user performed **from Tidemark**, whose tokens live in the
+//! Secret Service under [`crate::secrets::Kind::Token`]. The stored document has the
+//! *same shape* as the CLI's, which is why one parser reads both.
+//!
+//! Which of them this account speaks with is the caller's choice, handed to
+//! [`Claude::new`] as a [`Source`]. [`Source::Auto`] is the historical rule, and its
+//! order is deliberate: the Tidemark login is checked first because it exists only
+//! because the user explicitly signed in here, so it is the more recent statement of
+//! intent, and signing out removes it and hands the account straight back to the CLI
+//! file. The other two pin the account to one credential and treat the other as absent —
+//! a missing pinned login is [`ProviderError::NoCredential`], not a reason to read a
+//! file the user excluded.
 
-use super::{BoxFuture, Credential, Provider, ProviderError, http, parse_rfc3339, title_case};
+use super::{
+    BoxFuture, Credential, Provider, ProviderError, Source, http, parse_rfc3339, title_case,
+};
 use crate::oauth;
 use crate::oauth_file::{
     CredentialFile, CredentialFileError, Field, LockedCredentialFile, UpdateOutcome,
 };
 use crate::secrets::{self, Secrets};
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tidemark_types::{
@@ -126,6 +134,8 @@ pub struct Claude {
     /// Where a login performed from Tidemark is kept, when the caller has somewhere to
     /// keep one. `None` in tests that only exercise the CLI file.
     own: Option<Arc<dyn Secrets>>,
+    /// Which of the two credentials this account reads — see the module docs.
+    source: Source,
     usage_url: String,
     refresh_url: String,
     profile_url: String,
@@ -134,16 +144,22 @@ pub struct Claude {
     plan: OnceLock<String>,
 }
 
+/// The canonical Claude Code credential file, or `None` when `HOME` is unusable.
+///
+/// Free-standing rather than a method so that a caller can ask whether the CLI's login
+/// exists on this machine without building the provider.
+pub fn cli_credentials_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").filter(|home| Path::new(home).is_absolute())?;
+    Some(Path::new(&home).join(".claude/.credentials.json"))
+}
+
 impl Claude {
     /// Builds the canonical Claude Code account at `~/.claude/.credentials.json`.
-    pub fn new(own: Option<Arc<dyn Secrets>>) -> Result<Self, ProviderError> {
-        let home = std::env::var_os("HOME")
-            .filter(|home| Path::new(home).is_absolute())
-            .ok_or_else(|| {
-                ProviderError::Local("HOME does not name an absolute directory".into())
-            })?;
-        let path = Path::new(&home).join(".claude/.credentials.json");
-        let write_lock = Path::new(&home).join(".claude/.storage-write.lock");
+    pub fn new(own: Option<Arc<dyn Secrets>>, source: Source) -> Result<Self, ProviderError> {
+        let path = cli_credentials_path().ok_or_else(|| {
+            ProviderError::Local("HOME does not name an absolute directory".into())
+        })?;
+        let write_lock = path.with_file_name(".storage-write.lock");
         let mut claude = Self::with_endpoints(
             CredentialFile::new(path.clone(), path).coordinated_by(write_lock),
             USAGE_URL.to_owned(),
@@ -151,6 +167,7 @@ impl Claude {
             PROFILE_URL.to_owned(),
         )?;
         claude.own = own;
+        claude.source = source;
         Ok(claude)
     }
 
@@ -164,6 +181,7 @@ impl Claude {
             client: http::client()?,
             credentials,
             own: None,
+            source: Source::Auto,
             usage_url,
             refresh_url,
             profile_url,
@@ -245,23 +263,46 @@ impl Claude {
 
     /// The access token to spend, and the plan to put on the card.
     ///
-    /// A Tidemark login wins over the CLI file when there is one — see the module docs.
-    /// Neither source is consulted for the other's failures: a keyring that is locked
-    /// reports itself as locked rather than silently falling through to a file that may
-    /// hold a different account.
+    /// [`Source`] says which credential supplies it — see the module docs. A source that
+    /// was not selected is not consulted at all, and one that was selected answers for
+    /// itself: a keyring that is locked reports itself as locked rather than silently
+    /// falling through to a file that may hold a different account, and a pinned login
+    /// that is not there is [`ProviderError::NoCredential`].
     async fn credential(&self) -> Result<(Credential, Option<String>), ProviderError> {
-        if let Some(own) = &self.own {
-            let provider = ProviderId::new(PROVIDER_ID);
-            let account = AccountId::default();
-            let stored = own
-                .get(secrets::Kind::Token, &provider, &account)
-                .await
-                .map_err(ProviderError::from_secret_error)?;
-            if let Some(stored) = stored {
-                return self.own_login_credential(own.as_ref(), stored).await;
+        match self.source {
+            Source::Cli => self.cli_file_credential().await,
+            Source::OAuth => {
+                let Some(own) = &self.own else {
+                    return Err(ProviderError::NoCredential);
+                };
+                let stored = own
+                    .get(
+                        secrets::Kind::Token,
+                        &ProviderId::new(PROVIDER_ID),
+                        &AccountId::default(),
+                    )
+                    .await
+                    .map_err(ProviderError::from_secret_error)?;
+                match stored {
+                    Some(stored) => self.own_login_credential(own.as_ref(), stored).await,
+                    None => Err(ProviderError::NoCredential),
+                }
+            }
+            Source::Auto => {
+                if let Some(own) = &self.own {
+                    let provider = ProviderId::new(PROVIDER_ID);
+                    let account = AccountId::default();
+                    let stored = own
+                        .get(secrets::Kind::Token, &provider, &account)
+                        .await
+                        .map_err(ProviderError::from_secret_error)?;
+                    if let Some(stored) = stored {
+                        return self.own_login_credential(own.as_ref(), stored).await;
+                    }
+                }
+                self.cli_file_credential().await
             }
         }
-        self.cli_file_credential().await
     }
 
     /// The CLI's file, refreshed in place if the token in it is spent.
@@ -1228,6 +1269,136 @@ mod tests {
             requests.try_recv().is_err(),
             "the CLI file must not have been touched"
         );
+    }
+
+    #[test]
+    fn cli_source_reads_the_cli_file_even_when_a_login_is_stored() {
+        const USAGE: &str = r#"{
+          "limits":[
+            {"kind":"session","group":"session","percent":41,"severity":"normal",
+             "resets_at":"2026-08-20T21:50:00Z","scope":null,"is_active":true}
+          ],
+          "spend":null,"extra_usage":null
+        }"#;
+        // Both credentials are live and carry different tokens: the request that leaves
+        // proves which one was read.
+        let credentials = TestCredentials::expired();
+        fs::write(
+            &credentials.path,
+            serde_json::to_vec_pretty(&json!({"claudeAiOauth": {
+                "accessToken": "from-the-cli-file",
+                "refreshToken": "file-refresh",
+                "expiresAt": 4_102_444_800_000_i64,
+                "subscriptionType": "pro"
+            }}))
+            .expect("serialize"),
+        )
+        .expect("write a live CLI file");
+        let secrets = FakeSecrets::holding(json!({"claudeAiOauth": {
+            "accessToken": "from-the-tidemark-login",
+            "refreshToken": "own-refresh",
+            "expiresAt": 4_102_444_800_000_i64,
+            "subscriptionType": "max"
+        }}));
+        let (base, requests, server) = local_server(vec![USAGE]);
+        let mut provider = Claude::with_endpoints(
+            CredentialFile::new(credentials.path.clone(), credentials.path.clone()),
+            format!("{base}/usage"),
+            format!("{base}/token"),
+            format!("{base}/profile"),
+        )
+        .expect("provider builds");
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::Cli;
+
+        let snapshot = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect("the CLI file is enough");
+
+        assert_eq!(snapshot.windows[0].used_percent, 41.0);
+        assert_eq!(
+            snapshot.details[0].rows[0].value, "Pro",
+            "the plan came from the file, not from the stored login"
+        );
+        let usage_request = requests.recv().expect("one request");
+        assert!(
+            usage_request.contains("authorization: Bearer from-the-cli-file"),
+            "{usage_request}"
+        );
+        server.join().expect("server stopped");
+        assert!(requests.try_recv().is_err(), "nothing else was asked");
+    }
+
+    #[test]
+    fn oauth_source_reads_the_stored_login_even_when_the_cli_file_is_live() {
+        const USAGE: &str = r#"{
+          "limits":[
+            {"kind":"session","group":"session","percent":12,"severity":"normal",
+             "resets_at":"2026-08-20T21:50:00Z","scope":null,"is_active":true}
+          ],
+          "spend":null,"extra_usage":null
+        }"#;
+        // The mirror image: both credentials live, the pinned source is the login.
+        let credentials = TestCredentials::expired();
+        let before = fs::read(&credentials.path).expect("fixture readable");
+        let secrets = FakeSecrets::holding(json!({"claudeAiOauth": {
+            "accessToken": "from-the-tidemark-login",
+            "refreshToken": "own-refresh",
+            "expiresAt": 4_102_444_800_000_i64,
+            "subscriptionType": "max"
+        }}));
+        let (base, requests, server) = local_server(vec![USAGE]);
+        let mut provider = Claude::with_endpoints(
+            CredentialFile::new(credentials.path.clone(), credentials.path.clone()),
+            format!("{base}/usage"),
+            format!("{base}/token"),
+            format!("{base}/profile"),
+        )
+        .expect("provider builds");
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::OAuth;
+
+        let snapshot = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect("the stored login is enough");
+
+        assert_eq!(snapshot.windows[0].used_percent, 12.0);
+        let usage_request = requests.recv().expect("one request");
+        assert!(
+            usage_request.contains("authorization: Bearer from-the-tidemark-login"),
+            "{usage_request}"
+        );
+        server.join().expect("server stopped");
+        assert_eq!(
+            fs::read(&credentials.path).expect("still there"),
+            before,
+            "the pinned source never wrote to the CLI's file"
+        );
+    }
+
+    #[test]
+    fn oauth_source_without_a_login_says_so_without_opening_the_cli_file() {
+        // The file on disk is not even JSON: if the pinned source so much as opened it,
+        // the outcome could not be `NoCredential`.
+        let credentials = TestCredentials::expired();
+        fs::write(&credentials.path, b"this is not the CLI's JSON").expect("corrupt file");
+        let mut provider = Claude::with_endpoints(
+            CredentialFile::new(credentials.path.clone(), credentials.path.clone()),
+            "http://127.0.0.1:9/usage".to_owned(),
+            "http://127.0.0.1:9/token".to_owned(),
+            "http://127.0.0.1:9/profile".to_owned(),
+        )
+        .expect("provider builds");
+        provider.own = Some(Arc::new(FakeSecrets::default()) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::OAuth;
+
+        let error = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect_err("a pinned login that is not there is no credential");
+        assert!(matches!(error, ProviderError::NoCredential), "{error}");
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -1,4 +1,20 @@
-//! Codex subscription quota over the OAuth credentials owned by the Codex CLI.
+//! Codex subscription quota, over one of two credentials.
+//!
+//! # Two sources, and the one this account reads
+//!
+//! One is the Codex CLI's own `auth.json`, read in place and refreshed back into it, per
+//! ADR 0001 — never created here, never replaced wholesale. The other is a login the user
+//! performed **from Tidemark**, stored in the Secret Service under
+//! [`crate::secrets::Kind::Token`] in the *same shape* the CLI writes, which is why one
+//! parser reads both.
+//!
+//! Which of them this account speaks with is the caller's choice, handed to
+//! [`Codex::new`] as a [`Source`]. [`Source::Auto`] is the historical rule: the Tidemark
+//! login when there is one, the CLI's file otherwise. The pinned sources treat the other
+//! credential as absent for refresh as much as for reading — [`Source::Cli`] rotates the
+//! file's tokens and never consults the keyring, [`Source::OAuth`] rotates the stored
+//! login and never opens the file, and a pinned login that is not there is
+//! [`ProviderError::NoCredential`].
 //!
 //! # The trap this provider exists to demonstrate
 //!
@@ -30,7 +46,9 @@
 //! empty beside the real weekly window with a pace mark pinned to zero, and read as a
 //! second week of headroom the account does not have. See [`RESERVE_FEATURE`].
 
-use super::{BoxFuture, Credential, Provider, ProviderError, http, length_title, title_case};
+use super::{
+    BoxFuture, Credential, Provider, ProviderError, Source, http, length_title, title_case,
+};
 use crate::oauth;
 use crate::oauth_file::{
     CredentialFile, CredentialFileError, Field, LockedCredentialFile, UpdateOutcome,
@@ -135,20 +153,25 @@ pub struct Codex {
     /// Where a login performed from Tidemark is kept, when the caller has somewhere to
     /// keep one.
     own: Option<Arc<dyn Secrets>>,
+    /// Which of the two credentials this account reads — see the module docs.
+    source: Source,
     usage_url: String,
     refresh_url: String,
 }
 
 impl Codex {
     /// Builds the canonical Codex account at `$CODEX_HOME/auth.json`, or `~/.codex`.
-    pub fn new(own: Option<Arc<dyn Secrets>>) -> Result<Self, ProviderError> {
-        let path = auth_path()?;
+    pub fn new(own: Option<Arc<dyn Secrets>>, source: Source) -> Result<Self, ProviderError> {
+        let path = cli_credentials_path().ok_or_else(|| {
+            ProviderError::Local("HOME does not name an absolute directory".into())
+        })?;
         let mut codex = Self::with_endpoints(
             CredentialFile::new(path.clone(), path),
             USAGE_URL.to_owned(),
             REFRESH_URL.to_owned(),
         )?;
         codex.own = own;
+        codex.source = source;
         Ok(codex)
     }
 
@@ -161,6 +184,7 @@ impl Codex {
             client: http::client()?,
             credentials,
             own: None,
+            source: Source::Auto,
             usage_url,
             refresh_url,
         })
@@ -204,34 +228,60 @@ impl Codex {
 
     /// Reads the credential, refreshing first when the token says it is spent.
     ///
-    /// A Tidemark login wins over the CLI file when there is one; see the module docs.
+    /// [`Source`] says which of the two is read; see the module docs. A pinned login that
+    /// is not there is [`ProviderError::NoCredential`], not a reason to open the file.
     async fn load(&self, now: i64) -> Result<CodexCredentials, ProviderError> {
-        if let Some(stored) = self.own_document().await? {
-            return self.own_credentials(stored, now, false).await;
+        match self.source {
+            Source::Cli => self.cli_file_credentials(now, false).await,
+            Source::OAuth => match self.own_document().await? {
+                Some(stored) => self.own_credentials(stored, now, false).await,
+                None => Err(ProviderError::NoCredential),
+            },
+            Source::Auto => {
+                if let Some(stored) = self.own_document().await? {
+                    return self.own_credentials(stored, now, false).await;
+                }
+                self.cli_file_credentials(now, false).await
+            }
         }
+    }
+
+    /// Refreshes whatever the selected source holds, regardless of what its expiry claims.
+    ///
+    /// This is the path an opaque access token takes: nothing local could have predicted
+    /// its death, so the provider's 401 is the announcement and this is the response. The
+    /// source that was not selected is not consulted here either — a pinned file is
+    /// refreshed without the keyring ever being asked.
+    async fn force_refresh(&self) -> Result<CodexCredentials, ProviderError> {
+        let now = Timestamp::now().as_unix();
+        match self.source {
+            Source::Cli => self.cli_file_credentials(now, true).await,
+            Source::OAuth => match self.own_document().await? {
+                Some(stored) => self.own_credentials(stored, now, true).await,
+                None => Err(ProviderError::NoCredential),
+            },
+            Source::Auto => {
+                if let Some(stored) = self.own_document().await? {
+                    return self.own_credentials(stored, now, true).await;
+                }
+                self.cli_file_credentials(now, true).await
+            }
+        }
+    }
+
+    /// The CLI's file, refreshed in place when forced or when the token says it is spent.
+    async fn cli_file_credentials(
+        &self,
+        now: i64,
+        force: bool,
+    ) -> Result<CodexCredentials, ProviderError> {
         let locked = self.credentials.lock().map_err(map_file_error)?;
         let document = locked.read_json().map_err(map_file_error)?;
         let credentials = CodexCredentials::from_document(&document)?;
-        if credentials.is_expired_at(now) {
+        if force || credentials.is_expired_at(now) {
             return self.refresh(&locked, credentials).await;
         }
         Ok(credentials)
-    }
-
-    /// Refreshes whatever is currently stored, regardless of what its expiry claims.
-    ///
-    /// This is the path an opaque access token takes: nothing local could have predicted
-    /// its death, so the provider's 401 is the announcement and this is the response.
-    async fn force_refresh(&self) -> Result<CodexCredentials, ProviderError> {
-        if let Some(stored) = self.own_document().await? {
-            return self
-                .own_credentials(stored, Timestamp::now().as_unix(), true)
-                .await;
-        }
-        let locked = self.credentials.lock().map_err(map_file_error)?;
-        let document = locked.read_json().map_err(map_file_error)?;
-        let credentials = CodexCredentials::from_document(&document)?;
-        self.refresh(&locked, credentials).await
     }
 
     /// The document of a login performed from Tidemark, if there is one.
@@ -399,16 +449,18 @@ impl Provider for Codex {
     }
 }
 
-/// Where the Codex CLI keeps its credentials.
-fn auth_path() -> Result<PathBuf, ProviderError> {
+/// Where the Codex CLI keeps its credentials: `$CODEX_HOME/auth.json` when that names
+/// an absolute directory, else `~/.codex/auth.json` — or `None` when neither is usable.
+///
+/// Free-standing rather than a method so that a caller can ask whether the CLI's login
+/// exists on this machine without building the provider.
+pub fn cli_credentials_path() -> Option<PathBuf> {
     if let Some(home) = std::env::var_os("CODEX_HOME").filter(|home| Path::new(home).is_absolute())
     {
-        return Ok(Path::new(&home).join("auth.json"));
+        return Some(Path::new(&home).join("auth.json"));
     }
-    let home = std::env::var_os("HOME")
-        .filter(|home| Path::new(home).is_absolute())
-        .ok_or_else(|| ProviderError::Local("HOME does not name an absolute directory".into()))?;
-    Ok(Path::new(&home).join(".codex/auth.json"))
+    let home = std::env::var_os("HOME").filter(|home| Path::new(home).is_absolute())?;
+    Some(Path::new(&home).join(".codex/auth.json"))
 }
 
 /// Turns a usage response into a snapshot.
@@ -1320,6 +1372,214 @@ mod tests {
             fs::read(&home.path).expect("still there"),
             before,
             "the CLI's file is not read from and not written to"
+        );
+    }
+
+    #[test]
+    fn cli_source_reads_the_file_even_when_a_login_is_stored() {
+        // Both credentials are live and carry different tokens and account ids: the
+        // request that leaves proves which one was read.
+        let home = TestHome::expired();
+        fs::write(
+            &home.path,
+            serde_json::to_vec_pretty(&json!({
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "from-the-cli-file",
+                    "refresh_token": "file-refresh",
+                    "account_id": "acct-file"
+                }
+            }))
+            .expect("serialize"),
+        )
+        .expect("write a live CLI file");
+        let secrets = FakeSecrets::holding(json!({
+            "tokens": {"access_token": "from-the-tidemark-login", "refresh_token": "own-refresh", "account_id": "acct-own"}
+        }));
+        let (base, requests, server) = local_server(vec![USAGE]);
+        let mut provider = home.provider(&base);
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::Cli;
+
+        let snapshot = block_on(provider.fetch_inner()).expect("the CLI file is enough");
+
+        assert_eq!(snapshot.windows.len(), 1);
+        let usage_request = requests.recv().expect("one request");
+        assert!(
+            usage_request.contains("authorization: Bearer from-the-cli-file"),
+            "{usage_request}"
+        );
+        assert!(
+            usage_request.contains("chatgpt-account-id: acct-file"),
+            "{usage_request}"
+        );
+        server.join().expect("server stopped");
+        assert!(requests.try_recv().is_err(), "nothing else was asked");
+    }
+
+    #[test]
+    fn oauth_source_reads_the_stored_login_even_when_the_cli_file_is_live() {
+        // The mirror image: both credentials live, the pinned source is the login.
+        let home = TestHome::expired();
+        fs::write(
+            &home.path,
+            serde_json::to_vec_pretty(&json!({
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "from-the-cli-file",
+                    "refresh_token": "file-refresh",
+                    "account_id": "acct-file"
+                }
+            }))
+            .expect("serialize"),
+        )
+        .expect("write a live CLI file");
+        let before = fs::read(&home.path).expect("file readable");
+        let secrets = FakeSecrets::holding(json!({
+            "tokens": {"access_token": "from-the-tidemark-login", "refresh_token": "own-refresh", "account_id": "acct-own"}
+        }));
+        let (base, requests, server) = local_server(vec![USAGE]);
+        let mut provider = home.provider(&base);
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::OAuth;
+
+        let snapshot = block_on(provider.fetch_inner()).expect("the stored login is enough");
+
+        assert_eq!(snapshot.windows.len(), 1);
+        let usage_request = requests.recv().expect("one request");
+        assert!(
+            usage_request.contains("authorization: Bearer from-the-tidemark-login"),
+            "{usage_request}"
+        );
+        assert!(
+            usage_request.contains("chatgpt-account-id: acct-own"),
+            "{usage_request}"
+        );
+        server.join().expect("server stopped");
+        assert_eq!(
+            fs::read(&home.path).expect("still there"),
+            before,
+            "the pinned source never wrote to the CLI's file"
+        );
+    }
+
+    #[test]
+    fn oauth_source_without_a_login_says_so_without_opening_the_cli_file() {
+        // The file on disk is not even JSON: if the pinned source so much as opened it,
+        // the outcome could not be `NoCredential`.
+        let home = TestHome::expired();
+        fs::write(&home.path, b"this is not the CLI's JSON").expect("corrupt file");
+        let mut provider = home.provider("http://127.0.0.1:9");
+        provider.own = Some(Arc::new(FakeSecrets::default()) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::OAuth;
+
+        let error = block_on(provider.fetch_inner())
+            .expect_err("a pinned login that is not there is no credential");
+        assert!(matches!(error, ProviderError::NoCredential), "{error:?}");
+    }
+
+    #[test]
+    fn cli_source_refreshes_the_file_without_reading_the_stored_login() {
+        const ROTATION: (u16, &str) = (
+            200,
+            r#"{"access_token":"rotated","refresh_token":"rotated-refresh"}"#,
+        );
+        // The file's opaque token is rejected, so the retry path refreshes — and under
+        // Source::Cli it must spend the file's refresh token, never the stored login's.
+        let home = TestHome::expired();
+        fs::write(
+            &home.path,
+            serde_json::to_vec_pretty(&json!({
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "opaque-file-token",
+                    "refresh_token": "file-refresh",
+                    "account_id": "acct-file"
+                }
+            }))
+            .expect("serialize"),
+        )
+        .expect("write opaque credentials");
+        let secrets = FakeSecrets::holding(json!({
+            "tokens": {"access_token": "own-opaque", "refresh_token": "own-refresh", "account_id": "acct-own"}
+        }));
+        let (base, requests, server) = local_server(vec![(401, "{}"), ROTATION, USAGE]);
+        let mut provider = home.provider(&base);
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::Cli;
+
+        let snapshot = block_on(provider.fetch_inner()).expect("one refresh, one retry");
+        assert_eq!(snapshot.windows.len(), 1);
+
+        let rejected = requests.recv().expect("the first usage request");
+        assert!(
+            rejected.contains("authorization: Bearer opaque-file-token"),
+            "{rejected}"
+        );
+        let refresh = requests.recv().expect("refresh request");
+        assert!(
+            refresh.contains("\"refresh_token\":\"file-refresh\""),
+            "{refresh}"
+        );
+        assert!(!refresh.contains("own-refresh"), "{refresh}");
+        let retried = requests.recv().expect("the retried usage request");
+        assert!(
+            retried.contains("authorization: Bearer rotated"),
+            "{retried}"
+        );
+        server.join().expect("server stopped");
+
+        assert_eq!(
+            home.document()["tokens"]["access_token"],
+            "rotated",
+            "the rotation landed in the CLI's file"
+        );
+        let stored = secrets.stored();
+        assert_eq!(
+            stored["tokens"]["access_token"], "own-opaque",
+            "the stored login was never read, so there was nothing to write back"
+        );
+    }
+
+    #[test]
+    fn oauth_source_refreshes_the_stored_login_without_touching_the_cli_file() {
+        const ROTATION: (u16, &str) = (
+            200,
+            r#"{"access_token":"rotated","refresh_token":"rotated-refresh"}"#,
+        );
+        // The file on disk is not even JSON: the 401 retry path under Source::OAuth
+        // refreshes the stored login and never opens it.
+        let home = TestHome::expired();
+        fs::write(&home.path, b"this is not the CLI's JSON").expect("corrupt file");
+        let secrets = FakeSecrets::holding(json!({
+            "tokens": {"access_token": "opaque-own", "refresh_token": "own-refresh", "account_id": "acct-own"}
+        }));
+        let (base, requests, server) = local_server(vec![(401, "{}"), ROTATION, USAGE]);
+        let mut provider = home.provider(&base);
+        provider.own = Some(Arc::clone(&secrets) as Arc<dyn crate::secrets::Secrets>);
+        provider.source = Source::OAuth;
+
+        let snapshot = block_on(provider.fetch_inner()).expect("one refresh, one retry");
+        assert_eq!(snapshot.windows.len(), 1);
+
+        let _rejected = requests.recv().expect("the rejected request");
+        let refresh = requests.recv().expect("refresh request");
+        assert!(
+            refresh.contains("\"refresh_token\":\"own-refresh\""),
+            "{refresh}"
+        );
+        let retried = requests.recv().expect("the retried usage request");
+        assert!(
+            retried.contains("authorization: Bearer rotated"),
+            "{retried}"
+        );
+        server.join().expect("server stopped");
+
+        let stored = secrets.stored();
+        assert_eq!(stored["tokens"]["access_token"], "rotated");
+        assert_eq!(
+            stored["tokens"]["refresh_token"], "rotated-refresh",
+            "the rotation landed back in the keyring"
         );
     }
 

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -59,6 +59,58 @@ pub trait Provider: fmt::Debug + Send + Sync {
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>>;
 }
 
+/// Which of two credentials an account uses.
+///
+/// Claude, Codex and Antigravity each hold two: the vendor's own session — the CLI's
+/// credential file, or the running `agy` server — and a login the user performed **from
+/// Tidemark**, stored in the Secret Service. Two sources rather than a source and a
+/// fallback, because neither subsumes the other: the vendor's session is the account the
+/// user is actually working in, and Tidemark's login is the one that works on a machine
+/// the vendor's tool is not installed on at all. Neither is the right default everywhere,
+/// so the choice is the user's, and [`Source::Auto`] is what an account does until they
+/// make one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Source {
+    /// The provider's own rule: the stored login when there is one and the vendor's
+    /// session otherwise — except Antigravity, which asks its local server first.
+    #[default]
+    Auto,
+    /// Only the login Tidemark performed.
+    OAuth,
+    /// Only the vendor's own session: the CLI's credential file, or `agy`.
+    Cli,
+}
+
+impl Source {
+    /// The mode a stored setting names, defaulting to [`Source::Auto`].
+    ///
+    /// An unrecognised value is the default rather than an error: the settings file is
+    /// hand-editable, and a typo should cost the default rather than the account.
+    pub fn from_value(value: Option<&str>) -> Self {
+        match value {
+            Some(OAUTH_SOURCE) => Self::OAuth,
+            Some(CLI_SOURCE) => Self::Cli,
+            _ => Self::Auto,
+        }
+    }
+
+    /// The stored spelling of the mode — what [`Source::from_value`] reads back.
+    pub const fn as_value(self) -> &'static str {
+        match self {
+            Self::Auto => AUTO_SOURCE,
+            Self::OAuth => OAUTH_SOURCE,
+            Self::Cli => CLI_SOURCE,
+        }
+    }
+}
+
+/// The stored spelling of [`Source::Auto`].
+pub const AUTO_SOURCE: &str = "auto";
+/// The stored spelling of [`Source::OAuth`].
+pub const OAUTH_SOURCE: &str = "oauth";
+/// The stored spelling of [`Source::Cli`].
+pub const CLI_SOURCE: &str = "cli";
+
 /// What to call a window of this length, in the plainest terms that divide evenly.
 ///
 /// Shared because a window's span is the provider-neutral half of its title: every
@@ -249,6 +301,28 @@ mod tests {
     fn a_blank_credential_is_recognised_before_it_is_spent() {
         assert!(Credential::new("   ").is_blank());
         assert!(!Credential::new("sk-1").is_blank());
+    }
+
+    #[test]
+    fn a_source_is_read_from_its_stored_spelling_and_an_unknown_one_is_auto() {
+        assert_eq!(Source::from_value(Some("oauth")), Source::OAuth);
+        assert_eq!(Source::from_value(Some("cli")), Source::Cli);
+        assert_eq!(Source::from_value(Some("auto")), Source::Auto);
+        // Hand-editable file: a typo costs the default, not a card that will not start.
+        assert_eq!(Source::from_value(Some("nonsense")), Source::Auto);
+        assert_eq!(Source::from_value(None), Source::Auto);
+    }
+
+    #[test]
+    fn a_source_spells_itself_the_way_from_value_reads_it_back() {
+        for (source, spelling) in [
+            (Source::Auto, "auto"),
+            (Source::OAuth, "oauth"),
+            (Source::Cli, "cli"),
+        ] {
+            assert_eq!(source.as_value(), spelling);
+            assert_eq!(Source::from_value(Some(source.as_value())), source);
+        }
     }
 
     #[test]

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -19,8 +19,8 @@ pub use snapshot::{AccountId, DetailRow, DetailSection, ProviderId, Snapshot, pr
 pub use time::{AbsurdTimestamp, Timestamp};
 pub use window::{DANGER_AT, WARNING_AT, Window, WindowKey, WindowLength};
 pub use wire::{
-    CredentialKind, HistoryPoint, OptionChoice, ProviderDefinition, ProviderOption, ProviderState,
-    ProviderStatus, Remedy, WindowStatus,
+    CredentialKind, ExternalLogin, HistoryPoint, OptionChoice, ProviderDefinition, ProviderOption,
+    ProviderState, ProviderStatus, Remedy, WindowStatus,
 };
 
 /// Identity constants. Changing any of these is a breaking change for installed units,

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -208,6 +208,33 @@ pub struct ProviderOption {
     pub choices: Vec<OptionChoice>,
 }
 
+/// The local CLI login a provider can read instead of a login performed in Tidemark.
+///
+/// Three of the providers have two credentials rather than one: a token Tidemark obtained
+/// itself, and the token some other program on this machine already holds. Which of the
+/// two is used was, for a long time, decided silently in the daemon. It is published here
+/// instead, in enough detail for a client to *say* what the other credential is, where it
+/// lives, how to create one, and whether Tidemark writes to it — because a program that
+/// reads and refreshes a file another program owns must say so where the user can see it.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct ExternalLogin {
+    /// The setting that chooses between the two credentials, under `[provider.<slug>]`.
+    /// It is also one of [`ProviderDefinition::options`], and a client that draws the
+    /// choice itself must not draw it a second time among the ordinary settings.
+    pub option: String,
+    /// What the local login is called, in the words its own program uses — `Claude Code
+    /// login`, `agy session`.
+    pub label: String,
+    /// Where it lives, for a person: a path, or a sentence about a running process.
+    pub location: String,
+    /// What to run to create one. Empty when there is nothing single to name.
+    pub command: String,
+    /// Whether Tidemark refreshes this credential in place and writes the rotated token
+    /// back where it found it, per ADR 0001. `false` for a source Tidemark only reads.
+    pub writes_back: bool,
+}
+
 /// Presentation metadata for one provider in the daemon's catalog.
 #[derive(Debug, Clone, PartialEq, SerializeDict, DeserializeDict, Type)]
 #[zvariant(signature = "a{sv}")]
@@ -216,13 +243,21 @@ pub struct ProviderDefinition {
     pub title: String,
     pub credential: String,
     pub credential_hint: String,
-    pub external_fallback: Option<String>,
+    /// The other credential this provider can read, for the providers that have one.
+    pub external: Option<ExternalLogin>,
     pub options: Vec<ProviderOption>,
 }
 
 impl ProviderDefinition {
     pub fn credential_kind(&self) -> Option<CredentialKind> {
         CredentialKind::from_wire(&self.credential)
+    }
+
+    /// The setting that chooses between this provider's two credentials, when it has two.
+    pub fn auth_option(&self) -> Option<&str> {
+        self.external
+            .as_ref()
+            .map(|external| external.option.as_str())
     }
 }
 
@@ -330,6 +365,20 @@ pub struct ProviderStatus {
     /// Where the user gets the credential from, in one sentence. Absent when the answer is
     /// obvious enough not to need one.
     pub credential_hint: Option<String>,
+    /// Whether the local CLI login named by [`ProviderDefinition::external`] exists on
+    /// this machine. Absent when the provider has no such login, or when the daemon could
+    /// not tell — which is not the same as "there is none", and must not be drawn as one.
+    pub external_present: Option<bool>,
+    /// Which of the two credentials the next poll will actually use, as an
+    /// [`ExternalLogin`] choice value — `oauth` or `cli`.
+    ///
+    /// Published rather than derived by the client, and deliberately separate from the
+    /// choosing setting's own value: that setting may legitimately be unset, and what an
+    /// unset setting resolves to is the provider's business. Antigravity's local server is
+    /// the session the user is working in and wins by default; Claude's and Codex's own
+    /// login wins over the file their CLI owns. A client that guessed would have to be
+    /// taught each of those rules, and would go stale the first time one changed.
+    pub auth_source: Option<String>,
     /// The provider's own settings, with their current values and alternatives.
     pub options: Vec<ProviderOption>,
     /// Keys of the windows whose notifications the user has switched on.
@@ -355,6 +404,8 @@ impl ProviderStatus {
             credential: None,
             has_credential: None,
             credential_hint: None,
+            external_present: None,
+            auth_source: None,
             options: Vec::new(),
             notify: Vec::new(),
         }
@@ -464,13 +515,35 @@ mod tests {
             title: "Antigravity".into(),
             credential: CredentialKind::OAuth.as_wire().into(),
             credential_hint: "Sign in with Google.".into(),
-            external_fallback: Some("agy session".into()),
+            external: Some(ExternalLogin {
+                option: "source".into(),
+                label: "agy session".into(),
+                location: "a running agy server".into(),
+                command: "agy".into(),
+                writes_back: false,
+            }),
             options: Vec::new(),
         };
         let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
         let (decoded, _): (ProviderDefinition, _) = encoded.deserialize().expect("decodes");
         assert_eq!(decoded, original);
         assert_eq!(decoded.credential_kind(), Some(CredentialKind::OAuth));
+        assert_eq!(decoded.auth_option(), Some("source"));
+    }
+
+    #[test]
+    fn a_provider_with_one_credential_names_no_choice() {
+        // The absent field is the whole signal a client dispatches on: no external login
+        // means no source pill, and a key provider must never grow one.
+        let definition = ProviderDefinition {
+            provider: "zai".into(),
+            title: "Z.ai".into(),
+            credential: CredentialKind::Key.as_wire().into(),
+            credential_hint: "Z.ai dashboard → API keys.".into(),
+            external: None,
+            options: Vec::new(),
+        };
+        assert_eq!(definition.auth_option(), None);
     }
 
     #[test]

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -20,9 +20,9 @@
 //! It is a development aid, not a test fixture: nothing in the suite depends on it.
 
 use tidemark_types::{
-    AccountId, CredentialKind, DetailRow, DetailSection, ProviderDefinition, ProviderId,
-    ProviderState, ProviderStatus, Snapshot, Timestamp, Window, WindowKey, WindowLength, ids,
-    provider_label,
+    AccountId, CredentialKind, DetailRow, DetailSection, ExternalLogin, OptionChoice,
+    ProviderDefinition, ProviderId, ProviderOption, ProviderState, ProviderStatus, Snapshot,
+    Timestamp, Window, WindowKey, WindowLength, ids, provider_label,
 };
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
@@ -37,23 +37,33 @@ impl MockDaemon {
     // not running" if either fails — so a mock that answered only `GetStatus` drew no cards
     // at all. The entries are the accounts served below, with the least metadata the
     // settings panes will accept; this mock exists to be looked at, not to be configured.
+    //
+    // The exception is the credential choice. Three of the invented accounts have two
+    // credentials, the pane that picks between them is two screens rather than one control,
+    // and there is no way to look at the second screen on a machine whose real daemon
+    // reports the same answer every time. So the external logins are described here in the
+    // shape the real catalog publishes them in.
     async fn list_providers(&self) -> Vec<ProviderDefinition> {
         self.statuses
             .iter()
-            .map(|status| ProviderDefinition {
-                provider: status.provider.clone(),
-                title: provider_label(&status.provider).to_owned(),
-                // The invented accounts include the three OAuth providers; a key field
-                // offered for those would mislead whoever is looking at the panes.
-                credential: match status.provider.as_str() {
-                    "antigravity" | "claude" | "codex" => CredentialKind::OAuth,
-                    _ => CredentialKind::Key,
+            .map(|status| {
+                let external = external_login(&status.provider);
+                ProviderDefinition {
+                    provider: status.provider.clone(),
+                    title: provider_label(&status.provider).to_owned(),
+                    // The invented accounts include the three OAuth providers; a key field
+                    // offered for those would mislead whoever is looking at the panes.
+                    credential: if external.is_some() {
+                        CredentialKind::OAuth
+                    } else {
+                        CredentialKind::Key
+                    }
+                    .as_wire()
+                    .to_owned(),
+                    credential_hint: "Paste a key.".to_owned(),
+                    options: external.iter().map(source_option).collect(),
+                    external,
                 }
-                .as_wire()
-                .to_owned(),
-                credential_hint: "Paste a key.".to_owned(),
-                external_fallback: None,
-                options: Vec::new(),
             })
             .collect()
     }
@@ -71,6 +81,33 @@ impl MockDaemon {
         Ok(())
     }
 
+    /// The credential choice, answered the way the daemon answers it: the setting is
+    /// written, and the account is republished on the half it now sits on.
+    async fn set_option(
+        &mut self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        provider: &str,
+        account: &str,
+        name: &str,
+        value: &str,
+    ) -> fdo::Result<()> {
+        println!("set_option({provider:?}, {account:?}, {name:?}, {value:?})");
+        let Some(status) = self
+            .statuses
+            .iter_mut()
+            .find(|status| status.provider == provider && status.account == account)
+        else {
+            return Err(fdo::Error::InvalidArgs(format!("no {provider}/{account}")));
+        };
+        if name != AUTH_SOURCE {
+            return Err(fdo::Error::InvalidArgs(format!("no setting {name}")));
+        }
+        status.auth_source = Some(value.to_owned());
+        let published = status.clone();
+        Self::provider_changed(&emitter, published).await?;
+        Ok(())
+    }
+
     #[zbus(property(emits_changed_signal = "false"))]
     async fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_owned()
@@ -84,6 +121,57 @@ impl MockDaemon {
 
     #[zbus(signal)]
     pub async fn update_changed(emitter: &SignalEmitter<'_>, version: &str) -> zbus::Result<()>;
+}
+
+/// The setting the credential pill writes, spelled as the real catalog spells it.
+const AUTH_SOURCE: &str = "source";
+
+/// The three accounts that have a second credential, described as the daemon describes
+/// them: one that Tidemark refreshes in place, and one it only reads.
+fn external_login(provider: &str) -> Option<ExternalLogin> {
+    let (label, location, command, writes_back) = match provider {
+        "antigravity" => (
+            "agy session",
+            "a signed-in agy server on this machine",
+            "agy",
+            false,
+        ),
+        "claude" => (
+            "Claude Code login",
+            "~/.claude/.credentials.json",
+            "claude",
+            true,
+        ),
+        "codex" => ("Codex CLI login", "~/.codex/auth.json", "codex login", true),
+        _ => return None,
+    };
+    Some(ExternalLogin {
+        option: AUTH_SOURCE.to_owned(),
+        label: label.to_owned(),
+        location: location.to_owned(),
+        command: command.to_owned(),
+        writes_back,
+    })
+}
+
+/// The choice itself: two values, named after the two credentials.
+fn source_option(external: &ExternalLogin) -> ProviderOption {
+    ProviderOption {
+        name: external.option.clone(),
+        title: "Credential".to_owned(),
+        description: None,
+        value: "auto".to_owned(),
+        choices: vec![
+            OptionChoice {
+                value: "oauth".to_owned(),
+                title: "Tidemark login".to_owned(),
+            },
+            OptionChoice {
+                value: "cli".to_owned(),
+                title: external.label.clone(),
+            },
+        ],
+    }
 }
 
 fn window(title: &str, length: u64, used: f64, resets_in: Option<i64>) -> Window {
@@ -132,13 +220,22 @@ fn statuses() -> Vec<ProviderStatus> {
         ],
     );
     claude.next_poll_at = Some(Timestamp::now().as_unix() + 40);
+    // Reading Claude Code's own file, which is there and which Tidemark refreshes in
+    // place: the case the write-back sentence exists for.
+    claude.auth_source = Some("cli".to_owned());
+    claude.external_present = Some(true);
+    claude.has_credential = Some(false);
 
-    let codex = account(
+    let mut codex = account(
         "codex",
         "plus",
         // One window and nothing else, which is the live shape of this account.
         vec![window("1 week", 604_800, 97.5, Some(29 * 3600))],
     );
+    // Signed in here, with a CLI login on the machine that is deliberately not being used.
+    codex.auth_source = Some("oauth".to_owned());
+    codex.external_present = Some(true);
+    codex.has_credential = Some(true);
 
     let mut kimi = account(
         "kimi",
@@ -160,6 +257,11 @@ fn statuses() -> Vec<ProviderStatus> {
         ProviderState::NoCredential,
         Some("Sign in to Antigravity to see its quota.".into()),
     );
+    // The empty half of the CLI screen: nothing signed in either way, so the pane has a
+    // command to run and nothing found.
+    antigravity.auth_source = Some("cli".to_owned());
+    antigravity.external_present = Some(false);
+    antigravity.has_credential = Some(false);
 
     // The account that reports a fixed balance rather than only a percentage: the absolutes
     // behind the 41% are drawn under the bar, in the provider's own words. No live provider

--- a/crates/tidemark/src/model.rs
+++ b/crates/tidemark/src/model.rs
@@ -118,7 +118,7 @@ mod tests {
             title: "ClinePass".to_owned(),
             credential: "key".to_owned(),
             credential_hint: "ClinePass console.".to_owned(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         }];
         let titles = titles(&definitions);

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -4,8 +4,11 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 use gtk::glib;
-use tidemark_types::{CredentialKind, ProviderDefinition, ProviderOption, ProviderStatus, Remedy};
+use tidemark_types::{
+    CredentialKind, ExternalLogin, ProviderDefinition, ProviderOption, ProviderStatus, Remedy,
+};
 
+use super::model::AuthSource;
 use super::{model, reason};
 use crate::bus::DaemonProxy;
 use crate::{format, mark};
@@ -40,6 +43,10 @@ pub(super) struct ProviderDetail {
     authentication: adw::PreferencesGroup,
     key: RefCell<Option<KeyRows>>,
     sign_in: RefCell<Option<SignInRow>>,
+    /// The CLI half, for a provider whose credential can come from another program here.
+    local: RefCell<Option<LocalRows>>,
+    /// The pill that picks between the two halves. Absent for a provider with one.
+    choice: RefCell<Option<SourceChoice>>,
     external: RefCell<Option<adw::ActionRow>>,
     options: RefCell<BTreeMap<String, Rc<OptionRow>>>,
     notifications: adw::PreferencesGroup,
@@ -61,6 +68,75 @@ struct SignInRow {
     button: gtk::Button,
     stack: gtk::Stack,
     url: Rc<RefCell<String>>,
+}
+
+/// The rows of the half that reads a login another program on this machine holds.
+///
+/// Built once and hidden, like the sign-in row beside it: the two halves are one group,
+/// and rebuilding a group under a pointer that is on it loses the click.
+#[derive(Debug)]
+struct LocalRows {
+    /// Where the login is, and whether it is there.
+    found: adw::ActionRow,
+    /// `Found` or `Not found`, blank while the daemon has not said.
+    presence: gtk::Label,
+    /// What to run to create one. Absent when there is no single command to name.
+    command: Option<adw::ActionRow>,
+    /// That Tidemark writes to a file it does not own. Absent when it only reads.
+    note: Option<gtk::Label>,
+}
+
+impl LocalRows {
+    fn set_visible(&self, visible: bool) {
+        self.found.set_visible(visible);
+        if let Some(command) = &self.command {
+            command.set_visible(visible);
+        }
+        if let Some(note) = &self.note {
+            note.set_visible(visible);
+        }
+    }
+}
+
+/// The credential pill, told apart from the daemon's answer about which half is in force.
+///
+/// The same discipline as [`OptionSelection`], for the same reason: the pill moves the
+/// moment it is clicked, the write happens afterwards, and a refused write must put it
+/// back without that looking like a second click. What is different here is that the two
+/// halves are two screens, so a rollback moves the rows as well as the pill.
+#[derive(Debug)]
+struct SourceChoice {
+    /// The setting a click writes, as the daemon named it.
+    option: String,
+    group: adw::ToggleGroup,
+    authoritative: Cell<AuthSource>,
+    suppress: Cell<bool>,
+}
+
+impl SourceChoice {
+    /// The write this click asks for, or `None` when the pill was moved by us — or moved
+    /// to something this build has no screen for, which a daemon newer than it could do.
+    fn clicked(&self) -> Option<AuthSource> {
+        let chosen = AuthSource::from_value(&self.group.active_name()?)?;
+        (!self.suppress.get()).then_some(chosen)
+    }
+
+    fn apply_authoritative(&self, source: AuthSource) {
+        self.authoritative.set(source);
+        self.set_without_signal(source);
+    }
+
+    fn rollback(&self) -> AuthSource {
+        let authoritative = self.authoritative.get();
+        self.set_without_signal(authoritative);
+        authoritative
+    }
+
+    fn set_without_signal(&self, source: AuthSource) {
+        self.suppress.set(true);
+        self.group.set_active_name(Some(source.as_value()));
+        self.suppress.set(false);
+    }
 }
 
 #[derive(Debug)]
@@ -268,6 +344,8 @@ impl ProviderDetail {
             authentication,
             key: RefCell::new(None),
             sign_in: RefCell::new(None),
+            local: RefCell::new(None),
+            choice: RefCell::new(None),
             external: RefCell::new(None),
             options: RefCell::new(BTreeMap::new()),
             notifications,
@@ -334,7 +412,53 @@ impl ProviderDetail {
             }
         }
         drop(rows);
+        self.apply_local(status);
         self.apply_notifications(status);
+    }
+
+    /// Puts the pill and the two halves where the daemon says the account is.
+    ///
+    /// The half in force is the daemon's answer rather than the one last looked at: an
+    /// account whose local login has just appeared, or whose Tidemark login has just been
+    /// signed out of, has moved, and a dialog still showing the other half would be
+    /// describing a credential nothing is using.
+    fn apply_local(self: &Rc<Self>, status: &ProviderStatus) {
+        let Some(source) = model::auth_source(&self.definition, status) else {
+            return;
+        };
+        if let Some(choice) = self.choice.borrow().as_ref() {
+            choice.apply_authoritative(source);
+        }
+        if let Some(local) = self.local.borrow().as_ref() {
+            match model::external_presence_text(status) {
+                Some(text) => {
+                    // Coloured rather than only worded: this is the one line that says
+                    // whether the half being looked at can work at all, and it sits at the
+                    // end of a row whose title and subtitle are both black.
+                    let colour = if status.external_present == Some(true) {
+                        "success"
+                    } else {
+                        "warning"
+                    };
+                    local.presence.set_label(text);
+                    local.presence.set_css_classes(&[colour]);
+                    local.presence.set_visible(true);
+                }
+                None => local.presence.set_visible(false),
+            }
+        }
+        self.show_source(source);
+    }
+
+    /// Shows one half and hides the other. A login in progress belongs to the Tidemark
+    /// half, so the pill is held still until it finishes; see [`ProviderDetail::set_waiting`].
+    fn show_source(&self, source: AuthSource) {
+        if let Some(sign_in) = self.sign_in.borrow().as_ref() {
+            sign_in.row.set_visible(source == AuthSource::Tidemark);
+        }
+        if let Some(local) = self.local.borrow().as_ref() {
+            local.set_visible(source == AuthSource::Cli);
+        }
     }
 
     /// Redraws the notification switches for the windows the account currently reports.
@@ -425,7 +549,22 @@ impl ProviderDetail {
     fn build_authentication(self: &Rc<Self>) {
         match self.definition.credential_kind() {
             Some(CredentialKind::Key) => self.build_key_rows(),
-            Some(CredentialKind::OAuth) => self.build_sign_in_row(),
+            // A provider whose credential can also come from a CLI on this machine gets
+            // both halves and a pill to pick one. It is the same group either way: the two
+            // are alternatives, not a control and its fallback, and drawing them as two
+            // groups would suggest a login could be on both at once. The pill is added
+            // first because the group stacks its rows in the order they arrive, and the
+            // control that decides which rows below it mean anything belongs above them.
+            Some(CredentialKind::OAuth) => {
+                let external = self.definition.external.clone();
+                if let Some(external) = &external {
+                    self.build_source_choice(external);
+                }
+                self.build_sign_in_row();
+                if let Some(external) = &external {
+                    self.build_local_rows(external);
+                }
+            }
             // Nothing to paste and nobody to sign in to: the whole group would be an empty
             // box under a heading that promised a control. Configuring the account is its
             // settings alone, which are a group of their own.
@@ -627,13 +766,208 @@ impl ProviderDetail {
         });
     }
 
+    /// The pill in the group's header that picks between the two credentials.
+    ///
+    /// Built from the setting the daemon named rather than from anything known here, so
+    /// the halves are labelled in the provider's own words — `Claude Code login`, not a
+    /// slug this crate would have to be taught. A choice this build has no screen for is
+    /// refused outright: half a pill is worse than none, because the half that is drawn
+    /// looks like the whole choice.
+    fn build_source_choice(self: &Rc<Self>, external: &ExternalLogin) {
+        let Some(option) = self
+            .definition
+            .options
+            .iter()
+            .find(|option| option.name == external.option)
+        else {
+            return;
+        };
+        let toggles: Vec<(AuthSource, &str)> = option
+            .choices
+            .iter()
+            .filter_map(|choice| {
+                Some((
+                    AuthSource::from_value(&choice.value)?,
+                    choice.title.as_str(),
+                ))
+            })
+            .collect();
+        if toggles.len() != option.choices.len() || toggles.len() < 2 {
+            return;
+        }
+
+        // Full width, in a row of its own at the top of the group, rather than tucked into
+        // the group's header. The two labels are the providers' own names for the two
+        // credentials — `Claude Code login` is not shortenable without becoming a guess —
+        // and in a header suffix they share what the heading and its description leave
+        // over, which was enough to ellipsize both of them.
+        let group = adw::ToggleGroup::builder()
+            .hexpand(true)
+            .homogeneous(true)
+            .build();
+        for (source, title) in &toggles {
+            group.add(
+                adw::Toggle::builder()
+                    .name(source.as_value())
+                    .label(*title)
+                    .build(),
+            );
+        }
+        let row = adw::PreferencesRow::builder()
+            .activatable(false)
+            .child(&group)
+            .build();
+        row.add_css_class("credential-choice");
+        self.authentication.add(&row);
+
+        group.connect_active_name_notify({
+            let weak = Rc::downgrade(self);
+            move |_| {
+                let Some(detail) = weak.upgrade() else {
+                    return;
+                };
+                let asked = detail.choice.borrow().as_ref().and_then(|choice| {
+                    choice
+                        .clicked()
+                        .map(|source| (source, choice.option.clone()))
+                });
+                let Some((chosen, name)) = asked else {
+                    return;
+                };
+                // Moved before the write lands: the pill is the one control here whose
+                // two positions are two screens, and leaving the old screen under a
+                // pill that has already moved reads as the click having missed.
+                detail.show_source(chosen);
+                let status = detail.status.borrow();
+                let provider = status.provider.clone();
+                let account = status.account.clone();
+                drop(status);
+                let value = chosen.as_value().to_owned();
+                glib::spawn_future_local(async move {
+                    if let Err(error) = detail
+                        .proxy
+                        .set_option(&provider, &account, &name, &value)
+                        .await
+                    {
+                        let restored = detail.choice.borrow().as_ref().map(SourceChoice::rollback);
+                        if let Some(restored) = restored {
+                            detail.show_source(restored);
+                        }
+                        detail.toast(&reason(&error));
+                    }
+                });
+            }
+        });
+
+        *self.choice.borrow_mut() = Some(SourceChoice {
+            option: external.option.clone(),
+            group,
+            authoritative: Cell::new(AuthSource::Tidemark),
+            suppress: Cell::new(false),
+        });
+    }
+
+    /// The half that reads a login another program on this machine holds.
+    ///
+    /// Three things, in the order somebody with a problem needs them: whether the login is
+    /// there and where Tidemark looked, what to run if it is not, and — for the two
+    /// providers this is true of — that Tidemark refreshes the credential in place and
+    /// writes the new token back into a file it does not own. The last of those is ADR
+    /// 0001, and it is stated in the open rather than behind a disclosure: a program that
+    /// edits another program's credentials has to say so where the choice is made.
+    fn build_local_rows(self: &Rc<Self>, external: &ExternalLogin) {
+        // Markup off throughout: every string here is the daemon's, and a path is data.
+        let found = adw::ActionRow::builder()
+            .title(&external.label)
+            .subtitle(&external.location)
+            .use_markup(false)
+            .visible(false)
+            .build();
+        let presence = gtk::Label::builder()
+            .valign(gtk::Align::Center)
+            .visible(false)
+            .build();
+        let recheck = gtk::Button::builder()
+            .label("Check again")
+            .valign(gtk::Align::Center)
+            .build();
+        recheck.connect_clicked({
+            let weak = Rc::downgrade(self);
+            move |_| {
+                let Some(detail) = weak.upgrade() else {
+                    return;
+                };
+                let provider = detail.status.borrow().provider.clone();
+                glib::spawn_future_local(async move {
+                    if let Err(error) = detail.proxy.refresh(&provider).await {
+                        detail.toast(&reason(&error));
+                    }
+                });
+            }
+        });
+        let suffix = gtk::Box::builder().spacing(8).build();
+        suffix.append(&presence);
+        suffix.append(&recheck);
+        found.add_suffix(&suffix);
+        self.authentication.add(&found);
+
+        let command = (!external.command.is_empty()).then(|| {
+            let row = adw::ActionRow::builder()
+                .title("Sign in with the CLI")
+                .subtitle(&external.command)
+                .use_markup(false)
+                .visible(false)
+                .build();
+            let copy = gtk::Button::builder()
+                .label("Copy")
+                .valign(gtk::Align::Center)
+                .build();
+            copy.connect_clicked({
+                let weak = Rc::downgrade(self);
+                let command = external.command.clone();
+                move |button| {
+                    button.clipboard().set_text(&command);
+                    if let Some(detail) = weak.upgrade() {
+                        detail.toast("Command copied. Run it in a terminal.");
+                    }
+                }
+            });
+            row.add_suffix(&copy);
+            self.authentication.add(&row);
+            row
+        });
+
+        let note = model::write_back_text(external).map(|text| {
+            let label = caption(&text);
+            label.set_visible(false);
+            self.authentication.add(&label);
+            label
+        });
+
+        *self.local.borrow_mut() = Some(LocalRows {
+            found,
+            presence,
+            command,
+            note,
+        });
+    }
+
+    /// The provider's own settings — every one except the credential choice, which the
+    /// authentication group above draws as a pill. Left in the list it would appear twice,
+    /// and the second one would be a menu offering the same two values under a heading
+    /// that says nothing about which credential is in use.
     fn build_options(self: &Rc<Self>, group: &adw::PreferencesGroup) {
         let status = self.status.borrow();
-        let options = if status.options.is_empty() {
+        let declared = if status.options.is_empty() {
             &self.definition.options
         } else {
             &status.options
         };
+        let auth_option = self.definition.auth_option();
+        let options: Vec<&ProviderOption> = declared
+            .iter()
+            .filter(|option| Some(option.name.as_str()) != auth_option)
+            .collect();
         group.set_visible(!options.is_empty());
         for option in options {
             let row = self.build_option_row(option);
@@ -749,6 +1083,12 @@ impl ProviderDetail {
             return false;
         }
         self.waiting.set(url.is_some());
+        // A login in progress belongs to the Tidemark half and holds a fixed loopback
+        // port. Letting the pill move under it would hide the Cancel button while the
+        // listener is still bound, which is the one way to leave that port held.
+        if let Some(choice) = self.choice.borrow().as_ref() {
+            choice.group.set_sensitive(url.is_none());
+        }
         let sign_in_rows = self.sign_in.borrow();
         let Some(sign_in) = sign_in_rows.as_ref() else {
             return true;
@@ -788,8 +1128,19 @@ fn caption(text: &str) -> gtk::Label {
         .build()
 }
 
+/// The sentence under the group's heading: what is wrong, and where the credential comes
+/// from.
+///
+/// The second half is dropped for a provider whose two credentials are drawn as a pill.
+/// The hint for those reads "sign in through Tidemark, or read Claude Code's own login",
+/// which is the pill spelled out in prose directly above the pill — and the width it took
+/// was width the two labels needed.
 fn describe(definition: &ProviderDefinition, status: &ProviderStatus) -> String {
-    let hint = &definition.credential_hint;
+    let hint = if definition.external.is_some() {
+        ""
+    } else {
+        definition.credential_hint.as_str()
+    };
     match format::chip(status) {
         Some(chip)
             if status
@@ -803,7 +1154,7 @@ fn describe(definition: &ProviderDefinition, status: &ProviderStatus) -> String 
                 format!("{detail} — {hint}")
             }
         }
-        _ => hint.clone(),
+        _ => hint.to_owned(),
     }
 }
 
@@ -819,7 +1170,7 @@ mod tests {
             title: "Z.ai".into(),
             credential: kind.as_wire().into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         }
     }

--- a/crates/tidemark/src/provider_settings/model.rs
+++ b/crates/tidemark/src/provider_settings/model.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use tidemark_types::{ProviderDefinition, ProviderState, ProviderStatus};
+use tidemark_types::{ExternalLogin, ProviderDefinition, ProviderState, ProviderStatus};
 
 /// Catalog entries which have not already been configured and match the query.
 pub fn addable<'a>(
@@ -23,19 +23,108 @@ pub fn addable<'a>(
         .collect()
 }
 
-/// Concise copy for the configured-provider list.
-pub fn connection_text(definition: &ProviderDefinition, status: &ProviderStatus) -> String {
-    if status.has_credential == Some(true) {
-        return "Signed in through Tidemark".into();
+/// Which of an account's two credentials is in force.
+///
+/// Only ever asked of a provider that has two — see [`ProviderDefinition::external`]. The
+/// dialog needs it for one reason: the two halves of the choice are two different screens,
+/// and it must draw the one the account is actually on rather than the one the user last
+/// looked at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthSource {
+    /// The login Tidemark performed and holds itself.
+    Tidemark,
+    /// The login another program on this machine holds.
+    Cli,
+}
+
+impl AuthSource {
+    /// The choice value this travels as, which is also what the setting is written with.
+    pub const fn as_value(self) -> &'static str {
+        match self {
+            Self::Tidemark => "oauth",
+            Self::Cli => "cli",
+        }
     }
 
-    match (status.state(), definition.external_fallback.as_deref()) {
-        (Some(ProviderState::Pending), Some(fallback)) => {
-            format!("Checking for {fallback}…")
-        }
-        (Some(ProviderState::Ok), Some(fallback)) => format!("Using {fallback}"),
-        _ => "Not signed in".into(),
+    /// `None` for anything else, including the `auto` a setting nobody has touched holds:
+    /// what an untouched setting resolves to is the daemon's answer, published separately.
+    pub fn from_value(value: &str) -> Option<Self> {
+        [Self::Tidemark, Self::Cli]
+            .into_iter()
+            .find(|candidate| candidate.as_value() == value)
     }
+}
+
+/// The credential this account is on, for a provider that has two.
+///
+/// Taken from the daemon's own answer rather than worked out here. The setting behind the
+/// choice may be unset, and which credential an unset setting means differs per provider —
+/// Antigravity's local session wins by default, Claude's and Codex's own login does. Those
+/// rules live where the providers do. Falls back to the Tidemark half only when a daemon
+/// too old to answer is on the other end, which is the half that has a button to press.
+pub fn auth_source(definition: &ProviderDefinition, status: &ProviderStatus) -> Option<AuthSource> {
+    definition.external.as_ref()?;
+    Some(
+        status
+            .auth_source
+            .as_deref()
+            .and_then(AuthSource::from_value)
+            .unwrap_or(AuthSource::Tidemark),
+    )
+}
+
+/// Concise copy for the configured-provider list, and for the heading of the half in force.
+pub fn connection_text(definition: &ProviderDefinition, status: &ProviderStatus) -> String {
+    let Some(external) = definition.external.as_ref() else {
+        return own_login_text(status).into();
+    };
+    match auth_source(definition, status) {
+        Some(AuthSource::Cli) => match (status.state(), status.external_present) {
+            (_, Some(false)) => format!("No {} found", external.label),
+            (Some(ProviderState::Pending), _) => format!("Checking for {}…", external.label),
+            _ => format!("Using {}", external.label),
+        },
+        _ => own_login_text(status).into(),
+    }
+}
+
+/// What is true of the login Tidemark holds itself.
+///
+/// The unknown case is not folded into "not signed in": a keyring the daemon cannot see
+/// into may well hold a login, and offering to make a second one is how an account ends up
+/// with two.
+fn own_login_text(status: &ProviderStatus) -> &'static str {
+    match status.has_credential {
+        Some(true) => "Signed in through Tidemark",
+        Some(false) => "Not signed in",
+        None => "Cannot see the stored login",
+    }
+}
+
+/// Whether the local login exists, in the two words the CLI half puts beside its name.
+///
+/// `None` when the daemon did not say. Absence of an answer is drawn as no answer rather
+/// than as "not found": the difference is a user being told to run a login they already
+/// have.
+pub fn external_presence_text(status: &ProviderStatus) -> Option<&'static str> {
+    match status.external_present {
+        Some(true) => Some("Found"),
+        Some(false) => Some("Not found"),
+        None => None,
+    }
+}
+
+/// The sentence that says Tidemark writes to a file it does not own, or nothing when it
+/// only reads. Never hidden behind a disclosure: ADR 0001 is the most surprising thing
+/// this program does, and the CLI half is where it becomes true.
+pub fn write_back_text(external: &ExternalLogin) -> Option<String> {
+    external.writes_back.then(|| {
+        format!(
+            "When this token expires, Tidemark refreshes it and writes the new one back to \
+             {}, the way the CLI itself would. Nothing else in that file is touched.",
+            external.location
+        )
+    })
 }
 
 /// One line of the notifications group: a window the account reports, and whether the user
@@ -94,11 +183,13 @@ mod tests {
     use std::collections::HashSet;
 
     use tidemark_types::{
-        AccountId, CredentialKind, ProviderDefinition, ProviderId, ProviderState, ProviderStatus,
+        AccountId, CredentialKind, ExternalLogin, OptionChoice, ProviderDefinition, ProviderId,
+        ProviderOption, ProviderState, ProviderStatus,
     };
 
     use super::{
-        NotificationRow, addable, connection_text, merge_local_additions, notification_rows,
+        AuthSource, NotificationRow, addable, auth_source, connection_text, external_presence_text,
+        merge_local_additions, notification_rows, write_back_text,
     };
 
     fn definition(provider: &str, title: &str) -> ProviderDefinition {
@@ -107,19 +198,45 @@ mod tests {
             title: title.into(),
             credential: CredentialKind::Key.as_wire().into(),
             credential_hint: "Create a key in the provider dashboard.".into(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         }
     }
 
-    fn oauth_definition(provider: &str, fallback: Option<&str>) -> ProviderDefinition {
+    fn oauth_definition(provider: &str, label: Option<&str>) -> ProviderDefinition {
+        let external = label.map(|label| ExternalLogin {
+            option: "source".into(),
+            label: label.into(),
+            location: "~/.somewhere/creds.json".into(),
+            command: "somecli login".into(),
+            writes_back: true,
+        });
+        let options = external
+            .iter()
+            .map(|external| ProviderOption {
+                name: external.option.clone(),
+                title: "Credential".into(),
+                description: None,
+                value: "auto".into(),
+                choices: vec![
+                    OptionChoice {
+                        value: "oauth".into(),
+                        title: "Tidemark login".into(),
+                    },
+                    OptionChoice {
+                        value: "cli".into(),
+                        title: external.label.clone(),
+                    },
+                ],
+            })
+            .collect();
         ProviderDefinition {
             provider: provider.into(),
             title: provider.into(),
             credential: CredentialKind::OAuth.as_wire().into(),
             credential_hint: "Sign in through a browser.".into(),
-            external_fallback: fallback.map(str::to_owned),
-            options: Vec::new(),
+            external,
+            options,
         }
     }
 
@@ -132,6 +249,14 @@ mod tests {
             ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new("default"));
         status.set_state(state, None);
         status.has_credential = has_credential;
+        status
+    }
+
+    /// The daemon's answer, as it arrives: which half is in force, and whether the local
+    /// login is there.
+    fn on(mut status: ProviderStatus, source: AuthSource, present: Option<bool>) -> ProviderStatus {
+        status.auth_source = Some(source.as_value().to_owned());
+        status.external_present = present;
         status
     }
 
@@ -151,36 +276,99 @@ mod tests {
     }
 
     #[test]
-    fn oauth_fallback_copy_never_claims_an_unverified_session() {
+    fn the_cli_half_says_which_local_login_is_being_read() {
         let definition = oauth_definition("antigravity", Some("agy session"));
-        assert_eq!(
+        let cli = |state, present| {
             connection_text(
                 &definition,
-                &status("antigravity", ProviderState::Pending, Some(false))
-            ),
+                &on(
+                    status("antigravity", state, Some(false)),
+                    AuthSource::Cli,
+                    present,
+                ),
+            )
+        };
+        assert_eq!(
+            cli(ProviderState::Pending, Some(true)),
             "Checking for agy session…"
         );
+        assert_eq!(cli(ProviderState::Ok, Some(true)), "Using agy session");
+        // Not "Not signed in": the account is on the local half and there is nothing on it.
+        // The remedy is a command to run, not a button to press, and the copy must not
+        // point at the wrong one.
         assert_eq!(
-            connection_text(
-                &definition,
-                &status("antigravity", ProviderState::Ok, Some(false))
-            ),
-            "Using agy session"
+            cli(ProviderState::NoCredential, Some(false)),
+            "No agy session found"
         );
-        assert_eq!(
+    }
+
+    #[test]
+    fn the_tidemark_half_describes_only_the_login_tidemark_holds() {
+        let definition = oauth_definition("antigravity", Some("agy session"));
+        let own = |has_credential| {
             connection_text(
                 &definition,
-                &status("antigravity", ProviderState::NoCredential, Some(false))
-            ),
-            "Not signed in"
-        );
+                &on(
+                    status("antigravity", ProviderState::Ok, has_credential),
+                    AuthSource::Tidemark,
+                    Some(true),
+                ),
+            )
+        };
+        // A healthy local session is running in every one of these, and says nothing about
+        // the half being drawn.
+        assert_eq!(own(Some(true)), "Signed in through Tidemark");
+        assert_eq!(own(Some(false)), "Not signed in");
+        assert_eq!(own(None), "Cannot see the stored login");
+    }
+
+    #[test]
+    fn a_provider_with_one_credential_is_never_put_on_a_half() {
+        let definition = definition("zai", "Z.ai");
+        let mut status = status("zai", ProviderState::Ok, Some(true));
+        // Even if a daemon sent one, there is no second credential to switch to.
+        status.auth_source = Some("cli".into());
+        assert_eq!(auth_source(&definition, &status), None);
         assert_eq!(
-            connection_text(
-                &definition,
-                &status("antigravity", ProviderState::Ok, Some(true))
-            ),
+            connection_text(&definition, &status),
             "Signed in through Tidemark"
         );
+    }
+
+    #[test]
+    fn a_daemon_that_does_not_say_which_half_leaves_the_actionable_one_showing() {
+        let definition = oauth_definition("claude", Some("Claude Code login"));
+        let status = status("claude", ProviderState::Pending, Some(false));
+        assert_eq!(status.auth_source, None);
+        assert_eq!(
+            auth_source(&definition, &status),
+            Some(AuthSource::Tidemark)
+        );
+    }
+
+    #[test]
+    fn an_unanswered_presence_is_drawn_as_no_answer() {
+        let mut status = status("claude", ProviderState::Pending, Some(false));
+        assert_eq!(external_presence_text(&status), None);
+        status.external_present = Some(true);
+        assert_eq!(external_presence_text(&status), Some("Found"));
+        status.external_present = Some(false);
+        assert_eq!(external_presence_text(&status), Some("Not found"));
+    }
+
+    #[test]
+    fn only_a_source_tidemark_writes_to_admits_to_being_written_to() {
+        let mut external = ExternalLogin {
+            option: "source".into(),
+            label: "Claude Code login".into(),
+            location: "~/.claude/.credentials.json".into(),
+            command: "claude".into(),
+            writes_back: true,
+        };
+        let written = write_back_text(&external).expect("a written source says so");
+        assert!(written.contains("~/.claude/.credentials.json"), "{written}");
+        external.writes_back = false;
+        assert_eq!(write_back_text(&external), None);
     }
 
     #[test]

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -2,10 +2,10 @@
 //!
 //! Everything that libadwaita already names is used by name — `card`, `title-1`, `heading`,
 //! `caption`, `dim-label`, `warning`, `error` — so the window follows the system's accent
-//! colour, dark mode and font scaling without being told to. What is left is the two
-//! things Adwaita has no class for: the pill around a state chip, and the padding inside a
+//! colour, dark mode and font scaling without being told to. What is left is the three
+//! things Adwaita has no class for: the pill around a state chip, the padding inside a
 //! card, which `.card` deliberately does not set because it does not know what is going in
-//! it.
+//! it, and the padding around the credential pill, for the same reason.
 //!
 //! # The hover
 //!
@@ -87,6 +87,15 @@ pub(crate) const STYLE: &str = "
 .quota-footer {
     font-size: 0.9em;
     opacity: 0.45;
+}
+
+/* The credential pill sits in a preferences row of its own so that it gets the full width
+   of the group — a header suffix ellipsized both of its labels, and neither `Tidemark
+   login` nor `Claude Code login` can be shortened without becoming a guess. A plain
+   AdwPreferencesRow has no padding of its own, so the pill would otherwise touch the four
+   edges of the card it sits in. */
+.credential-choice {
+    padding: 8px;
 }
 ";
 

--- a/crates/tidemark/src/tray.rs
+++ b/crates/tidemark/src/tray.rs
@@ -496,7 +496,7 @@ mod tests {
             title: "ClinePass".to_owned(),
             credential: "key".to_owned(),
             credential_hint: "ClinePass console.".to_owned(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         }]);
         assert_eq!(

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -254,7 +254,7 @@ impl Account {
     }
 
     /// Whether dropping this account's client is safe, because it can be built again.
-    fn rebuildable(&self) -> bool {
+    pub(crate) fn rebuildable(&self) -> bool {
         self.factory.is_some() || self.rebuild.is_some()
     }
 
@@ -882,15 +882,25 @@ impl Engine {
     /// The client is dropped as well, so the credential is read again. A manual refresh is
     /// what the user reaches for straight after saving a key, and it would be a poor
     /// interface that answered it with the old one.
+    ///
+    /// The other login is looked for again for the same reason, and it is the more urgent
+    /// half: a refresh is also what the user reaches for straight after running `claude`
+    /// in a terminal, and the settings pane that sent them there is showing "Not found"
+    /// until somebody looks again. The keyring is *not* re-read here — that answer only
+    /// moves when Tidemark itself moves it, and every such path already probes.
     fn mark_due(&mut self, target: Option<&str>) {
         let now = Instant::now();
         for account in &mut self.accounts {
-            if target.is_none_or(|slug| account.provider.as_str() == slug) {
-                account.due = now;
-                if account.factory.is_some() {
-                    account.client = None;
-                }
+            if !target.is_none_or(|slug| account.provider.as_str() == slug) {
+                continue;
             }
+            account.due = now;
+            if account.factory.is_some() {
+                account.client = None;
+            }
+            let provider = account.provider.as_str().to_owned();
+            account.status.external_present = crate::registry::external_present(&provider);
+            account.status.auth_source = crate::registry::auth_source(&provider, &account.status);
         }
     }
 
@@ -929,36 +939,48 @@ impl Engine {
         self.probe_credentials(target).await;
     }
 
-    /// Records, for each account, whether Tidemark itself holds a credential for it.
+    /// Records, for each account, the two things a credentials dialog asks before anything
+    /// has been polled: whether Tidemark itself holds a credential for the account, and
+    /// whether the provider's other login — the vendor CLI's file, an `agy` session —
+    /// exists on this machine at all. From the two it then settles which credential the
+    /// next poll will use.
     ///
     /// Asked rather than inferred, and asked rarely — at startup and whenever a credential
-    /// changes — because the answer only moves when the user moves it. A locked keyring
-    /// leaves the answer unknown rather than answering "no": the dialog would otherwise
-    /// offer to replace a key that is there and simply out of reach.
+    /// changes — because the answers only move when the user moves them. A locked keyring
+    /// leaves the first answer unknown rather than answering "no": the dialog would
+    /// otherwise offer to replace a key that is there and simply out of reach. The second
+    /// proves existence, not usability — a file that exists may hold an expired token —
+    /// and it is asked even of accounts Tidemark holds nothing for, because for them it
+    /// is the whole answer.
     pub async fn probe_credentials(&mut self, target: Option<&str>) {
         for index in 0..self.accounts.len() {
             let account = &self.accounts[index];
             if !target.is_none_or(|slug| account.provider.as_str() == slug) {
                 continue;
             }
-            let Some(kind) = account.status.credential_kind().and_then(stored_kind) else {
-                // Nothing of ours to look for: the credential belongs to something else on
-                // the machine.
-                self.accounts[index].status.has_credential = None;
-                continue;
-            };
             let provider = account.provider.clone();
-            let name = account.account.clone();
-            let found = self.secrets.get(kind, &provider, &name).await;
-            let held = match found {
-                Ok(found) => Some(found.is_some()),
-                Err(SecretError::Locked) => None,
-                Err(error) => {
-                    tracing::debug!(provider = %provider, %error, "cannot see stored credentials");
-                    None
+            let kind = account.status.credential_kind().and_then(stored_kind);
+            let held = match kind {
+                Some(kind) => {
+                    let name = account.account.clone();
+                    match self.secrets.get(kind, &provider, &name).await {
+                        Ok(found) => Some(found.is_some()),
+                        Err(SecretError::Locked) => None,
+                        Err(error) => {
+                            tracing::debug!(provider = %provider, %error, "cannot see stored credentials");
+                            None
+                        }
+                    }
                 }
+                // Nothing of ours to look for: the credential belongs to something else
+                // on the machine.
+                None => None,
             };
             self.accounts[index].status.has_credential = held;
+            self.accounts[index].status.external_present =
+                crate::registry::external_present(provider.as_str());
+            self.accounts[index].status.auth_source =
+                crate::registry::auth_source(provider.as_str(), &self.accounts[index].status);
         }
     }
 

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -28,40 +28,83 @@ use tidemark_core::providers::keyed::{
     self, aiand, codebuff, deepgram, deepinfra, factory, fireworks, groq, ibmbob, kilo, litellm,
     llmproxy, openai_api, openrouter, poe, sub2api, wayfinder, xai,
 };
-use tidemark_core::providers::{Credential, Provider, ProviderError, antigravity, claude, codex};
+use tidemark_core::providers::{
+    AUTO_SOURCE, CLI_SOURCE, Credential, OAUTH_SOURCE, Provider, ProviderError, Source,
+    antigravity, claude, codex,
+};
 use tidemark_core::secrets::Secrets;
 use tidemark_types::{
-    AccountId, CredentialKind, OptionChoice, ProviderDefinition, ProviderId, ProviderOption,
+    AccountId, CredentialKind, ExternalLogin, OptionChoice, ProviderDefinition, ProviderId,
+    ProviderOption, ProviderStatus,
 };
 
 use crate::engine::Account;
 
-/// Name of Antigravity's usage-source setting under `[provider.antigravity]`.
-pub const ANTIGRAVITY_SOURCE: &str = "source";
+/// Name of the setting, under `[provider.<slug>]`, that says which of an OAuth provider's
+/// two credentials this account reads. One key serves all three: it was Antigravity's
+/// alone when Antigravity was the only provider with two credentials, so a
+/// `[provider.antigravity] source = "…"` written then keeps working untouched.
+pub const AUTH_SOURCE: &str = "source";
 
-/// The three OAuth providers: slug, title, credential hint, external fallback. Written out
-/// because each acquires its credential its own way; everything that varies beyond these
-/// four strings is decided where they are used.
-static OAUTH: &[(&str, &str, &str, &str)] = &[
-    (
-        antigravity::PROVIDER_ID,
-        "Antigravity",
-        "Sign in with Google through Tidemark",
-        "agy session",
-    ),
-    (
-        "claude",
-        "Claude",
-        "Sign in through Tidemark",
-        "Claude Code login",
-    ),
-    (
-        codex::PROVIDER_ID,
-        "Codex",
-        "Sign in through Tidemark",
-        "Codex CLI login",
-    ),
+/// One of the three OAuth providers: everything about it that varies, named. The same
+/// entry feeds the catalog, the settings schema and the account builders, and bare
+/// strings in a row are one transposition away from telling the user Tidemark writes back
+/// to a file it only reads.
+struct OAuthEntry {
+    /// Provider slug.
+    slug: &'static str,
+    /// Display title.
+    title: &'static str,
+    /// One sentence on where the credential comes from.
+    credential_hint: &'static str,
+    /// What the local login is called, in the words its own program uses.
+    external_label: &'static str,
+    /// Where the local login lives, for a person: a path, or a sentence about a process.
+    external_location: &'static str,
+    /// What to run to create one.
+    external_command: &'static str,
+    /// Whether Tidemark refreshes this credential in place and writes the rotated token
+    /// back where it found it (ADR 0001), or only ever reads it.
+    writes_back: bool,
+}
+
+/// The three OAuth providers, written out because each acquires its credential its own
+/// way; everything that varies between them is in this table, and everything else is
+/// decided where the entries are used.
+static OAUTH: &[OAuthEntry] = &[
+    OAuthEntry {
+        slug: antigravity::PROVIDER_ID,
+        title: "Antigravity",
+        credential_hint: "Sign in with Google through Tidemark, or read a signed-in agy session.",
+        external_label: "agy session",
+        external_location: "a signed-in agy server on this machine",
+        external_command: "agy",
+        writes_back: false,
+    },
+    OAuthEntry {
+        slug: claude::PROVIDER_ID,
+        title: "Claude",
+        credential_hint: "Sign in through Tidemark, or read Claude Code's own login.",
+        external_label: "Claude Code login",
+        external_location: "~/.claude/.credentials.json",
+        external_command: "claude",
+        writes_back: true,
+    },
+    OAuthEntry {
+        slug: codex::PROVIDER_ID,
+        title: "Codex",
+        credential_hint: "Sign in through Tidemark, or read the Codex CLI's own login.",
+        external_label: "Codex CLI login",
+        external_location: "~/.codex/auth.json",
+        external_command: "codex login",
+        writes_back: true,
+    },
 ];
+
+/// The table entry for an OAuth provider, or `None` for a provider with one credential.
+fn oauth_entry(provider: &str) -> Option<&'static OAuthEntry> {
+    OAUTH.iter().find(|entry| entry.slug == provider)
+}
 
 /// The hand-written key-authenticated providers: those whose fetch is more than one
 /// request, so a `keyed::Spec` cannot describe them — ai& pages a request log,
@@ -115,10 +158,8 @@ static HAND_WRITTEN: &[&keyed::HandSpec] = &[
 /// `None` for a slug this build knows nothing about; the caller falls back to capitalising
 /// the slug, which is all an unknown slug can honestly be called.
 pub fn title(provider: &str) -> Option<&'static str> {
-    OAUTH
-        .iter()
-        .find(|(slug, ..)| *slug == provider)
-        .map(|(_, title, ..)| *title)
+    oauth_entry(provider)
+        .map(|entry| entry.title)
         .or_else(|| {
             keyed::CATALOG
                 .iter()
@@ -143,13 +184,19 @@ pub fn title(provider: &str) -> Option<&'static str> {
 pub fn catalog(config: &Config) -> Vec<ProviderDefinition> {
     let mut definitions: Vec<ProviderDefinition> = OAUTH
         .iter()
-        .map(|(provider, title, hint, fallback)| ProviderDefinition {
-            provider: (*provider).to_owned(),
-            title: (*title).to_owned(),
+        .map(|entry| ProviderDefinition {
+            provider: entry.slug.to_owned(),
+            title: entry.title.to_owned(),
             credential: CredentialKind::OAuth.as_wire().to_owned(),
-            credential_hint: (*hint).to_owned(),
-            external_fallback: Some((*fallback).to_owned()),
-            options: options(provider, config),
+            credential_hint: entry.credential_hint.to_owned(),
+            external: Some(ExternalLogin {
+                option: AUTH_SOURCE.to_owned(),
+                label: entry.external_label.to_owned(),
+                location: entry.external_location.to_owned(),
+                command: entry.external_command.to_owned(),
+                writes_back: entry.writes_back,
+            }),
+            options: options(entry.slug, config),
         })
         .collect();
     definitions.extend(keyed::CATALOG.iter().map(|spec| ProviderDefinition {
@@ -157,7 +204,7 @@ pub fn catalog(config: &Config) -> Vec<ProviderDefinition> {
         title: spec.title.to_owned(),
         credential: CredentialKind::Key.as_wire().to_owned(),
         credential_hint: spec.credential_hint.to_owned(),
-        external_fallback: None,
+        external: None,
         options: options(spec.id, config),
     }));
     definitions.extend(
@@ -179,7 +226,7 @@ fn hand_written_definition(spec: &keyed::HandSpec, config: &Config) -> ProviderD
         title: spec.title.to_owned(),
         credential: spec.credential.as_wire().to_owned(),
         credential_hint: spec.credential_hint.to_owned(),
-        external_fallback: None,
+        external: None,
         options: options(spec.id, config),
     }
 }
@@ -192,8 +239,8 @@ pub fn account(
 ) -> Result<Option<Account>, ProviderError> {
     let account = match provider {
         antigravity::PROVIDER_ID => Some(antigravity_account(secrets, config)?),
-        "claude" => Some(claude_account(secrets)?),
-        codex::PROVIDER_ID => Some(codex_account(secrets)?),
+        claude::PROVIDER_ID => Some(claude_account(secrets, config)?),
+        codex::PROVIDER_ID => Some(codex_account(secrets, config)?),
         other => keyed::CATALOG
             .iter()
             .find(|spec| spec.id == other)
@@ -253,8 +300,8 @@ pub fn notify(provider: &str, config: &Config) -> Vec<String> {
 /// from `keyed::CATALOG`, or from the hand-written table for the providers that are not a
 /// `Spec`; either way the row is the same shape.
 pub fn options(provider: &str, config: &Config) -> Vec<ProviderOption> {
-    if provider == antigravity::PROVIDER_ID {
-        return vec![antigravity_source_option(config)];
+    if let Some(entry) = oauth_entry(provider) {
+        return vec![auth_source_option(entry, config)];
     }
     keyed::CATALOG
         .iter()
@@ -300,53 +347,100 @@ fn published_option(
     }
 }
 
-/// Antigravity's two quota sources, and letting the user say which one this account reads.
+/// The choice between an OAuth provider's two credentials: the login Tidemark performed
+/// itself, and the one the vendor's own program already holds on this machine.
 ///
-/// Published as a choice rather than decided here because neither source is right
-/// everywhere: `agy` is the vendor's own live session but has to be installed and logged
-/// in, while the login works on a machine with no `agy` and only for an account Google
-/// entitles to the Cloud Code quota RPCs.
-fn antigravity_source_option(config: &Config) -> ProviderOption {
-    let choices = vec![
-        OptionChoice {
-            value: antigravity::AUTO_SOURCE.to_owned(),
-            title: "Automatic".to_owned(),
-        },
-        OptionChoice {
-            value: antigravity::OAUTH_SOURCE.to_owned(),
-            title: "Google sign-in".to_owned(),
-        },
-        OptionChoice {
-            value: antigravity::CLI_SOURCE.to_owned(),
-            title: "Local agy session".to_owned(),
-        },
-    ];
+/// Exactly two choices, in a fixed order. `auto` is deliberately not among them: it
+/// survives as what an untouched `config.toml` means — which is why the value below may
+/// legitimately be a string the choices do not contain — but the user can only ever write
+/// one of the two concrete values. A control that offered "automatic" would let them
+/// re-ask for the silent picking this row exists to replace.
+///
+/// No description: the dialog draws this row itself, in the authentication group, with
+/// its own explanation, and a sentence here would be shown twice.
+fn auth_source_option(entry: &OAuthEntry, config: &Config) -> ProviderOption {
     ProviderOption {
-        name: ANTIGRAVITY_SOURCE.to_owned(),
-        title: "Usage source".to_owned(),
-        description: Some(
-            "Automatic reads the local agy session and falls back to the Google sign-in."
-                .to_owned(),
-        ),
-        value: source_value(config).0.to_owned(),
-        choices,
+        name: AUTH_SOURCE.to_owned(),
+        title: "Credential".to_owned(),
+        description: None,
+        value: config
+            .option(entry.slug, AUTH_SOURCE)
+            .unwrap_or(AUTO_SOURCE)
+            .to_owned(),
+        choices: vec![
+            OptionChoice {
+                value: OAUTH_SOURCE.to_owned(),
+                title: "Tidemark login".to_owned(),
+            },
+            OptionChoice {
+                value: CLI_SOURCE.to_owned(),
+                title: entry.external_label.to_owned(),
+            },
+        ],
     }
 }
 
-/// The stored usage source, and the client's own enum for it.
-fn source_value(config: &Config) -> (&'static str, antigravity::Source) {
-    match config.option(antigravity::PROVIDER_ID, ANTIGRAVITY_SOURCE) {
-        Some(antigravity::OAUTH_SOURCE) => (antigravity::OAUTH_SOURCE, antigravity::Source::OAuth),
-        Some(antigravity::CLI_SOURCE) => (antigravity::CLI_SOURCE, antigravity::Source::Cli),
-        _ => (antigravity::AUTO_SOURCE, antigravity::Source::Auto),
+/// Which of a provider's two credentials its account reads, from the stored setting.
+/// Anything unrecognised — including the unset default — is [`Source::Auto`]: the Tidemark login when there
+/// is one, the vendor program's otherwise — the behaviour these accounts have always had.
+fn source_value(provider: &str, config: &Config) -> Source {
+    Source::from_value(config.option(provider, AUTH_SOURCE))
+}
+
+/// Whether the local login a provider can read instead of a Tidemark login exists on this
+/// machine — `None` for a provider that has no such login at all.
+///
+/// This proves existence, not usability: the file existing is not the same as it holding
+/// a usable credential, and an installed `agy` is not the same as a signed-in one. The
+/// poll state says the rest. The answer exists so the dialog can offer the choice before
+/// anything has been polled.
+pub fn external_present(provider: &str) -> Option<bool> {
+    match provider {
+        claude::PROVIDER_ID => {
+            Some(claude::cli_credentials_path().is_some_and(|path| path.exists()))
+        }
+        codex::PROVIDER_ID => Some(codex::cli_credentials_path().is_some_and(|path| path.exists())),
+        antigravity::PROVIDER_ID => Some(antigravity::agy::is_available()),
+        _ => None,
     }
+}
+
+/// Which credential the next poll will use, resolving an unset setting the way the
+/// provider itself resolves [`Source::Auto`]. `None` for a provider with one credential.
+///
+/// The stored value is read off the published options rather than the file: the engine
+/// has already refreshed them, and re-reading `config.toml` here could disagree with them
+/// for the length of a reload. The `Auto` branches mirror the clients' own control flow
+/// rather than approximating it: Claude and Codex reach the vendor file only when the
+/// Secret Service answered that nothing is stored — a held token wins, and a locked
+/// keyring errors out before the file is ever opened — while Antigravity tries the local
+/// server first whenever `agy` is installed.
+pub fn auth_source(provider: &str, status: &ProviderStatus) -> Option<String> {
+    oauth_entry(provider)?;
+    let stored = status
+        .options
+        .iter()
+        .find(|option| option.name == AUTH_SOURCE)
+        .map(|option| option.value.as_str());
+    let resolved = match Source::from_value(stored) {
+        Source::OAuth => OAUTH_SOURCE,
+        Source::Cli => CLI_SOURCE,
+        Source::Auto => match provider {
+            claude::PROVIDER_ID | codex::PROVIDER_ID if status.has_credential == Some(false) => {
+                CLI_SOURCE
+            }
+            antigravity::PROVIDER_ID if status.external_present == Some(true) => CLI_SOURCE,
+            _ => OAUTH_SOURCE,
+        },
+    };
+    Some(resolved.to_owned())
 }
 
 /// The OAuth client to run a login against, for a provider that has one.
 pub fn oauth_client(provider: &str) -> Option<oauth::Client> {
     match provider {
         antigravity::PROVIDER_ID => Some(antigravity::oauth::client()),
-        "claude" => Some(claude::oauth_client()),
+        claude::PROVIDER_ID => Some(claude::oauth_client()),
         codex::PROVIDER_ID => Some(codex::oauth_client()),
         _ => None,
     }
@@ -364,7 +458,7 @@ pub async fn login_document(
 ) -> Result<serde_json::Value, ProviderError> {
     match provider {
         antigravity::PROVIDER_ID => antigravity::oauth::complete_login(response, now_ms).await,
-        "claude" => claude::document_from_login(response, now_ms),
+        claude::PROVIDER_ID => claude::document_from_login(response, now_ms),
         codex::PROVIDER_ID => codex::document_from_login(response),
         _ => Err(ProviderError::Local(format!(
             "{provider} does not sign in through Tidemark"
@@ -378,14 +472,12 @@ fn antigravity_account(
 ) -> Result<Account, ProviderError> {
     Ok(Account::with_client(Arc::new(antigravity::Antigravity::new(
         Some(Arc::clone(secrets)),
-        source_value(config).1,
+        source_value(antigravity::PROVIDER_ID, config),
     )?))
     .with_rebuild({
         let secrets = Arc::clone(secrets);
         Box::new(move |options| {
-            let source = antigravity::Source::from_value(
-                options.get(ANTIGRAVITY_SOURCE).map(String::as_str),
-            );
+            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
             Ok(Arc::new(antigravity::Antigravity::new(
                 Some(Arc::clone(&secrets)),
                 source,
@@ -393,27 +485,45 @@ fn antigravity_account(
         })
     })
     .with_credential(CredentialKind::OAuth)
-    .with_hint("Sign in with Google through Tidemark"))
+    .with_hint("Sign in with Google through Tidemark, or read a signed-in agy session."))
 }
 
-fn claude_account(secrets: &Arc<dyn Secrets>) -> Result<Account, ProviderError> {
-    Ok(
-        Account::with_client(Arc::new(claude::Claude::new(Some(Arc::clone(secrets)))?))
-            .with_credential(CredentialKind::OAuth)
-            .with_hint(
-                "Uses Claude Code's own login when there is one. Sign in here to give Tidemark an account of its own.",
-            ),
-    )
+fn claude_account(secrets: &Arc<dyn Secrets>, config: &Config) -> Result<Account, ProviderError> {
+    Ok(Account::with_client(Arc::new(claude::Claude::new(
+        Some(Arc::clone(secrets)),
+        source_value(claude::PROVIDER_ID, config),
+    )?))
+    .with_rebuild({
+        let secrets = Arc::clone(secrets);
+        Box::new(move |options| {
+            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
+            Ok(
+                Arc::new(claude::Claude::new(Some(Arc::clone(&secrets)), source)?)
+                    as Arc<dyn Provider>,
+            )
+        })
+    })
+    .with_credential(CredentialKind::OAuth)
+    .with_hint("Sign in through Tidemark, or read Claude Code's own login."))
 }
 
-fn codex_account(secrets: &Arc<dyn Secrets>) -> Result<Account, ProviderError> {
-    Ok(
-        Account::with_client(Arc::new(codex::Codex::new(Some(Arc::clone(secrets)))?))
-            .with_credential(CredentialKind::OAuth)
-            .with_hint(
-                "Uses the Codex CLI's own login when there is one. Sign in here to give Tidemark an account of its own.",
-            ),
-    )
+fn codex_account(secrets: &Arc<dyn Secrets>, config: &Config) -> Result<Account, ProviderError> {
+    Ok(Account::with_client(Arc::new(codex::Codex::new(
+        Some(Arc::clone(secrets)),
+        source_value(codex::PROVIDER_ID, config),
+    )?))
+    .with_rebuild({
+        let secrets = Arc::clone(secrets);
+        Box::new(move |options| {
+            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
+            Ok(
+                Arc::new(codex::Codex::new(Some(Arc::clone(&secrets)), source)?)
+                    as Arc<dyn Provider>,
+            )
+        })
+    })
+    .with_credential(CredentialKind::OAuth)
+    .with_hint("Sign in through Tidemark, or read the Codex CLI's own login."))
 }
 
 /// Every key-authenticated account is built the same way: the engine hands over the stored
@@ -535,35 +645,210 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_publishes_its_three_usage_sources() {
-        let config = empty_config();
-        let published = options(antigravity::PROVIDER_ID, &config);
-        let source = published
-            .iter()
-            .find(|option| option.name == ANTIGRAVITY_SOURCE)
-            .expect("the usage source is published");
-        let values: Vec<&str> = source
-            .choices
-            .iter()
-            .map(|choice| choice.value.as_str())
-            .collect();
-        assert_eq!(values, ["auto", "oauth", "cli"]);
-        assert_eq!(source.value, "auto", "auto is what an unset file means");
+    fn every_oauth_provider_publishes_its_two_credentials_as_the_choice() {
+        let published = catalog(&empty_config());
+        for entry in OAUTH {
+            let definition = published
+                .iter()
+                .find(|definition| definition.provider == entry.slug)
+                .unwrap_or_else(|| panic!("{} is in the table but not published", entry.slug));
+            let external = definition
+                .external
+                .as_ref()
+                .expect("an OAuth provider has two credentials to name");
+            assert_eq!(external.option, AUTH_SOURCE);
+            assert_eq!(external.label, entry.external_label);
+            assert_eq!(external.location, entry.external_location);
+            assert_eq!(external.command, entry.external_command);
+            assert_eq!(external.writes_back, entry.writes_back);
+            let option = definition
+                .options
+                .iter()
+                .find(|option| option.name == AUTH_SOURCE)
+                .expect("the credential choice is published");
+            assert_eq!(option.title, "Credential");
+            assert_eq!(option.description, None);
+            let choices: Vec<(&str, &str)> = option
+                .choices
+                .iter()
+                .map(|choice| (choice.value.as_str(), choice.title.as_str()))
+                .collect();
+            assert_eq!(
+                choices,
+                [
+                    (OAUTH_SOURCE, "Tidemark login"),
+                    (CLI_SOURCE, entry.external_label)
+                ],
+                "auto is the unset default, never a choice, for {}",
+                entry.slug
+            );
+        }
     }
 
     #[test]
-    fn a_configured_usage_source_is_what_the_option_reports() {
-        let path = scratch_config(
-            "antigravity-source",
-            "providers = [\"antigravity\"]\n\n[provider.antigravity]\nsource = \"cli\"\n",
+    fn a_provider_with_one_credential_publishes_no_external_login() {
+        // The absent field is the whole signal a client dispatches on: no external login
+        // means no credential choice to draw.
+        for definition in catalog(&empty_config()) {
+            assert_eq!(
+                definition.external.is_some(),
+                oauth_entry(&definition.provider).is_some(),
+                "{} must publish an external login exactly when it has two credentials",
+                definition.provider
+            );
+        }
+    }
+
+    #[test]
+    fn the_credential_choice_reports_the_stored_value_verbatim() {
+        for slug in [
+            antigravity::PROVIDER_ID,
+            claude::PROVIDER_ID,
+            codex::PROVIDER_ID,
+        ] {
+            let published = options(slug, &empty_config());
+            let source = published
+                .iter()
+                .find(|option| option.name == AUTH_SOURCE)
+                .expect("the credential choice is published");
+            assert_eq!(
+                source.value, AUTO_SOURCE,
+                "auto is what an unset file means"
+            );
+
+            let path = scratch_config(
+                &format!("{slug}-source"),
+                &format!("providers = [\"{slug}\"]\n\n[provider.{slug}]\nsource = \"cli\"\n"),
+            );
+            let config = Config::at(path.clone()).expect("config reads");
+            let published = options(slug, &config);
+            let source = published
+                .iter()
+                .find(|option| option.name == AUTH_SOURCE)
+                .expect("the credential choice is published");
+            assert_eq!(source.value, CLI_SOURCE);
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn the_oauth_accounts_rebuild_their_client_when_the_choice_changes() {
+        // Without a Rebuild the engine cannot drop the client on `set_option`, and a
+        // change of credential would take effect only on the next daemon restart.
+        let config = empty_config();
+        for slug in [
+            antigravity::PROVIDER_ID,
+            claude::PROVIDER_ID,
+            codex::PROVIDER_ID,
+        ] {
+            let account = account(slug, &secrets(), &config)
+                .expect("no error")
+                .expect("an OAuth provider builds an account");
+            assert!(
+                account.rebuildable(),
+                "{slug} must take a source change without a restart"
+            );
+        }
+    }
+
+    /// A status the way the engine hands one to `auth_source`: the published options
+    /// carrying the stored value — `None` meaning an unset file, which publishes `auto` —
+    /// and the two probe answers still to be filled in.
+    fn probed_status(provider: &str, stored: Option<&str>) -> ProviderStatus {
+        let mut status = ProviderStatus::pending(&ProviderId::new(provider), &AccountId::default());
+        status.options = vec![ProviderOption {
+            name: AUTH_SOURCE.to_owned(),
+            title: "Credential".to_owned(),
+            description: None,
+            value: stored.unwrap_or(AUTO_SOURCE).to_owned(),
+            choices: Vec::new(),
+        }];
+        status
+    }
+
+    #[test]
+    fn claude_says_which_credential_the_next_poll_will_use() {
+        for stored in [OAUTH_SOURCE, CLI_SOURCE] {
+            // A stored choice wins over whatever the probe found: it is read first.
+            let mut status = probed_status(claude::PROVIDER_ID, Some(stored));
+            status.has_credential = Some(false);
+            assert_eq!(
+                auth_source(claude::PROVIDER_ID, &status).as_deref(),
+                Some(stored)
+            );
+        }
+        for (has_credential, expected) in [
+            (Some(true), OAUTH_SOURCE),
+            (Some(false), CLI_SOURCE),
+            (None, OAUTH_SOURCE),
+        ] {
+            let mut status = probed_status(claude::PROVIDER_ID, None);
+            status.has_credential = has_credential;
+            assert_eq!(
+                auth_source(claude::PROVIDER_ID, &status).as_deref(),
+                Some(expected),
+                "auto reaches the vendor file only on Ok(None), not on a locked keyring"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_says_which_credential_the_next_poll_will_use() {
+        for stored in [OAUTH_SOURCE, CLI_SOURCE] {
+            let mut status = probed_status(codex::PROVIDER_ID, Some(stored));
+            status.has_credential = Some(false);
+            assert_eq!(
+                auth_source(codex::PROVIDER_ID, &status).as_deref(),
+                Some(stored)
+            );
+        }
+        for (has_credential, expected) in [
+            (Some(true), OAUTH_SOURCE),
+            (Some(false), CLI_SOURCE),
+            (None, OAUTH_SOURCE),
+        ] {
+            let mut status = probed_status(codex::PROVIDER_ID, None);
+            status.has_credential = has_credential;
+            assert_eq!(
+                auth_source(codex::PROVIDER_ID, &status).as_deref(),
+                Some(expected),
+                "auto reaches the vendor file only on Ok(None), not on a locked keyring"
+            );
+        }
+    }
+
+    #[test]
+    fn antigravity_says_which_credential_the_next_poll_will_use() {
+        for stored in [OAUTH_SOURCE, CLI_SOURCE] {
+            let mut status = probed_status(antigravity::PROVIDER_ID, Some(stored));
+            status.external_present = Some(true);
+            assert_eq!(
+                auth_source(antigravity::PROVIDER_ID, &status).as_deref(),
+                Some(stored)
+            );
+        }
+        for (external_present, expected) in [
+            (Some(true), CLI_SOURCE),
+            (Some(false), OAUTH_SOURCE),
+            (None, OAUTH_SOURCE),
+        ] {
+            let mut status = probed_status(antigravity::PROVIDER_ID, None);
+            status.external_present = external_present;
+            assert_eq!(
+                auth_source(antigravity::PROVIDER_ID, &status).as_deref(),
+                Some(expected),
+                "auto tries the local server first whenever agy is installed"
+            );
+        }
+    }
+
+    #[test]
+    fn a_provider_with_one_credential_says_nothing_about_a_source() {
+        assert_eq!(
+            auth_source("zai", &probed_status("zai", None)),
+            None,
+            "there is no second credential for the next poll to use"
         );
-        let config = Config::at(path).expect("config reads");
-        let published = options(antigravity::PROVIDER_ID, &config);
-        let source = published
-            .iter()
-            .find(|option| option.name == ANTIGRAVITY_SOURCE)
-            .expect("the usage source is published");
-        assert_eq!(source.value, "cli");
     }
 
     // Two specs of the tests' own, so the mapping can be checked without waiting for a
@@ -595,7 +880,7 @@ mod tests {
         assert_eq!(published.credential, "none");
         assert_eq!(published.credential_kind(), Some(CredentialKind::None));
         assert!(published.credential_hint.is_empty());
-        assert_eq!(published.external_fallback, None);
+        assert_eq!(published.external, None);
     }
 
     #[test]
@@ -634,12 +919,15 @@ mod tests {
         assert_eq!(definitions[0].provider, "antigravity");
         assert_eq!(definitions[0].credential, CredentialKind::OAuth.as_wire());
         assert_eq!(
-            definitions[0].external_fallback.as_deref(),
+            definitions[0]
+                .external
+                .as_ref()
+                .map(|external| external.label.as_str()),
             Some("agy session")
         );
         assert_eq!(
             definitions[0].credential_hint,
-            "Sign in with Google through Tidemark"
+            "Sign in with Google through Tidemark, or read a signed-in agy session."
         );
         assert!(
             definitions

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -864,7 +864,7 @@ mod tests {
             title: "Z.ai".into(),
             credential: "key".into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         }]
     }
@@ -960,7 +960,7 @@ mod tests {
             title: "Z.ai".into(),
             credential: "key".into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
-            external_fallback: None,
+            external: None,
             options: Vec::new(),
         };
         let (daemon, _secrets, _commands) =


### PR DESCRIPTION
Claude, Codex and Antigravity each have **two** credentials: one Tidemark performed itself and keeps in the Secret Service, and one another program on this machine already holds. Which of the two an account used was decided silently.

## What was hidden

- **Claude and Codex** preferred their own token and read the vendor CLI's file when there was none — `Claude::credential`, `Codex::load`. No setting, no control, and nothing in the interface said which had answered until a poll had already succeeded.
- **Antigravity** did expose a choice, but as a three-way menu among the ordinary settings, and its `Auto` prefers `agy`. Measured on a real machine with both credentials present: `has_credential: true`, reading from `agy`, and the list row saying **"Signed in through Tidemark"**. It was reporting the wrong account.
- **Nothing anywhere mentioned ADR 0001** — that Tidemark refreshes those vendor files *in place* and writes the rotated token back into a file it does not own. That is the most surprising thing this program does and it was invisible.

## What this does

Each of the three now publishes an `ExternalLogin`: the setting that picks between the two credentials, what the local login is called, where it lives, what to run to create one, and whether Tidemark writes to it. The authentication group leads with a two-part control over two halves.

**Tidemark login** — the sign-in row exactly as it was.

**The local login** — the three things somebody with a problem needs, in that order:

1. whether the login is there and where Tidemark looked (`~/.claude/.credentials.json`), with **Check again**;
2. what to run if it is not (`claude`, `codex login`, `agy`), with **Copy**;
3. for Claude and Codex, that Tidemark refreshes it in place and writes the new token back — ADR 0001, stated next to the choice rather than left to be discovered.

### Guarantees

- **A pinned credential that is absent is `no-credential`, never a quiet fall back to the other one.** Falling back shows quota for an account the user did not choose.
- **`Source::Auto` is unchanged**, and stays what an unset setting means, so no installed account changes behaviour on upgrade. The daemon publishes which credential `Auto` *resolves to*, so the control shows the truth instead of the client guessing a per-provider rule.
- **`[provider.antigravity] source` keeps its key and its stored values.** An existing `source = "auto"` keeps working untouched; the key is now shared by all three.

## Changes

| Crate | Change |
|---|---|
| `tidemark-types` | `ProviderDefinition::external` replaces `external_fallback`; `ProviderStatus` gains `external_present` and `auth_source` |
| `tidemark-core` | `Source` hoisted out of `antigravity` into `providers`; honoured by `Claude` and `Codex` in both `load` and `force_refresh`; `cli_credentials_path` exposed for probing |
| `tidemarkd` | one `AUTH_SOURCE` setting for all three; Claude and Codex gain the `Rebuild` they were missing, so a change applies without a daemon restart; `Refresh` looks for the vendor login again |
| `tidemark` | the pill (`AdwToggleGroup`, full width in a row of its own), the local half, and source-aware connection copy |

Two incidental fixes fell out: Claude and Codex could not apply a settings change without a restart because neither had a `Rebuild` closure, and a manual refresh did not re-look for the vendor login — which is exactly what a user does straight after running `claude` in a terminal.

## Verification

914 tests, `clippy` clean, `fmt` clean, `check-layering.sh` ok.

Driven end to end against the real daemon with real Claude, Codex and `agy` credentials, and against `mock-daemon` for the two states a real machine cannot produce.

| Check | Result |
|---|---|
| Pill renders, both labels legible, both halves reachable | pass |
| Choice persists to `config.toml` | pass |
| Claude pinned to CLI while a Tidemark token is stored → reads the file, `ok` | pass |
| Antigravity → Tidemark login → stopped reading `agy`, went to Cloud Code Assist directly | pass |
| Codex pinned to CLI, file moved aside → `no-credential` despite a stored token | pass — no silent fallback |
| Check again: Not found → Found | pass |
| ADR 0001 write-back: `mcpOAuth` (7 entries) byte-identical, only token/expiry fields moved, backup written, mode `0600` | pass |
| `claude -p` after the write-back | pass |
| `writes_back: false` draws no write-back sentence | pass (mock) |

## Open question, deliberately not resolved here

Antigravity's `Source::Auto` still prefers `agy` over an explicit Tidemark login, which contradicts `docs/superpowers/specs/2026-08-21-provider-management-antigravity-oauth-design.md:256` — *"an explicit Tidemark login represents the user's chosen account and must not be masked by another local session."* The implementation carries a deliberate comment arguing the opposite. This PR makes the behaviour **visible** rather than changing it. Worth deciding which of the two is wrong; it is a one-line change either way.
