### PR TITLE
feat(grid): let the user drag the cards into the order they want

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,10 +145,14 @@ whole window, or a Waybar module, or a line of CLI output. `AddProvider(provider
 and persists the provider's `default` account; `RemoveProvider(provider, account)` removes
 one. `ProviderChanged` carries the same status shape as `GetStatus` for an account that was
 added or updated, while `ProviderRemoved(provider, account)` tells long-running clients to
-drop its settings row and card. `Refresh(provider)` polls now, with an empty string meaning
-everything, re-reads the credential on the way, and looks again for the vendor login a
-provider can read instead of ours — a refresh is what a user reaches for straight after
-running `claude` in a terminal. `Version` says what is on the other end.
+drop its settings row and card. `SetOrder(providers)` rewrites the order the cards go in and
+`OrderChanged(providers)` announces it — a signal of its own rather than a burst of
+`ProviderChanged`, because a status carries no position: a client holding cards needs the
+sequence, not the readings again. `GetStatus` answers in that order from the moment it is
+emitted. `Refresh(provider)` polls now, with an empty string meaning everything, re-reads
+the credential on the way, and looks again for the vendor login a provider can read instead
+of ours — a refresh is what a user reaches for straight after running `claude` in a
+terminal. `Version` says what is on the other end.
 
 Credentials are the daemon's, so changing them is the daemon's too: `SetKey`, `SignOut`,
 `SetOption`, `SetWindowNotify`, and the two halves of a login. Nothing there is specific to the GUI — a
@@ -270,7 +274,18 @@ distribution-wide LTO off; `PKGBUILD` does it with `options=(!lto)`.
   the user explicitly signed in here; signing out removes it and hands the account back.
 - **Settings** — `config.toml` holds what is neither a secret nor a reading: Z.ai's region,
   the ordered `providers` array and the per-window notification opt-in (`[notify.<slug>]`,
-  a `windows` array of window keys) today, card order later. A missing file or missing
+  a `windows` array of window keys). **That `providers` array is the card order.** Not a
+  second key beside it: it is already ordered, already the user's set, already the order
+  `GetStatus` publishes in, and adding a provider already appends to it — which is exactly
+  what "a new card goes on the end" means. A separate `card_order` would be a second list to
+  keep in agreement with the first, and its first question — where a provider named in one
+  and absent from the other goes — has no good answer. Reordering **moves the values and
+  leaves the decoration where it was written**: a TOML array has no notion of a comment
+  belonging to an element, since in `"claude", # mine` the comment is part of the *next*
+  element's prefix and in the style above it part of its own, so carrying decoration along
+  would scramble comments and indentation in opposite directions depending on which style
+  the file uses. What comes back is the file byte for byte apart from the slugs. A missing
+  file or missing
   array has the same meaning as `providers = []`: a fresh installation has no configured
   accounts. It is edited rather than rewritten, so comments, ordering and keys a newer
   build added all survive a change made from the interface. A file that does not parse is
@@ -338,9 +353,28 @@ history that does not exist yet.
 
 ## Interface
 
-- **Grid of provider cards** (`GtkFlowBox`, 1–3 columns by width), sorted by urgency, with
-  user-defined order persisted to config. Reordering is manual `GtkDragSource` /
-  `GtkDropTarget` work — `GtkFlowBox` has no reorder API.
+- **Grid of provider cards**, one to three columns by width, **in the order the user put
+  them in**. Nothing else ever changes that order: there is no urgency sort underneath it,
+  a new account goes on the end, and the sequence is persisted by the daemon and
+  republished to every client. The grid the tray menu lists and the grid the settings
+  dialog lists are this one.
+- **The grid is a widget of ours, not a `GtkFlowBox`.** Reordering has to be *live* — the
+  cards a held card displaces move out of its way before the button is released, and move
+  back if the pointer changes its mind — and `gtk_flow_box_invalidate_sort()` sorts a
+  sequence and queues a resize, so a card that loses its place teleports. There is nothing
+  to interpolate, because the position *is* the allocation. Nothing in GTK 4.22 or
+  libadwaita 1.9 does this generally; the one upstream implementation of exactly this
+  behaviour is libadwaita's private `AdwTabGrid`, and `grid.rs` is its architecture: a
+  `GtkGestureDrag` on the container, a per-card offset in **index units** animated by an
+  `AdwTimedAnimation` restarted from its current value, an animation callback that queues an
+  allocation, and a `size_allocate` that turns a fractional index into a position.
+  `GtkDragSource` / `GtkDropTarget` are the wrong controllers for it: they carry a payload
+  and draw a detached icon, and an icon that is not in the grid cannot push anything.
+- **The order is committed on release, not on the way.** A file write and a D-Bus round trip
+  per pixel is not a design. The drop is applied locally first and sent afterwards, because
+  a grid that waited for the daemon before showing where the card landed would feel broken;
+  a refusal — the configured set moved while the card was in the air — puts the cards back
+  to what the daemon actually has.
 - **Empty state** — when there are no configured providers, the main window says
   `Welcome to Tidemark` and `Add a provider to start tracking your quota.` The providers
   button remains available while the daemon is connected.
@@ -370,11 +404,19 @@ history that does not exist yet.
   their colour rather than the one libadwaita would have picked. **It changes colour at 70%
   and 90% — the notification thresholds** — so the card and the notification never disagree
   about when a window became worth worrying about.
-- **A card raises on hover** — two pixels and a soft shadow — rather than taking the tint
-  `GtkFlowBoxChild` paints on its own square allocation, which shows as a hard edge around
-  the card's rounded corners. The `:hover` is matched on the child and the card is what
-  moves, so the pointer never falls off the widget it just raised. When the card becomes
-  clickable, `.card.activatable` supplies the platform's own hover and active states.
+- **A card raises on hover** — two pixels and a soft shadow. The `:hover` is matched on the
+  slot around the card and the card is what moves, because a CSS transform moves what GTK
+  picks and a card that lifted itself out from under the pointer would flicker. That slot
+  is an `AdwBin`; it was a `GtkFlowBoxChild`, which also tinted its own square allocation
+  behind a card with rounded corners and had to be told not to. `.card.activatable`
+  supplies the platform's own hover and active states.
+- **A card being carried is opaque.** `.card` takes `@card_bg_color`, which in the dark
+  style is 8% white over whatever is behind it — right for a card lying on the window, and
+  wrong for one crossing its neighbours, which then read straight through it. The dragged
+  card takes `@popover_bg_color`, the platform's own name for a surface floating above the
+  content, and a deeper shadow. Its foreground is deliberately left alone: the bar's track
+  and pace mark inherit the text colour, and changing it would make them shift tone for the
+  length of a drag.
 - **The grid is homogeneous.** Every card gets the same allocation, so cards in a row share
   a height and their footers line up; the cost is a short card in a single-column window
   carrying the height of the tallest one. The last row is left ragged: a filler card would

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -182,6 +182,58 @@ impl Config {
         Ok(!already_configured)
     }
 
