### PR TITLE
feat(about): show an About dialog from a primary menu

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -448,6 +448,24 @@ history that does not exist yet.
   not own. That last sentence is ADR 0001, and it is stated in the open next to the choice
   rather than left to be discovered: a program that edits another program's credentials
   says so where the decision is made.
+- **The primary menu is the platform's, and so is the About dialog.** The header's
+  rightmost button opens the menu every GNOME application keeps there; its one entry today
+  is About Tidemark, and Preferences joins it when there is a setting that is neither a
+  provider's nor a credential's. The dialog is `AdwAboutDialog` with properties set and no
+  layout of ours: the icon over the name, the version pill, Details, Report an Issue and
+  Legal are what the platform draws from `application-icon`, `version`, `website`,
+  `issue-url`, `copyright` and `license-type`. The warranty sentence and the licence link
+  are GTK's own text for `MIT_X11` rather than a second copy of a legal notice to keep in
+  agreement — and the issue link goes to `/issues/new/choose`, because the repository has
+  templates and a report that skips them has to be asked for the version and the desktop
+  all over again.
+- **The one page that is ours is Troubleshooting**, and it is there so those questions are
+  answered before they are asked: the client's version, the version the daemon on the other
+  end reported, the GTK and libadwaita the process actually loaded, the desktop and session
+  type, and whether a status-notifier host took the icon — which is the difference between
+  a close button that hides the window and one that ends the program. Runtime values, not
+  the compiled floor: the floor is what we built against and no evidence at all about the
+  machine the bug is on.
 - **Tray** — a static StatusNotifierItem, owned by the interface process rather than by the
   daemon. Left click shows the window; the menu lists the configured accounts with the
   percentage of their shortest window, in the order the grid uses, and ends with Open,

--- a/crates/tidemark/src/about.rs
+++ b/crates/tidemark/src/about.rs
@@ -1,0 +1,128 @@
+//! The About dialog: who wrote this, which version is running, and where to report it.
+//!
+//! `AdwAboutDialog` is the whole of it. Every part of the standard layout — the icon over
+//! the name, the version pill, Details, Report an Issue, Legal — is a property rather than
+//! a widget we place, so the dialog looks like every other GNOME application's and follows
+//! the platform when libadwaita changes its mind about the arrangement.
+//!
+//! The licence text is not written out here either. `gtk::License::MitX11` is what makes
+//! the Legal page say the application comes with absolutely no warranty and link the MIT
+//! licence; spelling that sentence ourselves would be a second copy of a legal notice to
+//! keep in agreement with the one GTK already translates.
+//!
+//! The one thing that is ours is the troubleshooting page. It answers the questions every
+//! bug report about this program starts with — which daemon is on the other end, whether
+//! the panel took the icon, which toolkit is actually loaded — and it answers them from the
+//! running process rather than from what the reporter remembers installing.
+
+use adw::prelude::*;
+use tidemark_types::ids;
+
+/// Where **Details** goes.
+const WEBSITE_URL: &str = "https://github.com/zbndev/tidemark";
+/// Where **Report an Issue** goes. `/new/choose` rather than the issue list, because the
+/// repository has templates and a report that skips them is a report that has to be asked
+/// for the version, the desktop and the provider all over again.
+const ISSUES_URL: &str = "https://github.com/zbndev/tidemark/issues/new/choose";
+/// The file the troubleshooting page's save button offers.
+const DEBUG_INFO_FILENAME: &str = "tidemark-debug-info.txt";
+
+/// Shows the About dialog over `parent`.
+///
+/// `AdwDialog` is modal within the window, so there is no second one to guard against: the
+/// menu button that activates this is behind it while it is up.
+pub fn present(parent: &impl IsA<gtk::Widget>, debug_info: &str) {
+    let dialog = adw::AboutDialog::builder()
+        .application_icon(ids::APP_ID)
+        .application_name("Tidemark")
+        .developer_name("zbndev")
+        .version(env!("CARGO_PKG_VERSION"))
+        // The summary the desktop file and the metainfo already use. It is what turns the
+        // website link into a **Details** page rather than a bare row.
+        .comments("Track AI provider quota limits.")
+        .website(WEBSITE_URL)
+        .issue_url(ISSUES_URL)
+        .copyright("© 2026 zbndev")
+        .license_type(gtk::License::MitX11)
+        .debug_info(debug_info)
+        .debug_info_filename(DEBUG_INFO_FILENAME)
+        .build();
+    dialog.present(Some(parent));
+}
+
+/// What the troubleshooting page shows, and what its copy button puts on the clipboard.
+///
+/// `daemon` is the version `tidemarkd` reported, absent when nothing answered on the bus;
+/// `tray` is whether a status-notifier host accepted the icon, which is the difference
+/// between a close button that hides the window and one that ends the program.
+///
+/// The toolkit versions are the ones the process loaded, not the ones it was built
+/// against. Those are the same number often enough that stating the compiled floor would
+/// look like an answer while being no evidence at all about the machine the bug is on.
+pub fn debug_info(daemon: Option<&str>, tray: bool) -> String {
+    compose(
+        daemon,
+        tray,
+        &format!(
+            "{}.{}.{}",
+            gtk::major_version(),
+            gtk::minor_version(),
+            gtk::micro_version()
+        ),
+        &format!(
+            "{}.{}.{}",
+            adw::major_version(),
+            adw::minor_version(),
+            adw::micro_version()
+        ),
+    )
+}
+
+/// The page, given the facts. Separate from the two calls above because those assert that
+/// GTK has been initialised, which a unit test has no way to arrange and no need to.
+fn compose(daemon: Option<&str>, tray: bool, gtk_version: &str, adw_version: &str) -> String {
+    let client = env!("CARGO_PKG_VERSION");
+    let daemon = daemon.unwrap_or("not running");
+    let tray = if tray {
+        "accepted"
+    } else {
+        "no status-notifier host"
+    };
+    format!(
+        "Tidemark: {client}\n\
+         tidemarkd: {daemon}\n\
+         GTK: {gtk_version}\n\
+         libadwaita: {adw_version}\n\
+         Desktop: {}\n\
+         Session: {}\n\
+         Tray: {tray}\n",
+        environment("XDG_CURRENT_DESKTOP"),
+        environment("XDG_SESSION_TYPE"),
+    )
+}
+
+/// One environment variable, with "unset" rather than an empty line: a report has to
+/// distinguish a desktop that says nothing from a field this program failed to fill in.
+fn environment(key: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| "unset".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compose;
+
+    #[test]
+    fn a_missing_daemon_is_stated_rather_than_left_blank() {
+        let info = compose(None, false, "4.22.4", "1.9.3");
+        assert!(info.contains("tidemarkd: not running"), "{info}");
+        assert!(info.contains("Tray: no status-notifier host"), "{info}");
+    }
+
+    #[test]
+    fn a_connected_daemon_reports_its_own_version() {
+        let info = compose(Some("0.2.0"), true, "4.22.4", "1.9.3");
+        assert!(info.contains("tidemarkd: 0.2.0"), "{info}");
+        assert!(info.contains("Tray: accepted"), "{info}");
+        assert!(info.contains("GTK: 4.22.4"), "{info}");
+    }
+}

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -7,10 +7,12 @@
 //! The pieces: `bus` talks to the daemon, `window` owns the order the cards are in,
 //! `grid` lays them out and lets the user drag them into a different one, `card` draws one
 //! account, `provider_settings` is the dialog that adds, edits and removes them,