+    /// Rewrites the order of the configured providers.
+    ///
+    /// The array is a permutation, not a replacement: `order` must name every configured
+    /// provider exactly once. A list that names something else — a slug that is not
+    /// configured, a slug that is missing, the same slug twice — is refused with nothing
+    /// written, because a client whose idea of the set is out of date should read the set
+    /// again rather than have this function guess which half of the disagreement it meant.
+    ///
+    /// **Only the values move; the decoration stays where it was written.** A TOML array
+    /// has no notion of a comment belonging to an element: in the style this file's own
+    /// tests use — `"claude", # first survivor` — the comment about one element is part of
+    /// the *next* element's prefix, and in the style above it, part of its own. So a
+    /// permutation that carried decoration along would scramble both the comments and the
+    /// indentation, in opposite directions depending on which style the file uses. Moving
+    /// the strings inside the existing layout is the one behaviour that is predictable:
+    /// the file comes back byte-identical apart from the slugs.
+    pub fn set_provider_order(&mut self, order: &[String]) -> Result<bool, ConfigError> {
+        let configured = self.providers()?;
+        let mut wanted = order.to_vec();
+        wanted.sort_unstable();
+        wanted.dedup();
+        let mut held = configured.clone();
+        held.sort_unstable();
+        if wanted.len() != order.len() || wanted != held {
+            return Err(ConfigError::InvalidProviders {
+                path: self.path.clone(),
+                reason: "the order must name every configured provider exactly once".to_owned(),
+            });
+        }
+        if configured == order {
+            return Ok(false);
+        }
+
+        self.normalize_providers(None)?;
+        let array = self
+            .document
+            .get_mut(PROVIDERS_KEY)
+            .and_then(Item::as_array_mut)
+            .ok_or_else(|| ConfigError::InvalidProviders {
+                path: self.path.clone(),
+                reason: "providers must be an array of strings".to_owned(),
+            })?;
+        // `Array::replace` keeps the decoration of the slot it writes into, which is
+        // exactly what is wanted here, and `order` was checked to be a permutation of the
+        // normalized array above, so this writes every slug back exactly once.
+        for (index, slug) in order.iter().enumerate() {
+            array.replace(index, slug.as_str());
+        }
+        self.write()?;
+        Ok(true)
+    }
+
     /// Removes a provider and its settings while normalizing any survivor duplicates.
     pub fn remove_provider(&mut self, provider: &str) -> Result<bool, ConfigError> {
         let providers = self.providers()?;
@@ -551,6 +603,116 @@ mod tests {
         assert!(!text.contains("[provider.zai]"), "{text}");
         let reread = Config::at(path.clone()).expect("parses again");
         assert_eq!(reread.providers().expect("readable"), ["claude", "future"]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn reordering_moves_only_the_slugs_and_leaves_the_layout_alone() {
+        let path = scratch("providers-reorder-layout");
+        std::fs::write(
+            &path,
+            "# root comment\n\
+             providers = [ # array heading\n\
+                 \"claude\",\n\
+                 \"zai\",\n\
+                 \"kimi\",\n\
+             ] # array tail\n\
+             \n\
+             [provider.zai]\n\
+             region = \"global\"\n",
+        )
+        .expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        assert!(
+            config
+                .set_provider_order(&["kimi".into(), "claude".into(), "zai".into()])
+                .expect("reordered")
+        );
+
+        let text = std::fs::read_to_string(&path).expect("written");
+        assert_eq!(
+            text,
+            "# root comment\n\
+             providers = [ # array heading\n\
+                 \"kimi\",\n\
+                 \"claude\",\n\
+                 \"zai\",\n\
+             ] # array tail\n\
+             \n\
+             [provider.zai]\n\
+             region = \"global\"\n",
+            "the layout, the comments and the provider table must all survive"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn reordering_a_single_line_array_keeps_it_on_one_line() {
+        let path = scratch("providers-reorder-inline");
+        std::fs::write(&path, "providers = [\"claude\", \"zai\"]\n").expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        assert!(
+            config
+                .set_provider_order(&["zai".into(), "claude".into()])
+                .expect("reordered")
+        );
+
+        let text = std::fs::read_to_string(&path).expect("written");
+        assert_eq!(text, "providers = [\"zai\", \"claude\"]\n");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn reordering_normalizes_duplicates_before_permuting() {
+        let path = scratch("providers-reorder-duplicates");
+        std::fs::write(&path, "providers = [\"claude\", \"zai\", \"claude\"]\n").expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        assert!(
+            config
+                .set_provider_order(&["zai".into(), "claude".into()])
+                .expect("reordered")
+        );
+
+        let reread = Config::at(path.clone()).expect("parses again");
+        assert_eq!(reread.providers().expect("readable"), ["zai", "claude"]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn an_unchanged_order_is_not_a_write() {
+        let path = scratch("providers-reorder-noop");
+        std::fs::write(&path, "providers = [\"claude\", \"zai\"]\n").expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        assert!(
+            !config
+                .set_provider_order(&["claude".into(), "zai".into()])
+                .expect("accepted")
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn an_order_that_is_not_a_permutation_is_refused_without_writing() {
+        let path = scratch("providers-reorder-refused");
+        let seed = "providers = [\"claude\", \"zai\"]\n";
+        std::fs::write(&path, seed).expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        for order in [
+            vec!["claude".to_owned()],
+            vec!["claude".to_owned(), "claude".to_owned()],
+            vec!["claude".to_owned(), "zai".to_owned(), "kimi".to_owned()],
+        ] {
+            assert!(
+                config.set_provider_order(&order).is_err(),
+                "{order:?} is not a permutation of the configured set"
+            );
+        }
+        assert_eq!(std::fs::read_to_string(&path).expect("readable"), seed);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -98,6 +98,9 @@ pub trait Daemon {
         enabled: bool,
     ) -> zbus::Result<()>;
 
+    /// Puts the configured providers in the order the user arranged the cards in.
+    fn set_order(&self, providers: &[String]) -> zbus::Result<()>;
+
     /// What the daemon on the other end is.
     #[zbus(property(emits_changed_signal = "false"))]
     fn version(&self) -> zbus::Result<String>;
@@ -109,6 +112,10 @@ pub trait Daemon {
     /// One configured account was removed.
     #[zbus(signal)]
     fn provider_removed(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// The configured providers are now in this order.
+    #[zbus(signal)]
+    fn order_changed(&self, providers: Vec<String>) -> zbus::Result<()>;
 
     /// Availability of a newer published application release changed.
     #[zbus(signal)]
@@ -134,6 +141,8 @@ pub enum Update {
     Changed(ProviderStatus),
     /// One configured account was removed.
     Removed { provider: String, account: String },
+    /// The configured providers were put in this order.
+    Reordered(Vec<String>),
     /// Availability of a newer published application release changed.
     Available(String),
     /// There is nothing to show, with the reason to put on the screen.
@@ -175,6 +184,7 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
     let mut owner = pin!(proxy.inner().receive_owner_changed().await?);
     let mut changes = pin!(proxy.receive_provider_changed().await?);
     let mut removals = pin!(proxy.receive_provider_removed().await?);
+    let mut orders = pin!(proxy.receive_order_changed().await?);
     let mut updates = pin!(proxy.receive_update_changed().await?);
 
     load(&proxy, on).await;
@@ -189,6 +199,9 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
             }
             if let Poll::Ready(removal) = removals.as_mut().poll_next(context) {
                 return Poll::Ready(Event::Removed(removal));
+            }
+            if let Poll::Ready(order) = orders.as_mut().poll_next(context) {
+                return Poll::Ready(Event::Reordered(order));
             }
             if let Poll::Ready(update) = updates.as_mut().poll_next(context) {
                 return Poll::Ready(Event::Available(update));
@@ -219,6 +232,10 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
                 }),
                 Err(error) => tracing::warn!(%error, "a ProviderRemoved signal did not parse"),
             },
+            Event::Reordered(Some(signal)) => match signal.args() {
+                Ok(args) => on(Update::Reordered(args.providers)),
+                Err(error) => tracing::warn!(%error, "an OrderChanged signal did not parse"),
+            },
             Event::Available(Some(signal)) => match signal.args() {
                 Ok(args) => on(Update::Available(args.version.to_owned())),
                 Err(error) => tracing::warn!(%error, "an UpdateChanged signal did not parse"),
@@ -227,6 +244,7 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
             Event::Owner(None)
             | Event::Changed(None)
             | Event::Removed(None)
+            | Event::Reordered(None)
             | Event::Available(None) => return Ok(()),
         }
     }
@@ -262,11 +280,12 @@ async fn load(proxy: &DaemonProxy<'static>, on: &impl Fn(Update)) {
     }
 }
 
-/// One of the two streams produced something.
+/// One of the streams the [`serve`] loop watches produced something.
 enum Event {
     Owner(Option<Option<zbus::names::UniqueName<'static>>>),
     Changed(Option<ProviderChanged>),
     Removed(Option<ProviderRemoved>),
+    Reordered(Option<OrderChanged>),
     Available(Option<UpdateChanged>),
 }
 

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -41,8 +41,8 @@ const MARK_GAP: i32 = 6;
 const PILL_PADDING: i32 = 2;
 
 /// Narrowest a card is allowed to get. Three of these plus spacing is what "three columns"
-/// costs, and it is what stops `GtkFlowBox` from packing three unreadable columns into a
-/// window that only has room for two.
+/// costs, and it is what stops the grid from packing three unreadable columns into a window
+/// that only has room for two.
 const MIN_WIDTH: i32 = 300;
 
 /// The account a card opens, retained separately from the readings that update in place.
@@ -79,7 +79,7 @@ struct Shown {
 /// A provider card.
 #[derive(Debug)]
 pub struct Card {
-    holder: gtk::FlowBoxChild,
+    slot: adw::Bin,
     mark: gtk::Image,
     name: gtk::Label,
     /// The provider's name as the catalog spells it, resolved once at construction: slugs
@@ -199,9 +199,9 @@ impl Card {
             .spacing(6)
             .build();
 
-        // Pinned to the bottom so that cards sharing a row line their footers up: GtkFlowBox
-        // stretches every child to the height of the tallest one in the row, and without
-        // this the extra space would fall in a different place on every card.
+        // Pinned to the bottom so that cards sharing a row line their footers up: the grid
+        // gives every card the height of the tallest one, and without this the extra space
+        // would fall in a different place on every card.
         let footer = gtk::Label::builder()
             .halign(gtk::Align::Start)
             .valign(gtk::Align::End)
@@ -221,15 +221,22 @@ impl Card {
         root.append(&rows);
         root.append(&footer);
 
-        // The card owns its `GtkFlowBoxChild` rather than letting the grid wrap it on
-        // insertion, so that the grid can reorder by sorting rather than by taking widgets
-        // out and putting them back: re-parenting a widget that a disposed wrapper still
-        // holds is a `Gtk-CRITICAL`, and it costs the focus and the pointer besides.
-        let holder = gtk::FlowBoxChild::builder()
+        // The card owns the widget the grid allocates rather than letting the grid wrap it,
+        // so that a reorder moves slots around a vector instead of taking widgets out of
+        // the tree and putting them back: re-parenting a widget that a disposed wrapper
+        // still holds is a `Gtk-CRITICAL`, and it costs the focus and the pointer besides.
+        //
+        // A plain `AdwBin` and not a `GtkFlowBoxChild`, which tinted its own square
+        // allocation behind a card with rounded corners and had to be told not to. What it
+        // is still for is the hover: `style.rs` matches `:hover` here and moves the card
+        // inside, because a CSS transform moves what GTK picks and a card that lifted
+        // itself out from under the pointer would flicker.
+        let slot = adw::Bin::builder()
             .child(&root)
             .focusable(true)
+            .css_classes([crate::grid::SLOT_CLASS])
             .build();
-        holder.set_cursor_from_name(Some("pointer"));
+        slot.set_cursor_from_name(Some("pointer"));
         let identity = CardIdentity::from(status);
         let invoke: Rc<dyn Fn()> = Rc::new({
             let on_activate = Rc::clone(&on_activate);
@@ -240,7 +247,7 @@ impl Card {
             let invoke = Rc::clone(&invoke);
             move |_, _, _, _| invoke()
         });
-        holder.add_controller(click);
+        slot.add_controller(click);
         let keys = gtk::EventControllerKey::new();
         keys.connect_key_pressed({
             let invoke = Rc::clone(&invoke);
@@ -256,10 +263,10 @@ impl Card {
                 }
             }
         });
-        holder.add_controller(keys);
+        slot.add_controller(keys);
 
         let card = Self {
-            holder,
+            slot,
             mark,
             name,
             provider_name,
@@ -283,9 +290,9 @@ impl Card {
         card
     }
 
-    /// The widget to put in the grid.
-    pub fn widget(&self) -> &gtk::FlowBoxChild {
-        &self.holder
+    /// The widget the grid allocates. Not the card itself: see the slot above.
+    pub fn widget(&self) -> &gtk::Widget {
+        self.slot.upcast_ref()
     }
 
     /// The status this card is showing.

--- a/crates/tidemark/src/grid.rs
+++ b/crates/tidemark/src/grid.rs
@@ -1,0 +1,1043 @@
+//! The grid the cards sit in, and the drag that reorders them.
+//!
+//! # Why this is a widget of our own
+//!
+//! `GtkFlowBox` laid out the columns until reordering arrived, and it cannot do the part
+//! that matters: while a card is being carried between two others, the cards it displaces
+//! have to move out of its way *before* the button is released, and move back if the
+//! pointer changes its mind. `gtk_flow_box_invalidate_sort()` sorts its sequence and queues
+//! a resize, so a card that loses its place teleports to the new one. There is no position
+//! to interpolate, because the position *is* the allocation.
+//!
+//! Nothing in GTK 4.22 or libadwaita 1.9 does this in the general case. `GtkNotebook` can
+//! reorder tabs and `AdwTabView` can reorder pages, and both keep how they animate it to
+//! themselves. What libadwaita does have is `AdwTabGrid` — private, and an exact match for
+//! the problem — and this module is its architecture:
+//!
+//! - one `GtkGestureDrag` on the container, not `GtkDragSource`. A drag source draws a
+//!   detached icon, and an icon that is not in the grid cannot push anything;
+//! - a per-card offset in **index units**, animated by an `AdwTimedAnimation` that is
+//!   restarted *from its current value*. That restart is what makes "changed their mind"
+//!   work: a card half-way out of the way is retargeted to zero and carries on from where
+//!   it is, rather than snapping back and starting again;
+//! - the animation callback queues an allocation, and `size_allocate` turns a fractional
+//!   index into a position;
+//! - the order is committed once, on release. Not on every motion event.
+//!
+//! # Why the arithmetic is in free functions
+//!
+//! [`columns`], [`slot`], [`drop_index`] and [`shift`] are where this can be wrong, and none
+//! of them needs a display to be wrong in. They are tested below, the way `bar::geometry`
+//! is.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use adw::prelude::*;
+use gtk::glib;
+use gtk::graphene;
+use gtk::gsk;
+use gtk::subclass::prelude::*;
+
+/// Space between cards, both ways. What the `GtkFlowBox` used.
+const SPACING: i32 = 12;
+/// Most columns, however wide the window gets. Three 300-pixel cards is already a wide
+/// window, and a fourth column would make each card a strip.
+const MAX_COLUMNS: usize = 3;
+/// How long a displaced card takes to get out of the way. `AdwTabGrid`'s figure.
+const REORDER_MS: u32 = 250;
+/// How long a released card takes to settle into its slot.
+const SETTLE_MS: u32 = 200;
+/// How close to the edge of the scrolled view the pointer has to get before the view
+/// follows it. Roughly a finger's width: near enough to be deliberate, far enough that it
+/// engages before the pointer is jammed against the edge.
+const AUTOSCROLL_EDGE: f64 = 48.0;
+/// Fastest the view scrolls itself, in pixels per second, reached at the very edge.
+const AUTOSCROLL_RATE: f64 = 900.0;
+
+/// The style class the slot around a card carries.
+pub const SLOT_CLASS: &str = "quota-slot";
+/// Added to the *slot* of the card being carried, so the stylesheet can lift the card
+/// inside it. On the slot rather than the card because the grid holds slots and knows
+/// nothing about what is in them; `style.rs` matches `.quota-slot.dragging > .quota-card`.
+const DRAGGING_CLASS: &str = "dragging";
+
+/// How many columns fit, between one and `max`.
+///
+/// Never zero: a window too narrow for one card gets one column and a horizontal squeeze,
+/// which is what the card's own width request is for.
+fn columns(available: i32, cell: i32, spacing: i32, max: usize) -> usize {
+    if cell <= 0 {
+        return 1;
+    }
+    let fitting = (available + spacing) / (cell + spacing);
+    (fitting.max(1) as usize).min(max.max(1))
+}
+
+/// Where slot `index` starts, relative to the first slot.
+///
+/// A fractional index interpolates between the two whole slots either side of it, which
+/// includes the step from the end of one row to the start of the next: a card moving across
+/// that boundary travels there rather than jumping.
+fn slot(index: f64, columns: usize, cell: (f64, f64), spacing: (f64, f64)) -> (f64, f64) {
+    let whole = |index: f64| {
+        let columns = columns.max(1) as f64;
+        let row = (index / columns).floor();
+        let column = index - row * columns;
+        (column * (cell.0 + spacing.0), row * (cell.1 + spacing.1))
+    };
+    let floor = index.floor();
+    let fraction = index - floor;
+    if fraction == 0.0 {
+        return whole(floor);
+    }
+    let (x0, y0) = whole(floor);
+    let (x1, y1) = whole(floor + 1.0);
+    (x0 + fraction * (x1 - x0), y0 + fraction * (y1 - y0))
+}
+
+/// The slot a dragged card's centre is over.
+///
+/// Measured against the **canonical** slots — where the cards would be if nothing were
+/// being dragged — rather than against where they currently are. Canonical slots do not
+/// move, so the answer is a monotone function of the pointer and cannot flicker between two
+/// values while the pointer is still.
+fn drop_index(
+    centre: (f64, f64),
+    count: usize,
+    columns: usize,
+    cell: (f64, f64),
+    spacing: (f64, f64),
+) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    let columns = columns.max(1);
+    let column = (centre.0 / (cell.0 + spacing.0))
+        .floor()
+        .clamp(0.0, (columns - 1) as f64) as usize;
+    let rows = count.div_ceil(columns);
+    let row = (centre.1 / (cell.1 + spacing.1))
+        .floor()
+        .clamp(0.0, (rows - 1) as f64) as usize;
+    (row * columns + column).min(count - 1)
+}
+
+/// The card a press at this point actually landed on, if it landed on one.
+///
+/// [`drop_index`] answers "which slot is this nearest to", which is what a drag in progress
+/// needs and what a press must not use: with five cards in three columns the sixth slot is
+/// empty, and the gutters and the centring margin are not on a card either. Answering
+/// "the nearest one" there would pick a card up off a click on the background.
+fn slot_at(
+    point: (f64, f64),
+    count: usize,
+    columns: usize,
+    cell: (f64, f64),
+    spacing: (f64, f64),
+) -> Option<usize> {
+    if count == 0 || cell.0 <= 0.0 || cell.1 <= 0.0 {
+        return None;
+    }
+    let index = drop_index(point, count, columns, cell, spacing);
+    let (x, y) = slot(index as f64, columns, cell, spacing);
+    let inside = point.0 >= x && point.0 < x + cell.0 && point.1 >= y && point.1 < y + cell.1;
+    inside.then_some(index)
+}
+
+/// The index shift a card at `index` takes while the card from `from` is carried to `to`.
+///
+/// Zero for the dragged card itself, which is positioned by the pointer rather than by a
+/// slot, and zero for everything outside the span the move covers.
+fn shift(index: usize, from: usize, to: usize) -> f64 {
+    if index == from {
+        return 0.0;
+    }
+    if from < to && index > from && index <= to {
+        return -1.0;
+    }
+    if from > to && index >= to && index < from {
+        return 1.0;
+    }
+    0.0
+}
+
+/// How fast the scrolled view should follow a pointer this far into its edge, in pixels per
+/// second. Positive scrolls down. Zero everywhere but the two edge bands.
+fn autoscroll_rate(pointer: f64, height: f64) -> f64 {
+    if height <= 2.0 * AUTOSCROLL_EDGE {
+        return 0.0;
+    }
+    if pointer < AUTOSCROLL_EDGE {
+        return -AUTOSCROLL_RATE * (1.0 - pointer.max(0.0) / AUTOSCROLL_EDGE);
+    }
+    let from_bottom = height - pointer;
+    if from_bottom < AUTOSCROLL_EDGE {
+        return AUTOSCROLL_RATE * (1.0 - from_bottom.max(0.0) / AUTOSCROLL_EDGE);
+    }
+    0.0
+}
+
+/// One card's place in the grid, and where it currently is on the way to it.
+struct Slot {
+    child: gtk::Widget,
+    /// Index shift as drawn right now, interpolated by [`Slot::animation`].
+    offset: Cell<f64>,
+    /// Index shift being animated towards.
+    target: Cell<f64>,
+    animation: RefCell<Option<adw::TimedAnimation>>,
+}
+
+/// A drag in progress, or a released card still settling into its slot.
+struct Drag {
+    /// Where the card is in the slot vector. Updated when the release commits the move.
+    index: usize,
+    /// The card's top-left in grid coordinates when the press landed.
+    origin: (f64, f64),
+    /// How far the pointer has moved since, as the gesture reports it.
+    pointer: (f64, f64),
+    /// How far the scrolled view has moved itself since, which the card follows too.
+    scrolled: f64,
+    /// Provisional destination, recomputed on every motion.
+    target: usize,
+    /// Set once the pointer has travelled far enough to be a drag rather than a click.
+    carrying: bool,
+    /// While the released card animates into its slot: where it started from.
+    settle: Option<(f64, f64)>,
+    /// Zero to one across the settle.
+    progress: f64,
+    animation: Option<adw::TimedAnimation>,
+    autoscroll: Option<gtk::TickCallbackId>,
+}
+
+/// What the grid hands a completed move to: the card's old index, then its new one.
+type OnReorder = Rc<dyn Fn(usize, usize)>;
+
+impl Drag {
+    /// The card's current top-left in grid coordinates, given where its slot is.
+    fn at(&self, resting: (f64, f64)) -> (f64, f64) {
+        match self.settle {
+            None => (
+                self.origin.0 + self.pointer.0,
+                self.origin.1 + self.pointer.1 + self.scrolled,
+            ),
+            Some(from) => (
+                from.0 + self.progress * (resting.0 - from.0),
+                from.1 + self.progress * (resting.1 - from.1),
+            ),
+        }
+    }
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct CardGrid {
+        pub(super) slots: RefCell<Vec<Slot>>,
+        pub(super) drag: RefCell<Option<Drag>>,
+        /// Called once per completed move, with the indices it went between.
+        pub(super) on_reorder: RefCell<Option<OnReorder>>,
+        /// The layout the last allocation settled on, so the drag arithmetic and the
+        /// allocation cannot come to different conclusions about where a slot is.
+        pub(super) columns: Cell<usize>,
+        pub(super) cell: Cell<(f64, f64)>,
+    }
+
+    // By hand because the reorder callback is a closure. What is worth printing is the
+    // shape of the grid and whether a card is in the air, not the identity of a function.
+    impl std::fmt::Debug for CardGrid {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("CardGrid")
+                .field("cards", &self.slots.borrow().len())
+                .field("columns", &self.columns.get())
+                .field("cell", &self.cell.get())
+                .field("dragging", &self.drag.borrow().is_some())
+                .finish()
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for CardGrid {
+        const NAME: &'static str = "TidemarkCardGrid";
+        type Type = super::CardGrid;
+        type ParentType = gtk::Widget;
+    }
+
+    impl ObjectImpl for CardGrid {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.obj().install_gesture();
+        }
+
+        fn dispose(&self) {
+            self.slots.borrow_mut().clear();
+            while let Some(child) = self.obj().first_child() {
+                child.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for CardGrid {
+        /// The number of columns depends on the width, so the height depends on it too.
+        fn request_mode(&self) -> gtk::SizeRequestMode {
+            gtk::SizeRequestMode::HeightForWidth
+        }
+
+        fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            let count = self.slots.borrow().len();
+            if count == 0 {
+                return (0, 0, -1, -1);
+            }
+            let cell_width = self.natural_width();
+            match orientation {
+                // One column is the minimum, because a card is as narrow as it is going to
+                // get. The natural width is however many columns there are cards for, up to
+                // the maximum, which is what stops a wide window at three.
+                gtk::Orientation::Horizontal => {
+                    let wanted = count.min(MAX_COLUMNS) as i32;
+                    (
+                        cell_width,
+                        wanted * cell_width + (wanted - 1) * SPACING,
+                        -1,
+                        -1,
+                    )
+                }
+                _ => {
+                    let available = if for_size < 0 {
+                        count.min(MAX_COLUMNS) as i32 * (cell_width + SPACING) - SPACING
+                    } else {
+                        for_size
+                    };
+                    let columns = columns(available, cell_width, SPACING, MAX_COLUMNS);
+                    let rows = count.div_ceil(columns) as i32;
+                    let height = rows * self.natural_height(cell_width) + (rows - 1) * SPACING;
+                    (height, height, -1, -1)
+                }
+            }
+        }
+
+        fn size_allocate(&self, width: i32, _height: i32, baseline: i32) {
+            let slots = self.slots.borrow();
+            if slots.is_empty() {
+                return;
+            }
+            let cell_width = self.natural_width();
+            let cell_height = self.natural_height(cell_width);
+            let columns = columns(width, cell_width, SPACING, MAX_COLUMNS);
+            self.columns.set(columns);
+            self.cell
+                .set((f64::from(cell_width), f64::from(cell_height)));
+
+            let cell = (f64::from(cell_width), f64::from(cell_height));
+            let spacing = (f64::from(SPACING), f64::from(SPACING));
+            let left = content_left(width, columns, cell.0);
+            let drag = self.drag.borrow();
+
+            for (index, held) in slots.iter().enumerate() {
+                let resting = slot(index as f64, columns, cell, spacing);
+                let (x, y) = match drag.as_ref() {
+                    Some(drag)
+                        if drag.index == index && (drag.carrying || drag.settle.is_some()) =>
+                    {
+                        drag.at(resting)
+                    }
+                    _ => slot(index as f64 + held.offset.get(), columns, cell, spacing),
+                };
+                let transform = gsk::Transform::new()
+                    .translate(&graphene::Point::new((left + x) as f32, y as f32));
+                held.child
+                    .allocate(cell_width, cell_height, baseline, Some(transform));
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    /// A grid of cards the user can drag into the order they want.
+    pub struct CardGrid(ObjectSubclass<imp::CardGrid>)
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
+}
+
+impl Default for CardGrid {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Where the block of columns starts inside an allocation of this width.
+///
+/// The block is centred: every card gets one column's width whatever the window is doing,
+/// so a filled row and a half-empty one both sit under the middle of the window rather than
+/// hugging its left edge.
+fn content_left(width: i32, columns: usize, cell_width: f64) -> f64 {
+    let columns = columns.max(1) as f64;
+    let used = columns * cell_width + (columns - 1.0) * f64::from(SPACING);
+    (f64::from(width) - used).max(0.0) / 2.0
+}
+
+impl imp::CardGrid {
+    /// The widest card's natural width, which every cell gets.
+    fn natural_width(&self) -> i32 {
+        self.slots
+            .borrow()
+            .iter()
+            .map(|held| held.child.measure(gtk::Orientation::Horizontal, -1).1)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// The tallest card's natural height at that width, which every cell gets — so cards
+    /// sharing a row share a height and their footers line up.
+    fn natural_height(&self, for_width: i32) -> i32 {
+        self.slots
+            .borrow()
+            .iter()
+            .map(|held| held.child.measure(gtk::Orientation::Vertical, for_width).1)
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+impl CardGrid {
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    /// Adds a card at the end. Where a new account goes, always.
+    pub fn append(&self, child: &impl IsA<gtk::Widget>) {
+        let child = child.as_ref().clone();
+        child.set_parent(self);
+        self.imp().slots.borrow_mut().push(Slot {
+            child,
+            offset: Cell::new(0.0),
+            target: Cell::new(0.0),
+            animation: RefCell::new(None),
+        });
+        self.queue_resize();
+    }
+
+    /// Removes one card, leaving the order of the rest alone.
+    pub fn remove(&self, child: &impl IsA<gtk::Widget>) {
+        self.abandon_drag();
+        let child = child.as_ref();
+        let mut slots = self.imp().slots.borrow_mut();
+        if let Some(index) = slots.iter().position(|held| &held.child == child) {
+            slots.remove(index).child.unparent();
+        }
+        drop(slots);
+        self.queue_resize();
+    }
+
+    /// Takes every card out.
+    pub fn clear(&self) {
+        self.abandon_drag();
+        for held in self.imp().slots.borrow_mut().drain(..) {
+            held.child.unparent();
+        }
+        self.queue_resize();
+    }
+
+    /// Puts the cards in this order, which should be the ones the grid holds.
+    ///
+    /// Applying an order the grid is already in does nothing, which is the ordinary case:
+    /// the daemon echoes back the order this client just asked it for.
+    pub fn set_order(&self, order: &[gtk::Widget]) {
+        {
+            let slots = self.imp().slots.borrow();
+            if slots.len() == order.len()
+                && slots
+                    .iter()
+                    .zip(order)
+                    .all(|(held, wanted)| &held.child == wanted)
+            {
+                return;
+            }
+        }
+        self.abandon_drag();
+        let mut slots = self.imp().slots.borrow_mut();
+        let mut held: Vec<Option<Slot>> = slots.drain(..).map(Some).collect();
+        for wanted in order {
+            let found = held
+                .iter()
+                .position(|slot| slot.as_ref().is_some_and(|slot| &slot.child == wanted));
+            if let Some(index) = found
+                && let Some(slot) = held[index].take()
+            {
+                slots.push(slot);
+            }
+        }
+        // Anything the order did not name keeps its relative place at the end rather than
+        // being dropped: the sequence arrives from another process and may have raced an add.
+        slots.extend(held.into_iter().flatten());
+        drop(slots);
+        self.reset_child_order();
+        self.queue_allocate();
+    }
+
+    /// Registers what to do with a completed move: the card's old and new index.
+    pub fn connect_reordered(&self, on_reorder: impl Fn(usize, usize) + 'static) {
+        *self.imp().on_reorder.borrow_mut() = Some(Rc::new(on_reorder));
+    }
+
+    /// The one gesture this widget has. Bubble phase, so a card's own click gesture sees the
+    /// press first; the sequence is claimed only once the pointer has travelled far enough
+    /// to be a drag, and claiming it is what cancels that click.
+    fn install_gesture(&self) {
+        let gesture = gtk::GestureDrag::new();
+        gesture.set_button(gtk::gdk::BUTTON_PRIMARY);
+        gesture.set_exclusive(true);
+        gesture.connect_drag_begin({
+            let grid = self.downgrade();
+            move |gesture, x, y| {
+                if let Some(grid) = grid.upgrade() {
+                    grid.begin(gesture, x, y);
+                }
+            }
+        });
+        gesture.connect_drag_update({
+            let grid = self.downgrade();
+            move |gesture, dx, dy| {
+                if let Some(grid) = grid.upgrade() {
+                    grid.update(gesture, dx, dy);
+                }
+            }
+        });
+        gesture.connect_drag_end({
+            let grid = self.downgrade();
+            move |_, _, _| {
+                if let Some(grid) = grid.upgrade() {
+                    grid.release();
+                }
+            }
+        });
+        self.add_controller(gesture);
+    }
+
+    /// Notes which card the press landed on, and nothing else. Whether this is a drag or a
+    /// click is not known yet, and deciding here would break the click.
+    fn begin(&self, gesture: &gtk::GestureDrag, x: f64, y: f64) {
+        self.abandon_drag();
+        let imp = self.imp();
+        let count = imp.slots.borrow().len();
+        if count < 2 {
+            // One card has nowhere to go, and no cards have nothing to move.
+            gesture.set_state(gtk::EventSequenceState::Denied);
+            return;
+        }
+        let (columns, cell) = (imp.columns.get(), imp.cell.get());
+        let spacing = (f64::from(SPACING), f64::from(SPACING));
+        let left = content_left(self.width(), columns, cell.0);
+        // A press on a gutter, on the centring margin, or on the empty tail of the last row
+        // is not a press on a card. `cell` is zero until the first allocation, which
+        // `slot_at` also refuses rather than guessing an index from nothing.
+        let Some(index) = slot_at((x - left, y), count, columns, cell, spacing) else {
+            gesture.set_state(gtk::EventSequenceState::Denied);
+            return;
+        };
+        *imp.drag.borrow_mut() = Some(Drag {
+            index,
+            origin: slot(index as f64, columns, cell, spacing),
+            pointer: (0.0, 0.0),
+            scrolled: 0.0,
+            target: index,
+            carrying: false,
+            settle: None,
+            progress: 0.0,
+            animation: None,
+            autoscroll: None,
+        });
+    }
+
+    /// Follows the pointer, once it has gone far enough to mean it.
+    fn update(&self, gesture: &gtk::GestureDrag, dx: f64, dy: f64) {
+        let starting = {
+            let mut held = self.imp().drag.borrow_mut();
+            let Some(drag) = held.as_mut() else {
+                return;
+            };
+            if drag.settle.is_some() {
+                return;
+            }
+            drag.pointer = (dx, dy);
+            if drag.carrying {
+                false
+            } else if self.drag_check_threshold(0, 0, dx as i32, dy as i32) {
+                drag.carrying = true;
+                true
+            } else {
+                return;
+            }
+        };
+        if starting {
+            // Claiming cancels the pressed card's own click gesture, so a drag never opens
+            // the detail dialog. The card also moves to the end of the child list, which is
+            // what puts it above its siblings for both painting and picking.
+            gesture.set_state(gtk::EventSequenceState::Claimed);
+            let index = self.imp().drag.borrow().as_ref().map(|drag| drag.index);
+            if let Some(index) = index {
+                let slots = self.imp().slots.borrow();
+                if let Some(held) = slots.get(index) {
+                    let child = held.child.clone();
+                    child.add_css_class(DRAGGING_CLASS);
+                    drop(slots);
+                    child.insert_before(self, None::<&gtk::Widget>);
+                }
+            }
+        }
+        self.follow_edge(gesture);
+        self.carry();
+    }
+
+    /// Puts the carried card where the pointer is, and moves whatever it displaces.
+    fn carry(&self) {
+        let imp = self.imp();
+        let (columns, cell) = (imp.columns.get(), imp.cell.get());
+        let spacing = (f64::from(SPACING), f64::from(SPACING));
+        let count = imp.slots.borrow().len();
+        let shifts: Vec<(usize, f64)> = {
+            let mut held = imp.drag.borrow_mut();
+            let Some(drag) = held.as_mut() else {
+                return;
+            };
+            if !drag.carrying || drag.settle.is_some() {
+                return;
+            }
+            let (x, y) = drag.at((0.0, 0.0));
+            let centre = (x + cell.0 / 2.0, y + cell.1 / 2.0);
+            let target = drop_index(centre, count, columns, cell, spacing);
+            if target == drag.target {
+                self.queue_allocate();
+                return;
+            }
+            drag.target = target;
+            let from = drag.index;
+            (0..count)
+                .map(|index| (index, shift(index, from, target)))
+                .collect()
+        };
+        for (index, wanted) in shifts {
+            self.animate_offset(index, wanted);
+        }
+        self.queue_allocate();
+    }
+
+    /// Retargets one card's index offset, continuing from wherever it currently is.
+    ///
+    /// The restart is the point. A card half-way out of the way that is asked to come back
+    /// carries on from where it is; putting it back in its old slot and animating again
+    /// would make the grid twitch every time the pointer crossed a boundary.
+    fn animate_offset(&self, index: usize, wanted: f64) {
+        let slots = self.imp().slots.borrow();
+        let Some(held) = slots.get(index) else {
+            return;
+        };
+        if held.target.get() == wanted {
+            return;
+        }
+        held.target.set(wanted);
+        if let Some(running) = held.animation.borrow_mut().take() {
+            running.pause();
+        }
+        let child = held.child.clone();
+        let from = held.offset.get();
+        drop(slots);
+
+        let target = adw::CallbackAnimationTarget::new({
+            let grid = self.downgrade();
+            move |value| {
+                let Some(grid) = grid.upgrade() else {
+                    return;
+                };
+                {
+                    let slots = grid.imp().slots.borrow();
+                    if let Some(held) = slots.iter().find(|held| held.child == child) {
+                        held.offset.set(value);
+                    }
+                }
+                grid.queue_allocate();
+            }
+        });
+        let animation = adw::TimedAnimation::new(self, from, wanted, REORDER_MS, target);
+        animation.set_easing(adw::Easing::EaseOutCubic);
+        animation.play();
+        let slots = self.imp().slots.borrow();
+        if let Some(held) = slots.get(index) {
+            *held.animation.borrow_mut() = Some(animation);
+        }
+    }
+
+    /// Commits the move and lets the released card settle into its slot.
+    fn release(&self) {
+        let imp = self.imp();
+        let Some((from, to)) = ({
+            let mut held = imp.drag.borrow_mut();
+            held.as_mut().and_then(|drag| {
+                if !drag.carrying || drag.settle.is_some() {
+                    return None;
+                }
+                if let Some(autoscroll) = drag.autoscroll.take() {
+                    autoscroll.remove();
+                }
+                Some((drag.index, drag.target))
+            })
+        }) else {
+            self.abandon_drag();
+            return;
+        };
+
+        let (columns, cell) = (imp.columns.get(), imp.cell.get());
+        let spacing = (f64::from(SPACING), f64::from(SPACING));
+        let landing = imp
+            .drag
+            .borrow()
+            .as_ref()
+            .expect("the drag was read above")
+            .at((0.0, 0.0));
+
+        // Committed here rather than on the way: a client that wrote a new order on every
+        // motion event would spend a file write and a D-Bus round trip per pixel.
+        {
+            let mut slots = imp.slots.borrow_mut();
+            let moved = slots.remove(from);
+            slots.insert(to, moved);
+            for held in slots.iter() {
+                held.target.set(0.0);
+                held.offset.set(0.0);
+                if let Some(running) = held.animation.borrow_mut().take() {
+                    running.pause();
+                }
+            }
+        }
+
+        let resting = slot(to as f64, columns, cell, spacing);
+        if landing == resting {
+            self.abandon_drag();
+        } else {
+            self.settle(to, landing);
+        }
+        if from != to
+            && let Some(on_reorder) = imp.on_reorder.borrow().clone()
+        {
+            on_reorder(from, to);
+        }
+    }
+
+    /// Animates the released card from where the pointer left it into its slot.
+    fn settle(&self, index: usize, from: (f64, f64)) {
+        let imp = self.imp();
+        {
+            let mut held = imp.drag.borrow_mut();
+            let Some(drag) = held.as_mut() else {
+                return;
+            };
+            drag.index = index;
+            drag.target = index;
+            drag.settle = Some(from);
+            drag.progress = 0.0;
+        }
+        let target = adw::CallbackAnimationTarget::new({
+            let grid = self.downgrade();
+            move |value| {
+                let Some(grid) = grid.upgrade() else {
+                    return;
+                };
+                if let Some(drag) = grid.imp().drag.borrow_mut().as_mut() {
+                    drag.progress = value;
+                }
+                grid.queue_allocate();
+            }
+        });
+        let animation = adw::TimedAnimation::new(self, 0.0, 1.0, SETTLE_MS, target);
+        animation.set_easing(adw::Easing::EaseOutCubic);
+        animation.connect_done({
+            let grid = self.downgrade();
+            move |_| {
+                if let Some(grid) = grid.upgrade() {
+                    grid.abandon_drag();
+                }
+            }
+        });
+        animation.play();
+        if let Some(drag) = imp.drag.borrow_mut().as_mut() {
+            drag.animation = Some(animation);
+        }
+    }
+
+    /// Ends whatever the grid was doing with a card: a finished settle, an interrupted one,
+    /// or a drag whose cards have been replaced underneath it.
+    fn abandon_drag(&self) {
+        let held = self.imp().drag.borrow_mut().take();
+        if let Some(drag) = held {
+            if let Some(animation) = drag.animation {
+                animation.pause();
+            }
+            if let Some(autoscroll) = drag.autoscroll {
+                autoscroll.remove();
+            }
+        }
+        for held in self.imp().slots.borrow().iter() {
+            held.child.remove_css_class(DRAGGING_CLASS);
+            held.target.set(0.0);
+            held.offset.set(0.0);
+            if let Some(running) = held.animation.borrow_mut().take() {
+                running.pause();
+            }
+        }
+        self.reset_child_order();
+        self.queue_allocate();
+    }
+
+    /// Puts the child list back in slot order, so picking and painting agree with it again.
+    fn reset_child_order(&self) {
+        let mut previous: Option<gtk::Widget> = None;
+        for held in self.imp().slots.borrow().iter() {
+            held.child.insert_after(self, previous.as_ref());
+            previous = Some(held.child.clone());
+        }
+    }
+
+    /// Starts, adjusts or stops the scroll that follows a pointer held near an edge.
+    ///
+    /// Without this the bottom row of a tall grid is unreachable: the pointer cannot leave
+    /// the viewport, and six cards in two columns are taller than the window.
+    fn follow_edge(&self, gesture: &gtk::GestureDrag) {
+        let Some(scroller) = self
+            .ancestor(gtk::ScrolledWindow::static_type())
+            .and_downcast::<gtk::ScrolledWindow>()
+        else {
+            return;
+        };
+        let Some((start_x, start_y)) = gesture.start_point() else {
+            return;
+        };
+        let Some((dx, dy)) = gesture.offset() else {
+            return;
+        };
+        let Some(pointer) = self.compute_point(
+            &scroller,
+            &graphene::Point::new((start_x + dx) as f32, (start_y + dy) as f32),
+        ) else {
+            return;
+        };
+        let rate = autoscroll_rate(f64::from(pointer.y()), f64::from(scroller.height()));
+        let running = self
+            .imp()
+            .drag
+            .borrow()
+            .as_ref()
+            .is_some_and(|drag| drag.autoscroll.is_some());
+        if rate == 0.0 {
+            if running
+                && let Some(drag) = self.imp().drag.borrow_mut().as_mut()
+                && let Some(autoscroll) = drag.autoscroll.take()
+            {
+                autoscroll.remove();
+            }
+            return;
+        }
+        if running {
+            return;
+        }
+        let adjustment = scroller.vadjustment();
+        let last: Cell<Option<i64>> = Cell::new(None);
+        let callback = self.add_tick_callback({
+            let scroller = scroller.clone();
+            move |grid, clock| {
+                let now = clock.frame_time();
+                let elapsed = match last.replace(Some(now)) {
+                    // Microseconds. The first frame of a scroll advances nothing, which is
+                    // one frame of latency and no risk of a jump from a stale clock.
+                    Some(previous) => (now - previous) as f64 / 1_000_000.0,
+                    None => 0.0,
+                };
+                let Some(rate) = grid.edge_rate(&scroller) else {
+                    return glib::ControlFlow::Break;
+                };
+                let before = adjustment.value();
+                let wanted = (before + rate * elapsed)
+                    .clamp(0.0, (adjustment.upper() - adjustment.page_size()).max(0.0));
+                adjustment.set_value(wanted);
+                if let Some(drag) = grid.imp().drag.borrow_mut().as_mut() {
+                    // The card follows the view, so it stays under the pointer instead of
+                    // sliding away from it while the grid moves.
+                    drag.scrolled += wanted - before;
+                }
+                grid.carry();
+                glib::ControlFlow::Continue
+            }
+        });
+        if let Some(drag) = self.imp().drag.borrow_mut().as_mut() {
+            drag.autoscroll = Some(callback);
+        }
+    }
+
+    /// The scroll rate the pointer currently asks for, or `None` when there is no drag left
+    /// to scroll for.
+    fn edge_rate(&self, scroller: &gtk::ScrolledWindow) -> Option<f64> {
+        let carried = {
+            let held = self.imp().drag.borrow();
+            let drag = held.as_ref()?;
+            if !drag.carrying || drag.settle.is_some() {
+                return None;
+            }
+            (
+                drag.origin.0 + drag.pointer.0,
+                drag.origin.1 + drag.pointer.1 + drag.scrolled,
+            )
+        };
+        let cell = self.imp().cell.get();
+        let point = self.compute_point(
+            scroller,
+            &graphene::Point::new(
+                (carried.0 + cell.0 / 2.0) as f32,
+                (carried.1 + cell.1 / 2.0) as f32,
+            ),
+        )?;
+        Some(autoscroll_rate(
+            f64::from(point.y()),
+            f64::from(scroller.height()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CELL: (f64, f64) = (300.0, 200.0);
+    const GAP: (f64, f64) = (12.0, 12.0);
+
+    #[test]
+    fn columns_are_the_most_that_fit_up_to_the_maximum() {
+        assert_eq!(
+            columns(200, 300, 12, 3),
+            1,
+            "a window too narrow for one card still shows one"
+        );
+        assert_eq!(columns(300, 300, 12, 3), 1);
+        assert_eq!(columns(611, 300, 12, 3), 1, "one pixel short of two");
+        assert_eq!(columns(612, 300, 12, 3), 2);
+        assert_eq!(columns(936, 300, 12, 3), 3);
+        assert_eq!(columns(4000, 300, 12, 3), 3, "and never a fourth");
+    }
+
+    #[test]
+    fn whole_slots_lay_out_in_rows() {
+        assert_eq!(slot(0.0, 3, CELL, GAP), (0.0, 0.0));
+        assert_eq!(slot(2.0, 3, CELL, GAP), (624.0, 0.0));
+        assert_eq!(slot(3.0, 3, CELL, GAP), (0.0, 212.0));
+        assert_eq!(slot(4.0, 3, CELL, GAP), (312.0, 212.0));
+    }
+
+    #[test]
+    fn a_half_step_across_the_end_of_a_row_travels_there() {
+        let (x, y) = slot(2.5, 3, CELL, GAP);
+        let (end_x, end_y) = slot(2.0, 3, CELL, GAP);
+        let (next_x, next_y) = slot(3.0, 3, CELL, GAP);
+        assert_eq!((x, y), ((end_x + next_x) / 2.0, (end_y + next_y) / 2.0));
+        assert!(
+            y > 0.0 && y < 212.0,
+            "a card crossing rows is between them, not on one"
+        );
+    }
+
+    #[test]
+    fn the_drop_index_is_the_slot_the_centre_is_over() {
+        // Five cards in three columns: 0, 1 and 2 on the first row, 3 and 4 on the second.
+        let index = |x: f64, y: f64| drop_index((x, y), 5, 3, CELL, GAP);
+        assert_eq!(index(10.0, 10.0), 0);
+        assert_eq!(index(311.0, 10.0), 0, "still inside the first column");
+        assert_eq!(index(313.0, 10.0), 1, "over the second");
+        assert_eq!(index(700.0, 10.0), 2);
+        assert_eq!(index(10.0, 300.0), 3);
+        assert_eq!(index(700.0, 300.0), 4, "clamped to the last card");
+    }
+
+    #[test]
+    fn the_drop_index_clamps_rather_than_running_off_the_grid() {
+        assert_eq!(drop_index((-500.0, -500.0), 5, 3, CELL, GAP), 0);
+        assert_eq!(drop_index((5000.0, 5000.0), 5, 3, CELL, GAP), 4);
+        assert_eq!(drop_index((0.0, 0.0), 0, 3, CELL, GAP), 0);
+    }
+
+    #[test]
+    fn a_press_only_picks_up_a_card_it_actually_landed_on() {
+        // Five cards in three columns, so the sixth slot of the second row is empty.
+        let at = |x: f64, y: f64| slot_at((x, y), 5, 3, CELL, GAP);
+        assert_eq!(at(299.0, 199.0), Some(0), "its far corner");
+        assert_eq!(at(299.0, 205.0), None, "one row's gutter below it");
+        assert_eq!(at(305.0, 10.0), None, "the gutter between two cards");
+        assert_eq!(at(10.0, 205.0), None, "the gutter between two rows");
+        assert_eq!(at(700.0, 300.0), None, "the empty tail of the last row");
+        assert_eq!(at(5000.0, 10.0), None, "past the last column");
+        assert_eq!(at(-10.0, 10.0), None, "the centring margin to the left");
+    }
+
+    #[test]
+    fn a_press_before_the_first_allocation_picks_up_nothing() {
+        assert_eq!(slot_at((10.0, 10.0), 5, 1, (0.0, 0.0), GAP), None);
+        assert_eq!(slot_at((10.0, 10.0), 0, 3, CELL, GAP), None);
+    }
+
+    #[test]
+    fn moving_forwards_pulls_everything_between_back_one() {
+        let shifts: Vec<f64> = (0..5).map(|index| shift(index, 1, 3)).collect();
+        assert_eq!(shifts, [0.0, 0.0, -1.0, -1.0, 0.0]);
+    }
+
+    #[test]
+    fn moving_backwards_pushes_everything_between_forward_one() {
+        let shifts: Vec<f64> = (0..5).map(|index| shift(index, 3, 1)).collect();
+        assert_eq!(shifts, [0.0, 1.0, 1.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn a_card_dropped_where_it_started_moves_nothing() {
+        let shifts: Vec<f64> = (0..5).map(|index| shift(index, 2, 2)).collect();
+        assert_eq!(shifts, [0.0; 5]);
+    }
+
+    #[test]
+    fn the_stylesheet_lifts_the_widget_the_drag_actually_marks() {
+        // The class goes on the slot, and the rule that makes a carried card opaque has to
+        // be written against the slot too. It was written against the card once, matched
+        // nothing, and the only symptom was a translucent card mid-drag — which no test
+        // reaches and no warning reports.
+        let selector = format!(".{SLOT_CLASS}.{DRAGGING_CLASS} >");
+        assert!(
+            crate::style::STYLE.contains(&selector),
+            "the stylesheet has to select {selector}"
+        );
+    }
+
+    #[test]
+    fn the_block_of_columns_is_centred_in_the_allocation() {
+        assert_eq!(content_left(1000, 3, 300.0), 38.0);
+        assert_eq!(content_left(312, 1, 300.0), 6.0);
+        assert_eq!(
+            content_left(200, 1, 300.0),
+            0.0,
+            "a squeezed card starts at the edge rather than off it"
+        );
+    }
+
+    #[test]
+    fn the_view_only_follows_a_pointer_in_one_of_the_two_edge_bands() {
+        assert_eq!(autoscroll_rate(300.0, 600.0), 0.0, "the middle is still");
+        assert!(autoscroll_rate(10.0, 600.0) < 0.0, "near the top, upwards");
+        assert!(autoscroll_rate(590.0, 600.0) > 0.0, "near the bottom, down");
+        assert_eq!(
+            autoscroll_rate(0.0, 600.0),
+            -AUTOSCROLL_RATE,
+            "the very edge is the fastest it goes"
+        );
+        assert_eq!(
+            autoscroll_rate(10.0, 80.0),
+            0.0,
+            "a viewport with no middle never scrolls itself"
+        );
+    }
+}

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -4,8 +4,9 @@
 //! no database: everything on screen arrived from `tidemarkd` over the session bus, and
 //! `scripts/check-layering.sh` is what keeps that true as the program grows.
 //!
-//! The pieces: `bus` talks to the daemon, `window` owns the grid, `card` draws one account,
-//! `provider_settings` is the dialog that adds, edits and removes them,
+//! The pieces: `bus` talks to the daemon, `window` owns the order the cards are in,
+//! `grid` lays them out and lets the user drag them into a different one, `card` draws one
+//! account, `provider_settings` is the dialog that adds, edits and removes them,
 //! `bar` draws the quota bar and its pace mark, `mark` finds the provider's own logo,
 //! `model` decides what order things go in, `format` decides what they say, and `style`
 //! adds the handful of CSS rules libadwaita does not already provide.
@@ -16,6 +17,7 @@ mod card;
 mod chart;
 mod detail;
 mod format;
+mod grid;
 mod mark;
 mod model;
 mod provider_settings;

--- a/crates/tidemark/src/model.rs
+++ b/crates/tidemark/src/model.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use tidemark_types::{ProviderDefinition, ProviderStatus, Snapshot, Window, WindowLength};
+use tidemark_types::{ProviderDefinition, Snapshot, Window, WindowLength};
 
 /// The catalog's spelling of each provider's name, by slug.
 pub type Titles = BTreeMap<String, String>;
@@ -53,30 +53,24 @@ pub fn ordered_windows(snapshot: &Snapshot) -> Vec<Window> {
     windows
 }
 
-/// How much attention an account is asking for, as the fraction of its dominant window that
-/// is gone. `None` for an account with no reading at all.
+/// The positions `slugs` take when arranged into `order`.
 ///
-/// This is only half of what `CONTEXT.md` § Interface eventually wants — the other half is
-/// the user's own order, which Step 15 persists to config and which will replace this as
-/// the outer sort. Until then the grid sorts itself, and an account that has never answered
-/// sits at the end rather than at the top, since a card with no numbers on it is not urgent,
-/// it is just empty.
-pub fn urgency(status: &ProviderStatus) -> Option<f64> {
-    status
-        .to_snapshot()?
-        .dominant_window()
-        .map(|window| window.used_percent)
-}
-
-/// Orders two cards for the grid: most consumed first, accounts with no reading last, ties
-/// broken by slug so that the grid does not shuffle between updates.
-pub fn compare(left: &ProviderStatus, right: &ProviderStatus) -> std::cmp::Ordering {
-    let key = |status: &ProviderStatus| urgency(status).unwrap_or(-1.0);
-    key(right)
-        .partial_cmp(&key(left))
-        .unwrap_or(std::cmp::Ordering::Equal)
-        .then_with(|| left.provider.cmp(&right.provider))
-        .then_with(|| left.account.cmp(&right.account))
+/// The user's order is the only order there is — nothing sorts the grid by urgency or by
+/// anything else, because an order that rearranged itself would not be the user's. So this
+/// is the whole of the rule: what the daemon published, applied to what the window holds.
+///
+/// Anything `order` does not name keeps its relative place at the end. That is a real case
+/// rather than defensiveness: the sequence arrives from another process and may have been
+/// sent before an account this client already knows about was added.
+pub fn arrangement(slugs: &[String], order: &[String]) -> Vec<usize> {
+    let mut positions: Vec<usize> = (0..slugs.len()).collect();
+    positions.sort_by_key(|index| {
+        order
+            .iter()
+            .position(|slug| *slug == slugs[*index])
+            .unwrap_or(order.len())
+    });
+    positions
 }
 
 #[cfg(test)]
@@ -103,12 +97,6 @@ mod tests {
             windows,
             details: Vec::new(),
         }
-    }
-
-    fn status(provider: &str, windows: Vec<Window>) -> ProviderStatus {
-        let mut status = ProviderStatus::pending(&ProviderId::new(provider), &AccountId::default());
-        status.set_reading(&snapshot(windows));
-        status
     }
 
     #[test]
@@ -164,39 +152,27 @@ mod tests {
     }
 
     #[test]
-    fn the_fullest_account_is_the_first_card() {
-        let mut cards = [
-            status("kimi", vec![window(Some(18_000), 10.0)]),
-            status("zai", vec![window(Some(18_000), 90.0)]),
-        ];
-        cards.sort_by(compare);
-        assert_eq!(cards[0].provider, "zai");
+    fn the_published_order_is_the_order_the_cards_take() {
+        let held = ["kimi".to_owned(), "zai".to_owned(), "claude".to_owned()];
+        let order = ["claude".to_owned(), "kimi".to_owned(), "zai".to_owned()];
+        assert_eq!(arrangement(&held, &order), [2, 0, 1]);
     }
 
     #[test]
-    fn an_account_with_nothing_to_show_sorts_last_rather_than_first() {
-        let waiting = ProviderStatus::pending(
-            &ProviderId::new("aaa-first-alphabetically"),
-            &AccountId::default(),
-        );
-        let mut cards = [waiting, status("zai", vec![window(Some(18_000), 0.0)])];
-        cards.sort_by(compare);
+    fn an_account_the_order_does_not_name_keeps_its_place_at_the_end() {
+        let held = ["kimi".to_owned(), "zai".to_owned(), "claude".to_owned()];
+        let order = ["claude".to_owned()];
         assert_eq!(
-            cards[0].provider, "zai",
-            "0% of a real reading outranks no reading at all"
+            arrangement(&held, &order),
+            [2, 0, 1],
+            "the unnamed accounts stay in the order they were already in"
         );
     }
 
     #[test]
-    fn equally_urgent_accounts_keep_a_stable_order() {
-        let mut cards = [
-            status("zai", vec![window(Some(18_000), 50.0)]),
-            status("codex", vec![window(Some(18_000), 50.0)]),
-        ];
-        cards.sort_by(compare);
-        let first = cards[0].provider.clone();
-        cards.sort_by(compare);
-        assert_eq!(cards[0].provider, first);
-        assert_eq!(first, "codex");
+    fn an_empty_order_moves_nothing() {
+        let held = ["kimi".to_owned(), "zai".to_owned()];
+        assert_eq!(arrangement(&held, &[]), [0, 1]);
+        assert!(arrangement(&[], &["zai".to_owned()]).is_empty());
     }
 }

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -7,20 +7,22 @@
 //! card, which `.card` deliberately does not set because it does not know what is going in
 //! it, and the padding around the credential pill, for the same reason.
 //!
-//! # The hover
+//! # The hover, and the lift
 //!
-//! `GtkFlowBoxChild` tints its own allocation, which is a square behind a card with rounded
-//! corners: the tint shows in the four corners as a hard edge around them. So the child's
-//! tint is switched off and the card is raised instead — two pixels and a soft shadow, the
-//! platform's own idea of an elevated surface, and nothing that repaints text.
+//! A card raises on hover — two pixels and a soft shadow, the platform's own idea of an
+//! elevated surface, and nothing that repaints text. It is `translateY` and not `scale`
+//! because scaling a widget resamples the text in it, and a card is mostly text.
 //!
-//! The `:hover` is matched on the child rather than on the card, deliberately: the child
-//! keeps its allocation while the card inside it moves, so a pointer resting near the lower
-//! edge does not fall outside the widget it just raised and start it flickering.
+//! **The `:hover` is matched on the slot around the card and applied to the card inside
+//! it.** A CSS transform moves what GTK picks, so a card that lifted itself out from under
+//! the pointer would flicker; the slot keeps its allocation while the card inside it moves.
+//! That slot used to be a `GtkFlowBoxChild`, which also had to be told not to tint its own
+//! square allocation behind a card with rounded corners. An `AdwBin` paints nothing, so
+//! only the hover rule is left.
 //!
-//! It is `translateY` and not `scale` because scaling a widget resamples the text in it, and
-//! a card is mostly text. This is the one place where the interface says "you can click
-//! this" before Step 14 makes the click do anything.
+//! A card being dragged is lifted further and holds still: the hover transform is taken off
+//! it, because it is already off the surface and because the grid is moving it by
+//! allocation rather than by transform.
 //!
 //! `alpha(currentColor, …)` is what keeps the chip theme-aware: the background is derived
 //! from whatever colour the tone class put on the label, so a warning chip and an error
@@ -39,16 +41,27 @@ pub(crate) const STYLE: &str = "
     transition: transform 150ms ease-out, box-shadow 150ms ease-out;
 }
 
-/* The grid's children are the cards themselves, so the hover belongs to the card and its
-   rounded corners; left alone, GtkFlowBoxChild tints its own square allocation and the
-   corners of the card get a visible hard edge around them. */
-.quota-grid > flowboxchild:hover {
-    background: none;
-}
-
-.quota-grid > flowboxchild:hover > .quota-card {
+/* The slot keeps the pointer while the card inside it moves. */
+.quota-grid > .quota-slot:hover > .quota-card {
     transform: translateY(-2px);
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.18), 0 8px 20px 0 rgba(0, 0, 0, 0.34);
+}
+
+/* Held by the pointer: opaque, further off the surface, and not offset, because the grid is
+   already carrying it.
+
+   The background is the point. `.card` takes `@card_bg_color`, which in the dark style is
+   8% white *over whatever is behind it* — correct for a card lying on the window, and wrong
+   for one being carried over its neighbours, which then show through it. A lifted card is
+   opaque, and `@popover_bg_color` is the platform's own name for a surface floating above
+   the content rather than a colour of our invention. The foreground is deliberately left
+   alone: the bar's track and its pace mark take the inherited text colour, and changing it
+   would make them shift tone for the length of a drag. */
+.quota-grid > .quota-slot.dragging > .quota-card,
+.quota-grid > .quota-slot:hover.dragging > .quota-card {
+    background-color: @popover_bg_color;
+    transform: none;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.24), 0 16px 36px 0 rgba(0, 0, 0, 0.44);
 }
 
 .quota-bar {

--- a/crates/tidemark/src/tray.rs
+++ b/crates/tidemark/src/tray.rs
@@ -74,20 +74,18 @@ impl Entry {
     }
 }
 
-/// The accounts as the menu lists them: fullest first, and never inventing a number.
+/// The accounts as the menu lists them: the order the grid is in, which is the order the
+/// user dragged the cards into.
 ///
-/// The order is [`model::compare`], the same one the grid sorts by, so the panel and the
-/// window do not disagree about which account is the worrying one. The percentage is of
-/// [`tidemark_types::Snapshot::dominant_window`] — the shortest window — which is the same
-/// rule the card leads with.
+/// It sorts nothing. The window hands over its cards in the order they are on screen, and a
+/// panel that applied a rule of its own would be a second opinion about an order the user
+/// set by hand. The percentage is of [`tidemark_types::Snapshot::dominant_window`] — the
+/// shortest window — which is the same rule the card leads with.
 ///
 /// An account whose last poll did not produce a reading says what [`format::chip`] says on
 /// its card, so the two never spell one situation two ways.
 pub fn entries(statuses: &[ProviderStatus], titles: &model::Titles) -> Vec<Entry> {
-    let mut ordered: Vec<&ProviderStatus> = statuses.iter().collect();
-    ordered.sort_by(|left, right| model::compare(left, right));
-
-    ordered
+    statuses
         .iter()
         .map(|status| Entry {
             label: label(statuses, status, titles),
@@ -132,7 +130,10 @@ fn label(all: &[ProviderStatus], status: &ProviderStatus, titles: &model::Titles
 /// so a rate-limited account that has numbers shows them, and the chip is what says the
 /// numbers are not fresh. Only an account with no reading at all falls back to the chip.
 fn value(status: &ProviderStatus) -> String {
-    match model::urgency(status) {
+    let dominant = status
+        .to_snapshot()
+        .and_then(|snapshot| snapshot.dominant_window().map(|window| window.used_percent));
+    match dominant {
         Some(used) => present::percent(used),
         None => format::chip(status)
             .map(|chip| chip.text)
@@ -436,14 +437,18 @@ mod tests {
     }
 
     #[test]
-    fn the_menu_is_in_the_same_order_as_the_grid() {
+    fn the_menu_is_in_the_order_it_was_given_and_not_one_of_its_own() {
         let statuses = [
             reading("kimi", "default", vec![window(18_000, 10.0)]),
             reading("zai", "default", vec![window(18_000, 90.0)]),
         ];
         let rows = entries(&statuses, &model::Titles::new());
-        assert_eq!(rows[0].line(), "Z.ai — 90%");
-        assert_eq!(rows[1].line(), "Kimi — 10%");
+        assert_eq!(
+            rows[0].line(),
+            "Kimi — 10%",
+            "the grid's order is the user's, and the panel does not have an opinion"
+        );
+        assert_eq!(rows[1].line(), "Z.ai — 90%");
     }
 
     #[test]
@@ -477,7 +482,7 @@ mod tests {
         let lines: Vec<String> = rows.iter().map(Entry::line).collect();
         assert_eq!(
             lines,
-            ["Z.ai (work) — 90%", "Kimi — 50%", "Z.ai (home) — 10%",]
+            ["Z.ai (work) — 90%", "Z.ai (home) — 10%", "Kimi — 50%"]
         );
     }
 

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -1,11 +1,10 @@
 //! The window: a grid of cards, and the two things that can be there instead of it.
 //!
-//! `GtkFlowBox` does the columns, between one and three by width, as `CONTEXT.md`
-//! § Interface asks. Its known cost is the last row: with four cards in a three-wide grid,
-//! the fourth sits alone. That is accepted rather than papered over — a filler card would
-//! be an invitation to click on nothing — while *within* a row the heights are equalised,
-//! which `GtkFlowBox` does for free by stretching every child to the tallest, and which the
-//! card turns into something deliberate by pinning its footer to the bottom.
+//! The cards are in the order the user put them in and nothing else ever changes it: the
+//! daemon publishes the sequence, a drag on the grid asks it to publish a different one,
+//! and a new account goes on the end. [`crate::grid::CardGrid`] does the columns and the
+//! drag; this module owns the vector the sequence applies to and is the only thing that
+//! talks to the daemon about it.
 //!
 //! The window is also where "updates without user action" is made true: statuses arrive on
 //! a signal, and a timer redraws the parts that depend on the clock rather than on new
@@ -13,8 +12,6 @@
 //! changes.
 
 use std::cell::RefCell;
-use std::cmp::Ordering;
-
 use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
@@ -24,6 +21,7 @@ use tidemark_types::{ProviderDefinition, ProviderStatus, Timestamp};
 use crate::bus::{self, DaemonProxy, Update};
 use crate::card::Card;
 use crate::detail::DetailDialog;
+use crate::grid::CardGrid;
 use crate::model;
 use crate::provider_settings::ProviderSettings;
 use crate::tray::{self, Tray};
@@ -82,10 +80,12 @@ pub struct MainWindow {
     window: adw::ApplicationWindow,
     stack: gtk::Stack,
     message: adw::StatusPage,
-    grid: gtk::FlowBox,
+    grid: CardGrid,
     refresh: gtk::Button,
     release: gtk::Button,
     providers: gtk::Button,
+    /// The cards in the order they are on screen. The one order this process has: the tray
+    /// menu and the settings list are both drawn from it, and it is what a drag permutes.
     cards: RefCell<Vec<Rc<Card>>>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     daemon: RefCell<Option<DaemonProxy<'static>>>,
@@ -105,26 +105,13 @@ impl MainWindow {
     /// accepted the tray icon; without one it exits rather than leaving an invisible
     /// process behind.
     pub fn present(app: &adw::Application, background: bool) {
-        let grid = gtk::FlowBox::builder()
-            .min_children_per_line(1)
-            .max_children_per_line(3)
-            .homogeneous(true)
-            .row_spacing(12)
-            .column_spacing(12)
-            .margin_top(12)
-            .margin_bottom(12)
-            .margin_start(12)
-            .margin_end(12)
-            .valign(gtk::Align::Start)
-            // Centred rather than stretched: `GtkFlowBox` gives every child the width of
-            // one column whatever the window is doing, so a filled row and a half-empty one
-            // both sit under the middle of the window instead of hugging its left edge.
-            .halign(gtk::Align::Center)
-            // Cards are not a list to pick from; the click that will matter opens a detail
-            // dialog, and that is the card's own gesture rather than a selection.
-            .selection_mode(gtk::SelectionMode::None)
-            .css_classes(["quota-grid"])
-            .build();
+        let grid = CardGrid::new();
+        grid.set_margin_top(12);
+        grid.set_margin_bottom(12);
+        grid.set_margin_start(12);
+        grid.set_margin_end(12);
+        grid.set_valign(gtk::Align::Start);
+        grid.add_css_class("quota-grid");
 
         let scroller = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Never)
@@ -192,7 +179,7 @@ impl MainWindow {
             tray: RefCell::new(None),
         });
 
-        main.install_sort();
+        main.connect_reorder();
         main.connect_refresh_button();
         main.connect_update_button();
         main.connect_providers_button();
@@ -260,6 +247,7 @@ impl MainWindow {
             }
             Update::Changed(status) => self.show_one(status),
             Update::Removed { provider, account } => self.show_removed(&provider, &account),
+            Update::Reordered(providers) => self.show_order(&providers),
             Update::Available(version) => self.show_update(&version),
             Update::Waiting(reason) => {
                 *self.daemon.borrow_mut() = None;
@@ -303,7 +291,7 @@ impl MainWindow {
                 "Add a provider to start tracking your quota.",
             );
             self.cards.borrow_mut().clear();
-            self.grid.remove_all();
+            self.grid.clear();
             self.update_provider_settings();
             self.update_detail_from_statuses(&[]);
             return;
@@ -315,12 +303,13 @@ impl MainWindow {
             .map(|status| self.make_card(status, now))
             .collect();
 
-        self.grid.remove_all();
+        self.grid.clear();
         *self.cards.borrow_mut() = cards.clone();
         for card in &cards {
+            // Appended in the sequence the daemon published, which is the sequence the user
+            // arranged: there is nothing left to sort afterwards.
             self.grid.append(card.widget());
         }
-        self.grid.invalidate_sort();
         self.stack.set_visible_child_name(PAGE_GRID);
         self.update_provider_settings();
         self.update_detail_from_statuses(&statuses);
@@ -370,10 +359,6 @@ impl MainWindow {
                 self.grid.append(card.widget());
             }
         }
-
-        // The order may have changed with the numbers; the grid re-sorts what it already
-        // holds rather than being rebuilt.
-        self.grid.invalidate_sort();
         self.stack.set_visible_child_name(PAGE_GRID);
         self.update_provider_settings();
         if let Some(dialog) = self.detail_dialog.get()
@@ -383,7 +368,7 @@ impl MainWindow {
         }
     }
 
-    /// Everything the daemon has said, in the order the cards were built.
+    /// Everything the daemon has said, in the order the cards are on screen.
     fn statuses(&self) -> Vec<ProviderStatus> {
         self.cards
             .borrow()
@@ -489,26 +474,98 @@ impl MainWindow {
         });
     }
 
-    /// Teaches the grid the order the cards go in, once.
+    /// Mirrors a completed drag into the card vector and asks the daemon to keep it.
     ///
-    /// Sorting rather than re-inserting: `GtkFlowBox` keeps its children where they are and
-    /// only changes their positions, so a card that overtakes another does not lose focus,
-    /// its tooltip, or the pointer that happens to be over it. Rebuilding the grid instead
-    /// means re-parenting widgets a disposed wrapper still holds, which GTK reports as a
-    /// critical and which costs a redraw of everything on every poll.
-    fn install_sort(self: &Rc<Self>) {
+    /// The move is applied here first and sent afterwards. A grid that waited for a round
+    /// trip before showing where the card landed would feel broken on a loaded machine, and
+    /// the daemon's answer changes nothing when it succeeds: it echoes the same sequence
+    /// back as `OrderChanged`, which [`MainWindow::show_order`] recognises as a no-op.
+    ///
+    /// A refusal is the interesting case. It means the configured set moved underneath the
+    /// drag — an account added or removed while it was in the air — so the cards go back to
+    /// what the daemon actually has rather than staying somewhere nobody asked for.
+    fn connect_reorder(self: &Rc<Self>) {
         let weak: Weak<Self> = Rc::downgrade(self);
-        self.grid.set_sort_func(move |left, right| {
+        self.grid.connect_reordered(move |from, to| {
             let Some(main) = weak.upgrade() else {
-                return Ordering::Equal.into();
+                return;
             };
-            let cards = main.cards.borrow();
-            let of = |child: &gtk::FlowBoxChild| cards.iter().find(|card| card.widget() == child);
-            match (of(left), of(right)) {
-                (Some(left), Some(right)) => model::compare(&left.status(), &right.status()).into(),
-                _ => Ordering::Equal.into(),
+            {
+                let mut cards = main.cards.borrow_mut();
+                if from >= cards.len() || to >= cards.len() {
+                    return;
+                }
+                let moved = cards.remove(from);
+                cards.insert(to, moved);
             }
+            main.update_provider_settings();
+            main.update_tray();
+
+            let Some(proxy) = main.daemon.borrow().clone() else {
+                return;
+            };
+            let order: Vec<String> = main
+                .cards
+                .borrow()
+                .iter()
+                .map(|card| card.status().provider)
+                .collect();
+            let weak = Rc::downgrade(&main);
+            glib::spawn_future_local(async move {
+                if let Err(error) = proxy.set_order(&order).await {
+                    tracing::warn!(%error, "the daemon refused the new card order");
+                    let Some(main) = weak.upgrade() else {
+                        return;
+                    };
+                    match proxy.get_status().await {
+                        Ok(statuses) => main.show_order(
+                            &statuses
+                                .iter()
+                                .map(|status| status.provider.clone())
+                                .collect::<Vec<String>>(),
+                        ),
+                        Err(error) => {
+                            tracing::warn!(%error, "and did not say what the order actually is")
+                        }
+                    }
+                }
+            });
         });
+    }
+
+    /// Puts the cards in the order the daemon published.
+    ///
+    /// Ordering by provider slug, because that is the identity `config.toml` has: two
+    /// accounts of one provider — which v1 does not create — keep their relative places.
+    fn show_order(&self, providers: &[String]) {
+        let slugs: Vec<String> = self
+            .cards
+            .borrow()
+            .iter()
+            .map(|card| card.status().provider)
+            .collect();
+        let positions = model::arrangement(&slugs, providers);
+        if positions.iter().enumerate().all(|(at, held)| at == *held) {
+            return;
+        }
+        {
+            let mut cards = self.cards.borrow_mut();
+            let mut held: Vec<Option<Rc<Card>>> = cards.drain(..).map(Some).collect();
+            for position in positions {
+                if let Some(card) = held[position].take() {
+                    cards.push(card);
+                }
+            }
+        }
+        let order: Vec<gtk::Widget> = self
+            .cards
+            .borrow()
+            .iter()
+            .map(|card| card.widget().clone())
+            .collect();
+        self.grid.set_order(&order);
+        self.update_provider_settings();
+        self.update_tray();
     }
 
     /// Shows the message page instead of the grid.

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -50,6 +50,11 @@ pub enum Publication {
         /// Stable account name.
         account: String,
     },
+    /// Put the published accounts in this provider order.
+    ///
+    /// A sequence rather than a status, because that is what changed: the readings are
+    /// exactly as they were, and a client redrawing a grid needs the positions.
+    Reordered(Vec<String>),
 }
 
 /// What the D-Bus interface asks the loop to do.
@@ -106,6 +111,13 @@ pub enum Command {
         window: String,
         /// Whether the user wants to hear about it.
         enabled: bool,
+        /// Completion sent after persistence and in-memory state agree.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Reorder the configured providers, in the same queue as topology writes.
+    SetOrder {
+        /// Every configured provider slug, in the order the user put them in.
+        providers: Vec<String>,
         /// Completion sent after persistence and in-memory state agree.
         reply: oneshot::Sender<Result<(), String>>,
     },
@@ -422,6 +434,37 @@ impl Engine {
         Ok(())
     }
 
+    /// Puts the configured providers in the order the user dragged them into.
+    ///
+    /// The accounts vector is reordered as well as the file, so a live reorder and a
+    /// restart produce the same sequence: this vector is what [`Engine::announce`] walks,
+    /// and a daemon that persisted one order and kept publishing another would disagree
+    /// with itself for the rest of the session.
+    ///
+    /// Nothing about polling changes. An account keeps its `due` time and its backoff — a
+    /// card moving on a grid is not news about a credential.
+    pub async fn set_order(&mut self, providers: &[String]) -> Result<(), String> {
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        config
+            .set_provider_order(providers)
+            .map_err(|error| error.to_string())?;
+
+        self.accounts.sort_by_key(|account| {
+            providers
+                .iter()
+                .position(|slug| slug == account.provider.as_str())
+                // An account for a provider the order does not name cannot happen while
+                // the file is the only source of both, and sorting it to the end is what
+                // the grid does with one anyway.
+                .unwrap_or(providers.len())
+        });
+        let _ = self
+            .updates
+            .send(Publication::Reordered(providers.to_vec()))
+            .await;
+        Ok(())
+    }
+
     /// Changes one provider option as a serialized configuration transaction.
     pub async fn set_option(
         &mut self,
@@ -521,6 +564,10 @@ impl Engine {
                         let result = self
                             .set_window_notify(&provider, &account, &window, enabled)
                             .await;
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::SetOrder { providers, reply }) => {
+                        let result = self.set_order(&providers).await;
                         let _ = reply.send(result);
                     }
                     Some(Command::CurrentSegment { provider, account, window, reply }) => {
@@ -1383,6 +1430,30 @@ mod tests {
         ));
         let config = Config::at(harness.config_path.clone()).expect("parses");
         assert!(config.providers().expect("readable").is_empty());
+    }
+
+    #[tokio::test]
+    async fn reordering_persists_the_array_and_moves_the_accounts_with_it() {
+        let mut harness = Harness::configured("runtime-order", &["kimi", "zai", "claude"]).await;
+        let order = vec!["claude".to_owned(), "kimi".to_owned(), "zai".to_owned()];
+
+        harness.engine.set_order(&order).await.expect("reordered");
+
+        let slugs: Vec<&str> = harness
+            .engine
+            .accounts()
+            .iter()
+            .map(|account| account.provider().as_str())
+            .collect();
+        assert_eq!(
+            slugs,
+            ["claude", "kimi", "zai"],
+            "announce walks this vector, so it has to agree with the file"
+        );
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(config.providers().expect("readable"), order);
+        let publication = harness.updates.recv().await.expect("announced");
+        assert!(matches!(publication, Publication::Reordered(published) if published == order));
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -169,6 +169,12 @@ async fn run() -> Result<(), Box<dyn Error>> {
                             tracing::warn!(%error, "could not announce a removal");
                         }
                     }
+                    Publication::Reordered(providers) => {
+                        published.reorder(&providers).await;
+                        if let Err(error) = Daemon::order_changed(&emitter, providers).await {
+                            tracing::warn!(%error, "could not announce a reorder");
+                        }
+                    }
                 }
             }
         }

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -81,6 +81,22 @@ impl Published {
         Some(statuses.remove(index))
     }
 
+    /// Puts the accounts in this provider order.
+    ///
+    /// Applied to the shared vector rather than left to the next `GetStatus` to sort,
+    /// because there is nothing for a client to sort by: the order is the user's and this
+    /// is where it is kept. An account whose provider the order does not name keeps its
+    /// place at the end — the sort is stable — so a sequence that has raced a removal
+    /// leaves the survivors alone instead of shuffling them.
+    pub async fn reorder(&self, providers: &[String]) {
+        self.0.write().await.sort_by_key(|status| {
+            providers
+                .iter()
+                .position(|slug| *slug == status.provider)
+                .unwrap_or(providers.len())
+        });
+    }
+
     /// Everything currently known.
     pub async fn all(&self) -> Vec<ProviderStatus> {
         self.0.read().await.clone()
@@ -663,6 +679,50 @@ impl Daemon {
         Ok(())
     }
 
+    /// Puts the configured providers in the order a client's user arranged them in.
+    ///
+    /// The order is the `providers` array in `config.toml` — the same array that says which
+    /// accounts exist, because it is already ordered and `AddProvider` already appends to
+    /// it. A second array beside it would only raise the question of what the position of a
+    /// provider named in one and not the other is.
+    ///
+    /// The list must name every configured provider exactly once. A client whose idea of
+    /// the set has been overtaken by an add or a remove is told so rather than having the
+    /// daemon guess: it can read `GetStatus` again and it will be sent `OrderChanged`
+    /// whenever anybody else succeeds.
+    ///
+    /// The identity is the provider slug and not the provider/account pair, because that
+    /// is the only identity the settings file has. v1 configures one `default` account per
+    /// provider; multi-account changes the shape of that array, and this call with it.
+    async fn set_order(&self, providers: Vec<String>) -> fdo::Result<()> {
+        let configured: Vec<String> = self
+            .statuses
+            .all()
+            .await
+            .into_iter()
+            .map(|status| status.provider)
+            .collect();
+        let mut wanted = providers.clone();
+        wanted.sort_unstable();
+        wanted.dedup();
+        let mut held = configured.clone();
+        held.sort_unstable();
+        held.dedup();
+        if wanted.len() != providers.len() || wanted != held {
+            return Err(fdo::Error::InvalidArgs(
+                "the order must name every configured provider exactly once".into(),
+            ));
+        }
+
+        self.config_request(|reply| Command::SetOrder {
+            providers: providers.clone(),
+            reply,
+        })
+        .await?;
+        tracing::info!(?providers, "card order changed");
+        Ok(())
+    }
+
     /// The daemon's version, so a client can tell what it is talking to.
     #[zbus(property(emits_changed_signal = "false"))]
     async fn version(&self) -> String {
@@ -683,6 +743,17 @@ impl Daemon {
         emitter: &SignalEmitter<'_>,
         provider: &str,
         account: &str,
+    ) -> zbus::Result<()>;
+
+    /// The configured providers are now in this order.
+    ///
+    /// Its own signal rather than a burst of `ProviderChanged`, because a status has no
+    /// position in it: a client holding cards needs the sequence, not the readings again.
+    /// `GetStatus` answers in the same order from the moment this is emitted.
+    #[zbus(signal)]
+    pub async fn order_changed(
+        emitter: &SignalEmitter<'_>,
+        providers: Vec<String>,
     ) -> zbus::Result<()>;
 
     /// Availability of a newer published release changed; empty means there is none.
@@ -844,6 +915,48 @@ mod tests {
 
         assert!(published.remove("zai", "default").await.is_some());
         assert_eq!(published.all().await[0].provider, "kimi");
+    }
+
+    #[tokio::test]
+    async fn a_reorder_moves_the_published_accounts_into_that_sequence() {
+        let published = Published::default();
+        published.upsert(status("zai")).await;
+        published.upsert(status("kimi")).await;
+        published.upsert(status("claude")).await;
+
+        published
+            .reorder(&["claude".into(), "zai".into(), "kimi".into()])
+            .await;
+
+        let providers: Vec<String> = published
+            .all()
+            .await
+            .into_iter()
+            .map(|status| status.provider)
+            .collect();
+        assert_eq!(providers, ["claude", "zai", "kimi"]);
+    }
+
+    #[tokio::test]
+    async fn a_reorder_leaves_an_account_it_does_not_name_at_the_end() {
+        let published = Published::default();
+        published.upsert(status("zai")).await;
+        published.upsert(status("kimi")).await;
+        published.upsert(status("claude")).await;
+
+        published.reorder(&["claude".into()]).await;
+
+        let providers: Vec<String> = published
+            .all()
+            .await
+            .into_iter()
+            .map(|status| status.provider)
+            .collect();
+        assert_eq!(
+            providers,
+            ["claude", "zai", "kimi"],
+            "the unnamed survivors keep the order they were in"
+        );
     }
 
     fn key_account(provider: &str) -> ProviderStatus {
@@ -1624,6 +1737,51 @@ mod tests {
             .await
             .expect("setting task did not panic")
             .expect("engine accepted setting");
+    }
+
+    #[tokio::test]
+    async fn an_order_that_is_not_the_configured_set_is_refused_before_the_engine() {
+        let (daemon, _secrets, mut commands) =
+            daemon_over(vec![key_account("zai"), key_account("kimi")]).await;
+
+        for order in [
+            vec!["zai".to_owned()],
+            vec!["zai".to_owned(), "zai".to_owned()],
+            vec!["zai".to_owned(), "kimi".to_owned(), "claude".to_owned()],
+        ] {
+            assert!(
+                daemon.set_order(order.clone()).await.is_err(),
+                "{order:?} is not the configured set"
+            );
+        }
+        assert!(
+            commands.try_recv().is_err(),
+            "a refused order never reaches the engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_valid_order_is_serialized_through_the_engine() {
+        let (daemon, _secrets, mut commands) =
+            daemon_over(vec![key_account("zai"), key_account("kimi")]).await;
+        let daemon = Arc::new(daemon);
+        let ordering = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.set_order(vec!["kimi".into(), "zai".into()]).await }
+        });
+
+        let Command::SetOrder { providers, reply } =
+            commands.recv().await.expect("order reaches engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert_eq!(providers, ["kimi", "zai"]);
+        assert!(!ordering.is_finished(), "D-Bus waits for persistence");
+        reply.send(Ok(())).expect("caller waits for reply");
+        ordering
+            .await
+            .expect("ordering task did not panic")
+            .expect("engine accepted the order");
     }
 
     #[tokio::test]

--- a/docs/superpowers/specs/2026-08-23-card-reordering-design.md
+++ b/docs/superpowers/specs/2026-08-23-card-reordering-design.md
@@ -1,0 +1,292 @@
+# Card Reordering Design
+
+- Status: approved
+- Date: 2026-08-23
+- Implements: implementation step 15
+
+## Purpose
+
+The grid of provider cards must be in the order the user put it in, changed by dragging a
+card to where they want it, and remembered across restarts. The order the grid shows is
+the order every other list of accounts uses.
+
+All documentation, source code, code comments, tests, logs, and interface copy are written
+in English.
+
+## Goals
+
+- Drag a card with the pointer and drop it anywhere in the grid.
+- **Live reflow.** While a card is held between two others, the cards it displaced move out
+  of its way and stay moved, and they move back if the pointer changes its mind — before
+  the button is released, not after it.
+- The order the user set is never changed by anything else. A new account is appended.
+- One order, one place: the grid, the tray menu and the configured list in provider
+  settings all read it.
+- Persisted by the daemon, in `config.toml`, and republished to every client.
+
+## Non-goals
+
+- Sorting by urgency, or any other automatic order. It is deleted, not kept as a mode.
+- Keyboard-driven reordering. The cards are focusable and activatable by keyboard already;
+  moving one without a pointer is a separate, additive change.
+- Dragging a card out of the window, onto another window, or onto anything but the grid.
+- Touch-screen reordering. The gesture takes the primary button; a touch drag inside a
+  scrollable view is the scroll gesture's, and taking it from there is its own decision.
+
+## What upstream actually provides
+
+Measured against GTK 4.22.4 and libadwaita 1.9.0 rather than assumed:
+
+- **There is no reorder API.** `GtkFlowBox`, `GtkListView` and `GtkGridView` expose sorting
+  and selection and nothing that moves a child by drag. `GtkNotebook` has
+  `gtk_notebook_set_tab_reorderable()` and `AdwTabView` has `adw_tab_view_reorder_page()`,
+  and both are tab-shaped and private about how they animate.
+- **`GtkFlowBox` cannot do the live part at all.** `gtk_flow_box_invalidate_sort()` sorts
+  its sequence and calls `gtk_widget_queue_resize()`, so a card that loses its place
+  teleports to the new one. There is no position to interpolate, because the position is
+  the allocation and the allocation is computed once per layout pass.
+- **`GtkDragSource` / `GtkDropTarget` are the wrong controllers for this.** They carry a
+  payload between widgets and draw a detached drag icon; the icon is not in the grid, so it
+  cannot push anything. They are what a *cross-window* drag would need, which this is not.
+- **The thing libadwaita does have is `AdwTabGrid`** — private, and an exact match for the
+  problem: a two-dimensional grid whose items reorder with live animated reflow. Its
+  architecture, which this design copies:
+
+  | `AdwTabGrid` | here |
+  |---|---|
+  | `GtkGestureDrag` on the container | the same |
+  | per-item `reorder_offset` / `end_reorder_offset`, in **index units** | the same |
+  | per-item `AdwTimedAnimation`, restarted from the current value | the same |
+  | the animation callback calls `gtk_widget_queue_allocate()` | the same |
+  | `size_allocate` maps a fractional index to a position and calls `gtk_widget_allocate()` with a translation | the same |
+  | `adw_tab_view_reorder_page()` only from `end_drag_reodering()` | `SetOrder` only on release |
+
+  Copying the pattern rather than the type: `adw-tab-grid-private.h` refuses inclusion from
+  outside libadwaita, and neither gtk4-rs nor libadwaita-rs binds it.
+
+Restarting each animation *from its current value* is what makes "the user changed their
+mind" work. A card half-way out of the way is retargeted to zero and continues from where
+it is, rather than jumping to its old slot and starting again.
+
+## Order is the `providers` array
+
+`config.toml` already carries the ordered array `CONTEXT.md` § Storage promised card order
+would live beside:
+
+```toml
+providers = ["claude", "codex", "zai"]
+```
+
+**That array is the card order.** Not a second key next to it. `providers` is already
+ordered, already the user's set, already the order `GetStatus` publishes in, and
+`AddProvider` already appends to it — which is exactly what "new cards go on the end" means.
+A separate `card_order` array would be a second list to keep in agreement with the first,
+and the first question it raises — what the order of a provider present in one and absent
+from the other is — has no good answer.
+
+The persisted identity is the provider slug, because that is the only identity this file
+has: v1 configures one `default` account per provider and `config.toml` cannot express a
+second one. When multi-account arrives it changes the shape of this array, and this method
+with it; inventing a `(provider, account)` order now would be a wire format claiming a
+precision the storage does not have.
+
+### `Config::set_provider_order`
+
+Permutes the existing array in place rather than writing a new one, like every other edit
+this file gets. **Only the values move; the decoration stays where it was written.**
+
+Carrying decoration along with each value was tried first and is wrong, because a TOML array
+has no notion of a comment belonging to an element. Both of these are ordinary:
+
+```toml
+providers = [
+    # the one I actually use
+    "claude",
+    "zai",       # the other one
+]
+```
+
+In the first style the comment is part of `claude`'s own prefix; in the second — which is
+the style this file's existing tests use — the comment after `"zai",` is part of the *next*
+element's prefix. So decoration that travels with the value scrambles comments and
+indentation in opposite directions depending on which style the file happens to use, and a
+single-line array additionally loses its spacing, because the first element's prefix is
+empty and the rest have a space: `["claude", "zai"]` becomes `[ "zai","claude"]`.
+
+Writing the slugs into the existing slots has none of those failure modes. `toml_edit`'s
+`Array::replace` keeps the slot's decoration by design, so the file comes back byte for byte
+apart from the strings: a multi-line array stays multi-line and indented, an inline one stays
+inline, and every comment stays on the line somebody wrote it on. The cost is stated rather
+than hidden: a comment naming a provider annotates the position afterwards, not the
+provider. That is the lesser evil against mangling the layout of a file a person edits, and
+it is the only behaviour of the three that is predictable from the outside.
+
+The order given must be a permutation of what is in the file. Anything else — an unknown
+slug, a missing one, a duplicate — is rejected without writing, because a client that has
+raced a removal should re-read rather than have the daemon guess which of the two it meant.
+
+## D-Bus
+
+One method and one signal.
+
+```text
+SetOrder(providers: as) -> ()
+OrderChanged(providers: as)
+```
+
+`SetOrder` follows the `SetWindowNotify` path exactly: validate against the configured
+accounts, then `config_request(Command::SetOrder { .. })` so the write happens on the
+engine's serial queue and the caller does not return until it is persisted.
+
+`OrderChanged` is a signal of its own rather than a burst of `ProviderChanged`, because
+`ProviderChanged` carries a status and a status has no position in it. A client holding
+cards needs to be told the sequence; it does not need to be told the readings again.
+
+`GetStatus` keeps returning accounts in the published order, so the daemon reorders its own
+`Published` vector as part of the same publication — a client that connects one message
+later must not see the old sequence. The engine reorders its `accounts` vector too, so a
+restart and a live reorder produce the same sequence.
+
+## The grid widget
+
+`gtk::FlowBox` is replaced by `CardGrid`, a `gtk::Widget` subclass in
+`crates/tidemark/src/grid.rs`. This is the first GObject subclass in the interface crate,
+and it is warranted: the drag state and the layout are one thing, because the position of
+every card is a function of the drag.
+
+The layout it computes is the layout the `FlowBox` was configured to produce, so the window
+looks the same when nothing is being dragged:
+
+- Cell width is the widest card's natural width; every cell gets it, so footers line up.
+- One to three columns, the most that fit the allocated width, spacing 12.
+- The block of columns is centred in the allocation. A filled row and a half-empty one sit
+  under the middle of the window rather than hugging its left edge.
+- The last row is left ragged.
+- Rows are the tallest card's natural height at that cell width.
+
+Four pure functions carry all of the arithmetic, so the parts that can be wrong are tested
+without a display, the way `bar::geometry` is:
+
+```rust
+/// How many columns fit, between one and `max`.
+fn columns(available: i32, cell: i32, spacing: i32, max: usize) -> usize;
+
+/// Where slot `index` starts. Fractional indices interpolate, including across the end of
+/// a row, so a card sliding from the end of one row to the start of the next travels there
+/// instead of jumping.
+fn slot(index: f64, columns: usize, cell: (f64, f64), spacing: (f64, f64)) -> (f64, f64);
+
+/// The slot a dragged card's centre is over.
+fn drop_index(centre: (f64, f64), count: usize, columns: usize, cell: (f64, f64),
+              spacing: (f64, f64)) -> usize;
+
+/// The index shift a card at `index` takes while `from` is being carried to `to`.
+fn shift(index: usize, from: usize, to: usize) -> f64;
+
+/// The card a press actually landed on, if it landed on one at all.
+fn slot_at(point: (f64, f64), count: usize, columns: usize, cell: (f64, f64),
+           spacing: (f64, f64)) -> Option<usize>;
+```
+
+`drop_index` is compared against the **canonical** slots — where the cards would be if
+nothing were being dragged — not against where they currently are. Canonical slots do not
+move, so the target index is a monotone function of pointer position and cannot oscillate
+between two values while the pointer is still.
+
+### The drag
+
+A `GtkGestureDrag` on the grid, primary button, exclusive, default (bubble) phase.
+
+- `drag-begin` records which slot the press landed on, and nothing else. `slot_at` and not
+  `drop_index`: the latter answers "which slot is this nearest to", which is what a drag in
+  progress wants and what a press must never use. Five cards in three columns leave a sixth
+  slot empty, and the gutters and the centring margin are not on a card either; answering
+  "the nearest one" there picks a card up off a click on the background.
+- `drag-update` does nothing until `gtk_drag_check_threshold` passes. It then claims the
+  sequence — which cancels the pressed card's `GtkGestureClick`, so a drag never opens the
+  detail dialog — moves the dragged slot to the end of the child list so that it both paints
+  and picks above its siblings, and starts following the pointer, clamped to the grid.
+  Every further update recomputes `drop_index`; when it changes, every card between the
+  source and the target is retargeted to ±1 and animated there over 250 ms with
+  `ADW_EASE`.
+- `drag-end` commits: the slot vector is permuted, every offset is retargeted to zero, and
+  the released card is animated from where the pointer left it to its new slot. The order
+  goes to the daemon once, here, not on every motion event.
+
+The dragged card is *the card*, not a drag icon: it is still a child of the grid, allocated
+at the pointer, which is what lets its siblings react to where it is.
+
+**Autoscroll is part of this, not a refinement.** Six cards in a two-column window are
+taller than the window, and the pointer cannot leave the viewport, so without it the last
+row is unreachable. While the pointer is within 48 px of the top or bottom of the enclosing
+`GtkScrolledWindow`, a tick callback advances its vertical adjustment at a rate
+proportional to how far in it is, and the same distance is added to the dragged card's
+position so that the card stays under the pointer.
+
+### The card's own widget
+
+The card's `GtkFlowBoxChild` becomes an `AdwBin` with the class `quota-slot`. It keeps the
+job the flow box's child had — it is the thing the grid allocates, the thing that takes
+focus, and the thing the click and key controllers are on — and loses the one that needed
+working around, which is that `GtkFlowBoxChild` tints its own square allocation behind a
+card with rounded corners.
+
+The hover stays matched on the slot and applied to the card inside it, for the reason it
+always was: a CSS `transform` moves what GTK picks, so a card that lifted itself out from
+under the pointer would flicker. The slot's allocation does not move, so it does not.
+
+**The carried card is opaque, and this is not cosmetic.** `.card` takes `@card_bg_color`,
+which in the dark style is 8% white over whatever is behind it — right for a card lying on
+the window, and wrong for one crossing its neighbours, which then read straight through it.
+The dragged card takes `@popover_bg_color`, the platform's own name for a surface floating
+above the content, plus a deeper shadow. Its foreground is left alone: the bar's track and
+pace mark inherit the text colour, and changing it would make them shift tone for the length
+of a drag.
+
+The class that selects it goes on the **slot**, because the grid holds slots and knows
+nothing about what is inside them. A rule written against the card instead matches nothing,
+and the only symptom is a translucent card mid-drag — no warning, no failing test, and
+nothing a screenshot of a resting grid would show. A test asserts that the stylesheet
+selects the class the drag actually sets.
+
+## What stops sorting
+
+`model::urgency` and `model::compare` are deleted, along with the `FlowBox` sort function
+they fed. Nothing replaces them: the order is the daemon's sequence, and there is no second
+rule that could disagree with it.
+
+- **The grid** holds its cards in that sequence and appends a new one.
+- **The tray menu** stops sorting and lists what it is given, which is the same sequence.
+  It keeps `needs_attention`, which is a threshold rather than an order.
+- **Provider settings** already draws its configured list in the sequence it is handed.
+  It now gets the visible one, because the window's card vector *is* the visible order.
+- **The add picker** is unaffected: it lists catalog entries that have no card, and a card
+  order says nothing about them.
+
+## Failure
+
+A rejected `SetOrder` leaves the daemon's order as it was, so the window re-reads
+`GetStatus` and returns the cards to it. The cards have already moved by then — the drop
+is applied locally first, because a grid that waited for a round trip before showing the
+result of a drag would feel broken on a loaded machine.
+
+## Verification
+
+- `columns`, `slot`, `drop_index`, `slot_at` and `shift` are unit-tested, including the wrap
+  between rows, the clamp past the last card, and every kind of press that is not on a card:
+  a gutter, the centring margin, and the empty tail of the last row.
+- `Config::set_provider_order` is tested for the permutation, for the file coming back byte
+  for byte apart from the slugs in both the multi-line-with-comments and the inline shape,
+  for normalising duplicates first, for an unchanged order not being a write, and for a
+  non-permutation being refused with nothing written.
+- `Published::reorder` is tested for the sequence and for leaving an account it was not told
+  about alone; `Engine::set_order` for persisting and moving its own account vector with it.
+- `Daemon::set_order` is tested for refusing a bad order before it reaches the engine, and
+  for waiting on persistence before it answers.
+- `model::arrangement` is tested for unnamed accounts keeping their relative position.
+- The stylesheet is tested against the class the drag sets, because that mismatch has no
+  other symptom than a translucent card while the pointer is down.
+- Live: dragging cards in one, two and three column widths, confirming the reflow follows
+  the pointer and returns, that the carried card is opaque over its neighbours, that the
+  order survives a daemon restart, that `config.toml` shows it, and that the tray menu and
+  the provider-settings list agree with the grid.


### PR DESCRIPTION
Implements `PLAN.md` Step 15. Design record: `docs/superpowers/specs/2026-08-23-card-reordering-design.md`.

Cards are in the order the user dragged them into, and nothing changes it automatically. Dragging a card reflows the grid **live** — the cards it displaces move out of the way before the button is released, and move back if the pointer changes its mind.

## The urgency sort is gone, not kept underneath

`model::urgency` and `model::compare` are deleted. There is one sequence, and the grid, the tray menu and the configured list in provider settings all read it; a second rule could only disagree with the order a person set by hand. A new account goes on the end.

## Why `GtkFlowBox` and `GtkDragSource` are both gone

Both things `CONTEXT.md` prescribed for this step turned out to be wrong. Checked against the GTK 4.22.4 and libadwaita 1.9.0 sources rather than assumed:

- **`GtkFlowBox` cannot do the live half at all.** `gtk_flow_box_invalidate_sort()` sorts its sequence and calls `gtk_widget_queue_resize()`, so a card that loses its place teleports to the new one. There is nothing to interpolate, because the position *is* the allocation.
- **`GtkDragSource`/`GtkDropTarget` are the wrong controllers.** They carry a payload between widgets and draw a detached drag icon; the icon is not in the grid, so it cannot push anything. They are what a cross-window drag would need, which this is not.
- **No public reorder-with-animation API exists** in GTK 4.18–4.22 or libadwaita 1.9. `GtkNotebook` and `AdwTabView` can reorder tabs and both keep how they animate it private.

The one upstream implementation of exactly this behaviour is libadwaita's **private `AdwTabGrid`**, so `crates/tidemark/src/grid.rs` is a `gtk::Widget` subclass built on its architecture:

| `AdwTabGrid` | here |
|---|---|
| `GtkGestureDrag` on the container | the same |
| per-item offset in **index units** | the same |
| per-item `AdwTimedAnimation`, restarted from its current value | the same |
| animation callback calls `gtk_widget_queue_allocate()` | the same |
| `size_allocate` maps a fractional index to a position | the same |
| `adw_tab_view_reorder_page()` only from `end_drag_reodering()` | `SetOrder` only on release |

Restarting each animation *from its current value* is what makes "the user changed their mind" work: a card half-way out of the way is retargeted to zero and carries on from where it is, rather than snapping back and starting again.

All the arithmetic that can be wrong lives in free functions — `columns`, `slot`, `drop_index`, `slot_at`, `shift`, `autoscroll_rate` — tested without a display, the way `bar::geometry` is.

Edge autoscroll is included rather than deferred: six cards in a two-column window are taller than the window and the pointer cannot leave the viewport, so without it the last row is unreachable.

## The order is the `providers` array

Not a second key beside it. That array is already ordered, already the user's set, already the order `GetStatus` publishes in, and `AddProvider` already appends to it — which is what "a new card goes on the end" means. A separate `card_order` would be a second list to keep in agreement with the first, and its first question (where does a provider named in one and absent from the other go?) has no good answer.

Reordering **moves the values and leaves the decoration where it was written**, because a TOML array has no notion of a comment belonging to an element: in `"claude", # mine` the comment is part of the *next* element's prefix, and in the style above it, part of its own. Carrying decoration along scrambles comments and indentation in opposite directions depending on the file's style. Writing the slugs into the existing slots returns the file byte for byte apart from the strings — proven on a real `config.toml` whose `providers = ["claude" , "codex", "zai", "kimi"     , "antigravity"]` kept its odd spacing exactly through a dozen reorders.

D-Bus gains `SetOrder(providers: as)` and `OrderChanged(providers: as)`. A signal of its own rather than a burst of `ProviderChanged`, because a status carries no position: a client holding cards needs the sequence, not the readings again. `GetStatus` answers in that order from the moment it is emitted. A non-permutation is refused without writing — a client that raced an add or a remove should re-read rather than have the daemon guess.

## The card's widget

`GtkFlowBoxChild` becomes an `AdwBin` slot. It keeps the job the flow box's child had — the thing the grid allocates, takes focus, and carries the click and key controllers — and loses the one that needed working around, which is tinting its own square allocation behind a card with rounded corners.

The hover stays matched on the slot and applied to the card inside it, for the reason it always was: a CSS `transform` moves what GTK picks, so a card that lifted itself out from under the pointer would flicker.

**A carried card is opaque.** `.card` takes `@card_bg_color`, which in the dark style is 8% white over whatever is behind it — right for a card lying on the window, and wrong for one crossing its neighbours, which then read straight through it. It now takes `@popover_bg_color`, the platform's own name for a surface floating above the content, plus a deeper shadow. Its foreground is deliberately left alone: the bar's track and pace mark inherit the text colour, and changing it would make them shift tone for the length of a drag.

## Two bugs found after it was already working

- A press on a gutter, on the centring margin, or on the empty tail of the last row picked up the *nearest* card instead of none. `drop_index` clamps by design — that is what a drag in progress needs — so presses now go through `slot_at`, which returns `None` when the point is not on a card.
- The carried card was translucent, and the rule meant to fix it selected `.quota-card.dragging` while the drag marks the **slot**, so it matched nothing at all. This has no symptom other than the pixels: no warning, no failing test, and nothing a screenshot of a resting grid would show. A test now pins the stylesheet to the class the drag actually sets.

## Verification

- `cargo test --workspace` — 937 tests pass.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, `scripts/check-layering.sh` — clean.
- Live, from the installed package: dragging in one, two and three column widths; the reflow follows the pointer and returns; the carried card is opaque over its neighbours; the order survives a daemon restart; `config.toml`, `GetStatus`, the tray menu and the provider-settings list all agree with the grid after each drag; `SetOrder` refuses a non-permutation without writing.

## Deliberately not here

- Keyboard reordering. The cards are focusable and activatable by keyboard already; moving one without a pointer is a small additive change on top of this order model.
- Touch-screen reordering. The gesture takes the primary button; a touch drag inside a scrollable view belongs to the scroll gesture, and taking it from there is its own decision.