-//! `bar` draws the quota bar and its pace mark, `mark` finds the provider's own logo,
-//! `model` decides what order things go in, `format` decides what they say, and `style`
-//! adds the handful of CSS rules libadwaita does not already provide.
+//! `about` is the primary menu's dialog, `bar` draws the quota bar and its pace mark,
+//! `mark` finds the provider's own logo, `model` decides what order things go in,
+//! `format` decides what they say, and `style` adds the handful of CSS rules libadwaita
+//! does not already provide.
 
+mod about;
 mod bar;
 mod bus;
 mod card;

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -15,9 +15,10 @@ use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
-use gtk::glib;
+use gtk::{gio, glib};
 use tidemark_types::{ProviderDefinition, ProviderStatus, Timestamp};
 
+use crate::about;
 use crate::bus::{self, DaemonProxy, Update};
 use crate::card::Card;
 use crate::detail::DetailDialog;
@@ -89,6 +90,9 @@ pub struct MainWindow {
     cards: RefCell<Vec<Rc<Card>>>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     daemon: RefCell<Option<DaemonProxy<'static>>>,
+    /// What the daemon last said its version was, for the About dialog's troubleshooting
+    /// page. `None` while nothing is answering on the bus.
+    daemon_version: RefCell<Option<String>>,
     update_notice: RefCell<UpdateNotice>,
     /// The provider dialog while it is open, so live catalog and status changes reach it.
     provider_settings: DialogSlot<ProviderSettings>,
@@ -146,7 +150,22 @@ impl MainWindow {
             .sensitive(false)
             .build();
 
+        // The platform's primary menu: rightmost in the header, and the place a GNOME user
+        // looks for About without being told where it is. `primary` is what makes F10 open
+        // it, which is the shortcut the shell's own menus answer to.
+        let menu = gio::Menu::new();
+        menu.append(Some("_About Tidemark"), Some("win.about"));
+        let primary_menu = gtk::MenuButton::builder()
+            .icon_name("open-menu-symbolic")
+            .tooltip_text("Main Menu")
+            .menu_model(&menu)
+            .primary(true)
+            .build();
+
         let header = adw::HeaderBar::new();
+        // First packed is furthest right, so the menu leads and the buttons follow it
+        // inwards.
+        header.pack_end(&primary_menu);
         header.pack_end(&refresh);
         header.pack_end(&release);
         header.pack_start(&providers);
@@ -173,6 +192,7 @@ impl MainWindow {
             cards: RefCell::new(Vec::new()),
             definitions: RefCell::new(Vec::new()),
             daemon: RefCell::new(None),
+            daemon_version: RefCell::new(None),
             update_notice: RefCell::new(UpdateNotice::new(env!("CARGO_PKG_VERSION"))),
             provider_settings: DialogSlot::default(),
             detail_dialog: DialogSlot::default(),
@@ -183,6 +203,7 @@ impl MainWindow {
         main.connect_refresh_button();
         main.connect_update_button();
         main.connect_providers_button();
+        main.connect_about_action();
         main.start_clock();
         main.start_tray(background);
         if !background {
@@ -202,6 +223,7 @@ impl MainWindow {
         match update {
             Update::Connected(proxy, daemon_version, available, definitions, statuses) => {
                 *self.daemon.borrow_mut() = Some(proxy);
+                self.daemon_version.replace(daemon_version.clone());
                 *self.definitions.borrow_mut() = definitions;
                 self.refresh.set_sensitive(true);
                 self.providers.set_sensitive(true);
@@ -251,6 +273,7 @@ impl MainWindow {
             Update::Available(version) => self.show_update(&version),
             Update::Waiting(reason) => {
                 *self.daemon.borrow_mut() = None;
+                self.daemon_version.replace(None);
                 self.refresh.set_sensitive(false);
                 self.providers.set_sensitive(false);
                 self.show_update("");
@@ -472,6 +495,27 @@ impl MainWindow {
             );
             assert!(main.provider_settings.insert_if_empty(dialog));
         });
+    }
+
+    /// Installs `win.about`, the one entry in the primary menu.
+    ///
+    /// A window action rather than an application one: what the dialog reports — which
+    /// daemon answered, whether the panel took the icon — is this window's knowledge, and
+    /// an `app.` action would have to go looking for the window to find it.
+    fn connect_about_action(self: &Rc<Self>) {
+        let weak: Weak<Self> = Rc::downgrade(self);
+        let action = gio::SimpleAction::new("about", None);
+        action.connect_activate(move |_, _| {
+            let Some(main) = weak.upgrade() else {
+                return;
+            };
+            let info = about::debug_info(
+                main.daemon_version.borrow().as_deref(),
+                main.tray.borrow().is_some(),
+            );
+            about::present(&main.window, &info);
+        });
+        self.window.add_action(&action);
     }
 
     /// Mirrors a completed drag into the card vector and asks the daemon to keep it.


### PR DESCRIPTION
The header gains the menu button GNOME applications keep at its right end. Its one entry today is **About Tidemark**; Preferences joins it when there is a setting that belongs to neither a provider nor a credential — a menu entry that opens nothing is a stub, not a placeholder.

## The dialog

`AdwAboutDialog` with properties set and no layout of ours, so the icon over the name, the version pill, **Details**, **Report an Issue** and **Legal** are what the platform draws and stay right when libadwaita changes its mind about the arrangement.

- `gtk::License::MitX11` is what makes the Legal page state the absent warranty and link the licence. Writing that sentence here would be a second copy of a legal notice to keep in agreement with the one GTK already translates.
- **Report an Issue** goes to `/issues/new/choose` rather than the issue list: the repository has templates, and a report that skips them has to be asked for the version, the desktop and the provider all over again.

## Troubleshooting is the one page that is ours

It answers what every bug report about this program starts with, from the running process rather than from what the reporter remembers installing: the client's version, the version the daemon on the other end reported, the GTK and libadwaita **actually loaded**, the desktop and session type, and whether a status-notifier host took the icon — which is the difference between a close button that hides the window and one that ends the program. Runtime values, not the compiled floor: the floor is what we built against and no evidence at all about the machine the bug is on.

Composing that text is split from reading the toolkit versions, because `adw::major_version()` asserts GTK is initialised and the shape is worth a unit test without a display.

## Changes

- `crates/tidemark/src/about.rs` — new; the dialog and the debug-info text.
- `crates/tidemark/src/window.rs` — the menu button (`primary`, so F10 opens it), the `win.about` action, and a `daemon_version` the About dialog reads. A window action rather than an application one: what the page reports is this window's knowledge.
- `CONTEXT.md` — the two interface decisions above.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` green, `scripts/check-layering.sh` ok. Opened against the live daemon on this machine: the accessibility tree shows `Tidemark / zbndev / button "0.1.1" / Details / Report an Issue / Troubleshooting / Legal`, and the troubleshooting text box reads `Tidemark: 0.1.1 / tidemarkd: 0.1.1 / GTK: 4.22.4 / libadwaita: 1.9.3 / Desktop: Hyprland`.
