### PR TITLE
feat: add daemon-backed application preferences

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -228,7 +228,11 @@ distribution-wide LTO off; `PKGBUILD` does it with `options=(!lto)`.
   only when `used_percent` changes, plus an hourly anchor. Points older than 90 days are
   thinned to one per 15 minutes, except that the first and last point of every segment
   always survive — without them a thinned segment loses the two things worth keeping, where
-  it started and how full it got. Nothing is deleted outright.
+  it started and how full it got. The default retention is `forever`, so nothing is deleted
+  outright unless the user chooses six months or one year in Preferences. A shorter policy
+  deletes older points immediately and during daily maintenance. Clear History deletes
+  points, segments, notification deduplication and last-observed state, then compacts the
+  database; provider configuration and credentials are separate and survive.
 - **Last seen is not last written** — the reading segmentation compares against is the last
   one *observed*, which is not the last one *stored*. A window can roll over without
   consumption moving, and that transition is visible only in a reading no point was written
@@ -293,6 +297,20 @@ distribution-wide LTO off; `PKGBUILD` does it with `options=(!lto)`.
   provider-specific settings and both kinds of Tidemark-owned credential, then removes its
   account and card; quota history and vendor-owned credential files or `agy` sessions are
   retained.
+- **Application preferences use the same file, not GSettings.** `[general]` carries
+  `minimize_on_close` (default `true`) and `startup`, whose named modes are `app` (the
+  default: app and tray), `daemon` (daemon only), and `off`; `[updates] check` defaults to
+  `true`; `[history] retention` is `forever`, `six-months` or `one-year`. A present value
+  with the wrong type or an unknown named choice is an error, not a reason to guess.
+  Mutations travel over D-Bus and share the engine's serial configuration queue, so a
+  provider edit and a global preference cannot overwrite each other.
+- **The startup mode names one coherent desired state in `config.toml` and applies both
+  platform integrations.** Hiding the desktop client writes the standard per-user XDG
+  autostart override (`Hidden=true`); exposing it removes that override and reveals the
+  packaged `/etc/xdg/autostart` entry again. Daemon-only startup uses `systemctl --user
+  enable tidemarkd.service`; the other modes disable that unit without stopping the current
+  daemon, because launching the app already D-Bus-activates it. If either platform
+  integration or persistence fails, the previous platform mode is restored.
 
 ## Networking
 
@@ -448,11 +466,13 @@ history that does not exist yet.
   not own. That last sentence is ADR 0001, and it is stated in the open next to the choice
   rather than left to be discovered: a program that edits another program's credentials
   says so where the decision is made.
-- **The primary menu is the platform's, and so is the About dialog.** The header's
-  rightmost button opens the menu every GNOME application keeps there; its one entry today
-  is About Tidemark, and Preferences joins it when there is a setting that is neither a
-  provider's nor a credential's. The dialog is `AdwAboutDialog` with properties set and no
-  layout of ours: the icon over the name, the version pill, Details, Report an Issue and
+- **The primary menu is the platform's, and so are its dialogs.** The header's rightmost
+  button opens the menu every GNOME application keeps there. Preferences and About
+  Tidemark are separate sections; provider and credential management stays on its existing
+  header button because accounts are managed, not application preferences. Preferences is
+  an `AdwPreferencesDialog` with General, Updates and Data pages and standard rows. About
+  is an `AdwAboutDialog` with properties set and no layout of ours: the icon over the name,
+  the version pill, Details, Report an Issue and
   Legal are what the platform draws from `application-icon`, `version`, `website`,
   `issue-url`, `copyright` and `license-type`. The warranty sentence and the licence link
   are GTK's own text for `MIT_X11` rather than a second copy of a legal notice to keep in
@@ -472,14 +492,20 @@ history that does not exist yet.
   Refresh and Quit. The icon takes the `NeedsAttention` status at the same threshold the
   bar changes colour at and the notification fires at, so the panel cannot become a third
   opinion about when a window got worrying.
-- **Closing the window hides it; the tray is what the program minimises to.** The process
-  stays, the readings keep arriving, and Quit in the tray menu is the only way out. This is
-  conditional on the icon actually being accepted: when no status-notifier host answers, the
-  close button closes the program exactly as it did before, because hiding a window with
-  nothing left to bring it back is worse than having no tray.
-- **Desktop autostart uses that same condition.** `tidemark --background` builds the window
-  without showing it and stays only after a StatusNotifier host accepts the icon. On a
-  desktop without one it exits cleanly instead of leaving an invisible process behind.
+- **Closing the window hides it by default; the tray is what the program minimises to.**
+  `minimize_on_close = true` keeps the interface process alive, readings keep arriving, and
+  Quit in the tray menu is the way out. Switching it off makes close end the interface
+  process. Both choices remain conditional on the icon actually being accepted: when no
+  status-notifier host answers, close always ends the process because hiding a window with
+  nothing left to bring it back is worse than ignoring a preference.
+- **The `app` startup mode uses that same tray condition.** `tidemark --background` builds
+  the window without showing it and stays only after a StatusNotifier host accepts the
+  icon. On a desktop without one it exits cleanly instead of leaving an invisible process
+  behind.
+- **Release checks are optional twice.** `[updates] check = false` stops the hourly GitHub
+  request at runtime and clears any published update notice. The daemon's `update-check`
+  Cargo feature is enabled by default for upstream builds; a distribution can build with
+  `--no-default-features`, in which case Preferences shows the switch off and unavailable.
 - **`libayatana-appindicator-glib` is GPL-3** and cannot be linked into an MIT project. The
   protocol is spoken through `ksni`, which is Unlicense — public domain, so compatible —
   and which is built on the same zbus the interface already reaches the daemon over.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ name = "tidemarkd"
 version = "0.1.1"
 dependencies = [
  "reqwest",
+ "rusqlite",
  "semver",
  "serde_json",
  "thiserror",

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -20,6 +20,7 @@
 
 use std::path::{Path, PathBuf};
 
+use tidemark_types::Preferences;
 use toml_edit::{Array, DocumentMut, Item, Table, Value, value};
 
 use crate::paths;
@@ -36,6 +37,14 @@ const PROVIDERS_KEY: &str = "providers";
 /// declared nor enumerable.
 const NOTIFY_TABLE: &str = "notify";
 const NOTIFY_WINDOWS_KEY: &str = "windows";
+
+const GENERAL_TABLE: &str = "general";
+const MINIMIZE_ON_CLOSE_KEY: &str = "minimize_on_close";
+const STARTUP_KEY: &str = "startup";
+const UPDATES_TABLE: &str = "updates";
+const RELEASE_CHECK_KEY: &str = "check";
+const HISTORY_TABLE: &str = "history";
+const HISTORY_RETENTION_KEY: &str = "retention";
 
 /// Why the settings could not be read or written.
 #[derive(Debug, thiserror::Error)]
@@ -86,6 +95,18 @@ pub enum ConfigError {
         /// Whose list it is.
         provider: String,
     },
+    /// An application preference has a wrong type or an unknown named value.
+    #[error("{path}: [{table}] {key} {reason}")]
+    InvalidPreference {
+        /// The file.
+        path: PathBuf,
+        /// The table carrying the preference.
+        table: &'static str,
+        /// The key carrying the preference.
+        key: &'static str,
+        /// What was wrong with it.
+        reason: String,
+    },
 }
 
 /// The settings file, held open across edits.
@@ -116,6 +137,151 @@ impl Config {
                 source,
             })?;
         Ok(Self { path, document })
+    }
+
+    /// Reads the application-wide preferences, applying documented defaults only to
+    /// absent keys. A present value with the wrong type is refused rather than guessed.
+    pub fn preferences(&self) -> Result<Preferences, ConfigError> {
+        let defaults = Preferences::default();
+        let history_retention = self
+            .preference_string(HISTORY_TABLE, HISTORY_RETENTION_KEY)?
+            .unwrap_or(defaults.history_retention.as_str())
+            .to_owned();
+        if !Preferences::valid_retention(&history_retention) {
+            return Err(self.invalid_preference(
+                HISTORY_TABLE,
+                HISTORY_RETENTION_KEY,
+                format!("has unknown value {history_retention:?}"),
+            ));
+        }
+        let startup_mode = self
+            .preference_string(GENERAL_TABLE, STARTUP_KEY)?
+            .unwrap_or(defaults.startup_mode.as_str())
+            .to_owned();
+        if !Preferences::valid_startup(&startup_mode) {
+            return Err(self.invalid_preference(
+                GENERAL_TABLE,
+                STARTUP_KEY,
+                format!("has unknown value {startup_mode:?}"),
+            ));
+        }
+        Ok(Preferences {
+            release_check: self
+                .preference_bool(UPDATES_TABLE, RELEASE_CHECK_KEY)?
+                .unwrap_or(defaults.release_check),
+            minimize_on_close: self
+                .preference_bool(GENERAL_TABLE, MINIMIZE_ON_CLOSE_KEY)?
+                .unwrap_or(defaults.minimize_on_close),
+            startup_mode,
+            history_retention,
+        })
+    }
+
+    pub fn set_release_check(&mut self, enabled: bool) -> Result<(), ConfigError> {
+        self.set_preference(UPDATES_TABLE, RELEASE_CHECK_KEY, value(enabled))
+    }
+
+    pub fn set_minimize_on_close(&mut self, enabled: bool) -> Result<(), ConfigError> {
+        self.set_preference(GENERAL_TABLE, MINIMIZE_ON_CLOSE_KEY, value(enabled))
+    }
+
+    pub fn set_startup_mode(&mut self, mode: &str) -> Result<(), ConfigError> {
+        if !Preferences::valid_startup(mode) {
+            return Err(self.invalid_preference(
+                GENERAL_TABLE,
+                STARTUP_KEY,
+                format!("has unknown value {mode:?}"),
+            ));
+        }
+        self.set_preference(GENERAL_TABLE, STARTUP_KEY, value(mode))
+    }
+
+    pub fn set_history_retention(&mut self, retention: &str) -> Result<(), ConfigError> {
+        if !Preferences::valid_retention(retention) {
+            return Err(self.invalid_preference(
+                HISTORY_TABLE,
+                HISTORY_RETENTION_KEY,
+                format!("has unknown value {retention:?}"),
+            ));
+        }
+        self.set_preference(HISTORY_TABLE, HISTORY_RETENTION_KEY, value(retention))
+    }
+
+    fn preference_bool(
+        &self,
+        table: &'static str,
+        key: &'static str,
+    ) -> Result<Option<bool>, ConfigError> {
+        let Some(item) = self.preference(table, key)? else {
+            return Ok(None);
+        };
+        item.as_bool()
+            .map(Some)
+            .ok_or_else(|| self.invalid_preference(table, key, "must be true or false".into()))
+    }
+
+    fn preference_string(
+        &self,
+        table: &'static str,
+        key: &'static str,
+    ) -> Result<Option<&str>, ConfigError> {
+        let Some(item) = self.preference(table, key)? else {
+            return Ok(None);
+        };
+        item.as_str()
+            .map(Some)
+            .ok_or_else(|| self.invalid_preference(table, key, "must be a string".into()))
+    }
+
+    fn preference(
+        &self,
+        table: &'static str,
+        key: &'static str,
+    ) -> Result<Option<&Item>, ConfigError> {
+        let Some(table_item) = self.document.get(table) else {
+            return Ok(None);
+        };
+        let table_item = table_item
+            .as_table_like()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: table.into(),
+            })?;
+        Ok(table_item.get(key))
+    }
+
+    fn set_preference(
+        &mut self,
+        table: &'static str,
+        key: &'static str,
+        setting: Item,
+    ) -> Result<(), ConfigError> {
+        let table_item = self
+            .document
+            .entry(table)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let table_item = table_item
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: table.into(),
+            })?;
+        table_item.insert(key, setting);
+        self.write()
+    }
+
+    fn invalid_preference(
+        &self,
+        table: &'static str,
+        key: &'static str,
+        reason: String,
+    ) -> ConfigError {
+        ConfigError::InvalidPreference {
+            path: self.path.clone(),
+            table,
+            key,
+            reason,
+        }
     }
 
     /// One provider setting, if the user has one.
@@ -975,5 +1141,66 @@ mod tests {
         let text = std::fs::read_to_string(&path).expect("read back");
         assert!(text.contains("# hand-written"), "{text}");
         assert!(text.contains("# the one that matters"), "{text}");
+    }
+    #[test]
+    fn a_first_run_has_safe_application_preferences() {
+        let path = scratch("preferences-defaults");
+        let _ = std::fs::remove_file(&path);
+        let config = Config::at(path).expect("loaded");
+
+        assert_eq!(
+            config.preferences().expect("readable"),
+            tidemark_types::Preferences::default()
+        );
+        assert!(config.preferences().expect("readable").release_check);
+        assert!(config.preferences().expect("readable").minimize_on_close);
+        assert_eq!(config.preferences().expect("readable").startup_mode, "app");
+        assert_eq!(
+            config.preferences().expect("readable").history_retention,
+            "forever"
+        );
+    }
+
+    #[test]
+    fn application_preferences_survive_a_round_trip_without_rewriting_the_file() {
+        let path = scratch("preferences-roundtrip");
+        std::fs::write(&path, "# belongs to the user\nproviders = []\n").expect("seeded");
+        let mut config = Config::at(path.clone()).expect("loaded");
+        let preferences = tidemark_types::Preferences {
+            release_check: false,
+            minimize_on_close: false,
+            startup_mode: "daemon".into(),
+            history_retention: "six-months".into(),
+        };
+
+        config.set_release_check(false).expect("release setting");
+        config.set_minimize_on_close(false).expect("close setting");
+        config.set_startup_mode("daemon").expect("startup mode");
+        config
+            .set_history_retention("six-months")
+            .expect("retention setting");
+
+        let reread = Config::at(path.clone()).expect("reloaded");
+        assert_eq!(reread.preferences().expect("readable"), preferences);
+        let text = std::fs::read_to_string(path).expect("read back");
+        assert!(text.starts_with("# belongs to the user\n"), "{text}");
+    }
+
+    #[test]
+    fn an_unknown_history_retention_is_refused() {
+        let path = scratch("preferences-retention");
+        std::fs::write(&path, "[history]\nretention = \"eventually\"\n").expect("seeded");
+        let config = Config::at(path).expect("valid TOML");
+
+        assert!(config.preferences().is_err());
+    }
+
+    #[test]
+    fn an_unknown_startup_mode_is_refused() {
+        let path = scratch("preferences-startup");
+        std::fs::write(&path, "[general]\nstartup = \"everything\"\n").expect("seeded");
+        let config = Config::at(path).expect("valid TOML");
+
+        assert!(config.preferences().is_err());
     }
 }

--- a/crates/tidemark-core/src/secrets.rs
+++ b/crates/tidemark-core/src/secrets.rs
@@ -41,11 +41,10 @@ type MutationMap = SyncMutex<HashMap<SecretSlot, Arc<Mutex<()>>>>;
 /// `CONTEXT.md` § Identity. `xdg:schema` is the attribute name `libsecret` and other
 /// Secret Service clients use by convention to carry it — there is no dedicated field in
 /// the D-Bus API.
-pub const SCHEMA: &str = "io.github.zbndev.Tidemark.ProviderKey";
+pub use tidemark_types::ids::SECRET_SCHEMA as SCHEMA;
 
-/// The Secret Service schema a Tidemark-owned OAuth credential is filed under. Separate
-/// from [`SCHEMA`] for the reason in the module docs.
-pub const TOKEN_SCHEMA: &str = "io.github.zbndev.Tidemark.ProviderToken";
+/// The separate schema a Tidemark-owned OAuth credential is filed under.
+pub use tidemark_types::ids::TOKEN_SCHEMA;
 
 const ATTR_SCHEMA: &str = "xdg:schema";
 const ATTR_PROVIDER: &str = "provider";

--- a/crates/tidemark-core/src/storage/mod.rs
+++ b/crates/tidemark-core/src/storage/mod.rs
@@ -255,6 +255,64 @@ impl History {
         Ok(removed)
     }
 
+    /// Deletes history older than an explicit retention cutoff.
+    ///
+    /// An open segment and its latest observed state survive even when the daemon has been
+    /// offline longer than the retention period. The next reading still needs that state
+    /// to decide whether a reset happened while it was away.
+    pub fn prune_before(&mut self, cutoff: Timestamp) -> Result<usize, StorageError> {
+        let transaction = self.connection.transaction()?;
+        let removed = transaction.execute(
+            "DELETE FROM point WHERE captured_at < ?1",
+            params![cutoff.as_unix()],
+        )?;
+        transaction.execute(
+            r"
+            DELETE FROM notice
+            WHERE EXISTS (
+                SELECT 1 FROM segment
+                WHERE segment.provider = notice.provider
+                  AND segment.account  = notice.account
+                  AND segment.window   = notice.window
+                  AND segment.segment  = notice.segment
+                  AND segment.ended_at IS NOT NULL
+                  AND segment.ended_at < ?1
+            )
+            ",
+            params![cutoff.as_unix()],
+        )?;
+        transaction.execute(
+            "DELETE FROM segment WHERE ended_at IS NOT NULL AND ended_at < ?1",
+            params![cutoff.as_unix()],
+        )?;
+        transaction.commit()?;
+        Ok(removed)
+    }
+
+    /// Removes every stored reading, segment, notice and last-observed window state.
+    ///
+    /// The deletes commit as one transaction: a database that refuses halfway keeps
+    /// everything, so the caller can retry instead of inheriting a half-cleared history.
+    /// Compaction runs only after the commit, and its failure is logged rather than
+    /// reported — the deletion is already durable, and a failed VACUUM is not a failed
+    /// clear.
+    pub fn clear(&mut self) -> Result<(), StorageError> {
+        let transaction = self.connection.transaction()?;
+        transaction.execute_batch(
+            r"
+            DELETE FROM notice;
+            DELETE FROM point;
+            DELETE FROM window_state;
+            DELETE FROM segment;
+            ",
+        )?;
+        transaction.commit()?;
+        if let Err(error) = self.connection.execute_batch("VACUUM") {
+            tracing::warn!(%error, "history cleared but could not be compacted");
+        }
+        Ok(())
+    }
+
     /// Whether a notification of this kind has already gone out for this segment.
     ///
     /// Kinds are the daemon's vocabulary rather than the database's: what is stored is
@@ -981,6 +1039,99 @@ mod tests {
                 .notice_sent("test", "default", &key(), 2, "reset")
                 .expect("looked up"),
             "the segment still open must keep its notices"
+        );
+    }
+    #[test]
+    fn pruning_drops_points_before_the_retention_cutoff() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 10.0, Some(5 * HOUR)))
+            .expect("old point");
+        history
+            .ingest(&snapshot(2 * HOUR, 20.0, Some(5 * HOUR)))
+            .expect("new point");
+
+        assert_eq!(history.prune_before(at(HOUR)).expect("pruned"), 1);
+        let points = history.points("test", "default", &key(), 1).expect("read");
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].used_percent, 20.0);
+    }
+
+    #[test]
+    fn clearing_history_removes_points_segments_state_and_notices() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 72.0, Some(5 * HOUR)))
+            .expect("ingested");
+        history
+            .record_notice("test", "default", &key(), 1, "threshold-70", at(0))
+            .expect("recorded");
+
+        history.clear().expect("cleared");
+
+        assert_eq!(history.point_count().expect("points counted"), 0);
+        assert_eq!(
+            history
+                .segment_count("test", "default", &key())
+                .expect("segments counted"),
+            0
+        );
+        assert!(
+            !history
+                .notice_sent("test", "default", &key(), 1, "threshold-70")
+                .expect("notice checked")
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("state checked"),
+            None
+        );
+    }
+
+    /// A clear the database refuses partway through must keep everything: the caller will
+    /// retry, and a half-cleared database would forget notices that still apply while the
+    /// segments they belong to survive.
+    #[test]
+    fn a_clear_that_fails_partway_keeps_everything_stored() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 72.0, Some(5 * HOUR)))
+            .expect("ingested");
+        history
+            .record_notice("test", "default", &key(), 1, "threshold-70", at(0))
+            .expect("recorded");
+        history
+            .connection
+            .execute_batch(
+                "CREATE TRIGGER pinned_segment BEFORE DELETE ON segment
+                 BEGIN SELECT RAISE(FAIL, 'segments are pinned'); END;",
+            )
+            .expect("trigger installed");
+
+        assert!(
+            history.clear().is_err(),
+            "a pinned segment refuses the clear"
+        );
+
+        assert_eq!(history.point_count().expect("points counted"), 1);
+        assert_eq!(
+            history
+                .segment_count("test", "default", &key())
+                .expect("segments counted"),
+            1
+        );
+        assert!(
+            history
+                .notice_sent("test", "default", &key(), 1, "threshold-70")
+                .expect("notice checked"),
+            "a notice whose segment survived the failed clear must survive too"
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("state checked"),
+            Some(1)
         );
     }
 }

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -19,8 +19,8 @@ pub use snapshot::{AccountId, DetailRow, DetailSection, ProviderId, Snapshot, pr
 pub use time::{AbsurdTimestamp, Timestamp};
 pub use window::{DANGER_AT, WARNING_AT, Window, WindowKey, WindowLength};
 pub use wire::{
-    CredentialKind, ExternalLogin, HistoryPoint, OptionChoice, ProviderDefinition, ProviderOption,
-    ProviderState, ProviderStatus, Remedy, WindowStatus,
+    CredentialKind, DataInfo, ExternalLogin, HistoryPoint, OptionChoice, Preferences,
+    ProviderDefinition, ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus,
 };
 
 /// Identity constants. Changing any of these is a breaking change for installed units,
@@ -41,6 +41,8 @@ pub mod ids {
     pub const DAEMON_INTERFACE: &str = "io.github.zbndev.Tidemark.Daemon1";
     /// Secret Service schema for keys Tidemark owns.
     pub const SECRET_SCHEMA: &str = "io.github.zbndev.Tidemark.ProviderKey";
+    /// Secret Service schema for OAuth tokens created by a login through Tidemark.
+    pub const TOKEN_SCHEMA: &str = "io.github.zbndev.Tidemark.ProviderToken";
 }
 
 /// The value every outbound request identifies itself with.

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -316,6 +316,74 @@ impl WindowStatus {
     }
 }
 
+/// Paths and storage facts shown on the Preferences data page.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct DataInfo {
+    pub config_path: String,
+    pub history_path: String,
+    pub history_bytes: u64,
+    pub key_schema: String,
+    pub token_schema: String,
+    /// False when a distribution built the daemon without its GitHub release checker.
+    pub release_check_available: bool,
+}
+
+/// Application preferences kept by the daemon in `config.toml`.
+///
+/// Strings are used for named choices so a newer daemon can add one without changing the
+/// D-Bus signature. Unknown choices are rejected by the daemon rather than guessed by a
+/// client.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct Preferences {
+    /// Whether the daemon may ask GitHub for the latest release.
+    pub release_check: bool,
+    /// Whether the window's close button hides it when a tray icon can bring it back.
+    pub minimize_on_close: bool,
+    /// `app`, `daemon`, or `off`: the one coherent login-start behavior.
+    pub startup_mode: String,
+    /// `forever`, `six-months`, or `one-year`.
+    pub history_retention: String,
+}
+
+impl Preferences {
+    pub const STARTUP_APP: &'static str = "app";
+    pub const STARTUP_DAEMON: &'static str = "daemon";
+    pub const STARTUP_OFF: &'static str = "off";
+
+    pub const RETENTION_FOREVER: &'static str = "forever";
+    pub const RETENTION_SIX_MONTHS: &'static str = "six-months";
+    pub const RETENTION_ONE_YEAR: &'static str = "one-year";
+
+    /// Whether this build knows the named startup mode.
+    pub fn valid_startup(value: &str) -> bool {
+        matches!(
+            value,
+            Self::STARTUP_APP | Self::STARTUP_DAEMON | Self::STARTUP_OFF
+        )
+    }
+
+    /// Whether this build knows the named retention policy.
+    pub fn valid_retention(value: &str) -> bool {
+        matches!(
+            value,
+            Self::RETENTION_FOREVER | Self::RETENTION_SIX_MONTHS | Self::RETENTION_ONE_YEAR
+        )
+    }
+}
+
+impl Default for Preferences {
+    fn default() -> Self {
+        Self {
+            release_check: true,
+            minimize_on_close: true,
+            startup_mode: Self::STARTUP_APP.into(),
+            history_retention: Self::RETENTION_FOREVER.into(),
+        }
+    }
+}
+
 /// One stored measurement from the current segment of a rate-limit window.
 ///
 /// The daemon, rather than a client, owns the database that holds these rows. This compact
@@ -714,5 +782,33 @@ mod tests {
             snapshot.dominant_window().expect("present").length,
             WindowLength::from_secs(18_000)
         );
+    }
+    #[test]
+    fn data_info_survives_the_bus() {
+        let original = DataInfo {
+            config_path: "/home/test/.config/tidemark/config.toml".into(),
+            history_path: "/home/test/.local/share/tidemark/history.db".into(),
+            history_bytes: 8192,
+            key_schema: "io.github.zbndev.Tidemark.ProviderKey".into(),
+            token_schema: "io.github.zbndev.Tidemark.ProviderToken".into(),
+            release_check_available: true,
+        };
+
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
+        let (decoded, _): (DataInfo, _) = encoded.deserialize().expect("decodes again");
+        assert_eq!(decoded, original);
+    }
+    #[test]
+    fn preferences_survive_the_bus() {
+        let original = Preferences {
+            release_check: false,
+            minimize_on_close: false,
+            startup_mode: "daemon".into(),
+            history_retention: "one-year".into(),
+        };
+
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
+        let (decoded, _): (Preferences, _) = encoded.deserialize().expect("decodes again");
+        assert_eq!(decoded, original);
     }
 }

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -25,7 +25,7 @@ use std::future::poll_fn;
 use std::pin::pin;
 use std::task::Poll;
 
-use tidemark_types::{ProviderDefinition, ProviderStatus};
+use tidemark_types::{DataInfo, Preferences, ProviderDefinition, ProviderStatus, ids};
 use zbus::export::futures_core::Stream;
 
 /// How long to wait before trying the session bus again after a failure. Only reached when
@@ -53,6 +53,11 @@ pub trait Daemon {
 
     /// A newer published application release, or an empty string when none is known.
     fn get_update(&self) -> zbus::Result<String>;
+    /// Application-wide preferences stored by the daemon.
+    fn get_preferences(&self) -> zbus::Result<Preferences>;
+
+    /// Paths and storage facts for the Preferences data page.
+    fn get_data_info(&self) -> zbus::Result<DataInfo>;
 
     /// Stored points in the current segment of one window, oldest first.
     fn current_segment(
@@ -98,6 +103,12 @@ pub trait Daemon {
         enabled: bool,
     ) -> zbus::Result<()>;
 
+    fn set_release_check(&self, enabled: bool) -> zbus::Result<()>;
+    fn set_minimize_on_close(&self, enabled: bool) -> zbus::Result<()>;
+    fn set_startup_mode(&self, mode: &str) -> zbus::Result<()>;
+    fn set_history_retention(&self, retention: &str) -> zbus::Result<()>;
+    fn clear_history(&self) -> zbus::Result<()>;
+
     /// Puts the configured providers in the order the user arranged the cards in.
     fn set_order(&self, providers: &[String]) -> zbus::Result<()>;
 
@@ -117,6 +128,14 @@ pub trait Daemon {
     #[zbus(signal)]
     fn order_changed(&self, providers: Vec<String>) -> zbus::Result<()>;
 
+    /// Application preferences changed.
+    #[zbus(signal)]
+    fn preferences_changed(&self, preferences: Preferences) -> zbus::Result<()>;
+
+    /// Paths or storage facts changed.
+    #[zbus(signal)]
+    fn data_changed(&self, data: DataInfo) -> zbus::Result<()>;
+
     /// Availability of a newer published application release changed.
     #[zbus(signal)]
     fn update_changed(&self, version: &str) -> zbus::Result<()>;
@@ -134,6 +153,8 @@ pub enum Update {
         DaemonProxy<'static>,
         Option<String>,
         String,
+        Preferences,
+        DataInfo,
         Vec<ProviderDefinition>,
         Vec<ProviderStatus>,
     ),
@@ -145,6 +166,10 @@ pub enum Update {
     Reordered(Vec<String>),
     /// Availability of a newer published application release changed.
     Available(String),
+    /// Application-wide preferences changed.
+    Preferences(Preferences),
+    /// Paths or storage facts changed.
+    Data(DataInfo),
     /// There is nothing to show, with the reason to put on the screen.
     Waiting(String),
 }
@@ -186,6 +211,8 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
     let mut removals = pin!(proxy.receive_provider_removed().await?);
     let mut orders = pin!(proxy.receive_order_changed().await?);
     let mut updates = pin!(proxy.receive_update_changed().await?);
+    let mut preference_changes = pin!(proxy.receive_preferences_changed().await?);
+    let mut data_changes = pin!(proxy.receive_data_changed().await?);
 
     load(&proxy, on).await;
 
@@ -205,6 +232,12 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
             }
             if let Poll::Ready(update) = updates.as_mut().poll_next(context) {
                 return Poll::Ready(Event::Available(update));
+            }
+            if let Poll::Ready(preferences) = preference_changes.as_mut().poll_next(context) {
+                return Poll::Ready(Event::Preferences(preferences));
+            }
+            if let Poll::Ready(data) = data_changes.as_mut().poll_next(context) {
+                return Poll::Ready(Event::Data(data));
             }
             Poll::Pending
         })
@@ -240,12 +273,22 @@ async fn serve(on: &impl Fn(Update)) -> zbus::Result<()> {
                 Ok(args) => on(Update::Available(args.version.to_owned())),
                 Err(error) => tracing::warn!(%error, "an UpdateChanged signal did not parse"),
             },
+            Event::Preferences(Some(signal)) => match signal.args() {
+                Ok(args) => on(Update::Preferences(args.preferences)),
+                Err(error) => tracing::warn!(%error, "a PreferencesChanged signal did not parse"),
+            },
+            Event::Data(Some(signal)) => match signal.args() {
+                Ok(args) => on(Update::Data(args.data)),
+                Err(error) => tracing::warn!(%error, "a DataChanged signal did not parse"),
+            },
             // Any stream ending means the connection is finished with.
             Event::Owner(None)
             | Event::Changed(None)
             | Event::Removed(None)
             | Event::Reordered(None)
-            | Event::Available(None) => return Ok(()),
+            | Event::Available(None)
+            | Event::Preferences(None)
+            | Event::Data(None) => return Ok(()),
         }
     }
 }
@@ -265,11 +308,45 @@ async fn load(proxy: &DaemonProxy<'static>, on: &impl Fn(Update)) {
         tracing::info!(%error, "the daemon did not answer GetUpdate; hiding update availability");
         String::new()
     });
+    let preferences = match proxy.get_preferences().await {
+        Ok(preferences) => preferences,
+        // A daemon from before the method existed. That is the one failure compiled-in
+        // defaults are the right answer to: there is nothing on the other end that could
+        // have an opinion yet.
+        Err(error) if unknown_method(&error) => {
+            tracing::info!(%error, "the daemon predates GetPreferences; using defaults");
+            Preferences::default()
+        }
+        // Anything else is a daemon that has the method and could not answer it — a
+        // config.toml that does not parse, most likely. Defaults here would put a
+        // configuration the user never wrote on screen and invite them to edit it, so
+        // the failure goes on screen instead.
+        Err(error) => {
+            tracing::warn!(%error, "the daemon could not read its preferences");
+            on(Update::Waiting(format!(
+                "The daemon could not read its preferences: {error}"
+            )));
+            return;
+        }
+    };
+    let data = proxy.get_data_info().await.unwrap_or_else(|error| {
+        tracing::info!(%error, "the daemon did not answer GetDataInfo; hiding storage facts");
+        DataInfo {
+            config_path: String::new(),
+            history_path: String::new(),
+            history_bytes: 0,
+            key_schema: ids::SECRET_SCHEMA.into(),
+            token_schema: ids::TOKEN_SCHEMA.into(),
+            release_check_available: false,
+        }
+    });
     match (definitions, statuses) {
         (Ok(definitions), Ok(statuses)) => on(Update::Connected(
             proxy.clone(),
             version,
             available,
+            preferences,
+            data,
             definitions,
             statuses,
         )),
@@ -280,6 +357,21 @@ async fn load(proxy: &DaemonProxy<'static>, on: &impl Fn(Update)) {
     }
 }
 
+/// Whether an error says the method itself is not there.
+///
+/// It is the one answer that separates an older daemon, which a client may speak for with
+/// its own defaults, from a current daemon reporting a real failure, which it may not.
+/// zbus delivers an error reply as [`zbus::Error::MethodError`] carrying the wire name;
+/// the [`zbus::fdo`] form is matched too so a locally built error classifies the same way.
+fn unknown_method(error: &zbus::Error) -> bool {
+    const UNKNOWN_METHOD: &str = "org.freedesktop.DBus.Error.UnknownMethod";
+    match error {
+        zbus::Error::MethodError(name, _, _) => name.as_str() == UNKNOWN_METHOD,
+        zbus::Error::FDO(error) => matches!(error.as_ref(), zbus::fdo::Error::UnknownMethod(_)),
+        _ => false,
+    }
+}
+
 /// One of the streams the [`serve`] loop watches produced something.
 enum Event {
     Owner(Option<Option<zbus::names::UniqueName<'static>>>),
@@ -287,6 +379,8 @@ enum Event {
     Removed(Option<ProviderRemoved>),
     Reordered(Option<OrderChanged>),
     Available(Option<UpdateChanged>),
+    Preferences(Option<PreferencesChanged>),
+    Data(Option<DataChanged>),
 }
 
 #[cfg(test)]
@@ -294,9 +388,10 @@ mod tests {
     use std::cell::RefCell;
     use std::process;
 
-    use tidemark_types::{ProviderDefinition, ProviderStatus, ids};
+    use tidemark_types::{Preferences, ProviderDefinition, ProviderStatus, ids};
 
     use super::{DaemonProxy, Update, load};
+    use zbus::fdo;
 
     #[derive(Debug)]
     struct VersionService(&'static str);
@@ -320,6 +415,26 @@ mod tests {
 
         fn get_status(&self) -> Vec<ProviderStatus> {
             Vec::new()
+        }
+    }
+    /// A daemon that implements `GetPreferences` but cannot read its own storage.
+    #[derive(Debug)]
+    struct FailingPreferencesService;
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl FailingPreferencesService {
+        fn list_providers(&self) -> Vec<ProviderDefinition> {
+            Vec::new()
+        }
+
+        fn get_status(&self) -> Vec<ProviderStatus> {
+            Vec::new()
+        }
+
+        fn get_preferences(&self) -> fdo::Result<Preferences> {
+            Err(fdo::Error::Failed(
+                "the preferences in config.toml do not parse".into(),
+            ))
         }
     }
 
@@ -405,13 +520,103 @@ mod tests {
             .await;
 
             match seen.into_inner() {
-                Some(Update::Connected(_, version, available, definitions, statuses)) => {
+                Some(Update::Connected(
+                    _,
+                    version,
+                    available,
+                    preferences,
+                    data,
+                    definitions,
+                    statuses,
+                )) => {
                     assert_eq!(version, None);
                     assert_eq!(available, "");
+                    assert_eq!(preferences, Preferences::default());
+                    assert!(!data.release_check_available);
                     assert!(definitions.is_empty());
                     assert!(statuses.is_empty());
                 }
                 other => panic!("expected connected status, got {other:?}"),
+            }
+        });
+    }
+    #[test]
+    fn only_a_missing_get_preferences_is_answered_with_defaults() {
+        zbus::block_on(async {
+            let Ok(client_connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus is reachable");
+                return;
+            };
+
+            // A daemon from before GetPreferences existed: the interface answers, the
+            // method does not, and compiled-in defaults are the compatibility answer.
+            let legacy = format!("io.github.zbndev.Tidemark.LegacyTest.p{}", process::id());
+            let _legacy = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(legacy.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, StatusService)
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("legacy test service");
+            let legacy_destination = zbus::names::OwnedBusName::try_from(legacy.as_str())
+                .expect("valid owned test destination");
+            let proxy = DaemonProxy::builder(&client_connection)
+                .destination(legacy_destination)
+                .expect("test destination")
+                .build()
+                .await
+                .expect("daemon proxy");
+            let seen = RefCell::new(None);
+
+            load(&proxy, &|update| {
+                seen.replace(Some(update));
+            })
+            .await;
+
+            match seen.into_inner() {
+                Some(Update::Connected(_, _, _, preferences, _, _, _)) => {
+                    assert_eq!(preferences, Preferences::default());
+                }
+                other => panic!("expected compatibility defaults, got {other:?}"),
+            }
+
+            // A daemon that has GetPreferences but fails to read: the error must reach
+            // the window rather than being replaced by defaults the user never wrote.
+            let broken = format!("io.github.zbndev.Tidemark.BrokenTest.p{}", process::id());
+            let _broken = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(broken.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, FailingPreferencesService)
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("broken test service");
+            let broken_destination = zbus::names::OwnedBusName::try_from(broken.as_str())
+                .expect("valid owned test destination");
+            let proxy = DaemonProxy::builder(&client_connection)
+                .destination(broken_destination)
+                .expect("test destination")
+                .build()
+                .await
+                .expect("daemon proxy");
+            let seen = RefCell::new(None);
+
+            load(&proxy, &|update| {
+                seen.replace(Some(update));
+            })
+            .await;
+
+            match seen.into_inner() {
+                Some(Update::Waiting(reason)) => {
+                    assert!(
+                        reason.contains("do not parse"),
+                        "the read failure should stay visible, got: {reason}"
+                    );
+                }
+                other => panic!("expected the read failure to stay visible, got {other:?}"),
             }
         });
     }

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -22,6 +22,7 @@ mod format;
 mod grid;
 mod mark;
 mod model;
+mod preferences;
 mod provider_settings;
 mod style;
 mod tray;

--- a/crates/tidemark/src/preferences.rs
+++ b/crates/tidemark/src/preferences.rs
@@ -1,0 +1,554 @@
+//! Application preferences: behavior, startup, updates and local data.
+
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
+
+use adw::prelude::*;
+use gtk::glib;
+use tidemark_types::{DataInfo, Preferences};
+
+use crate::bus::DaemonProxy;
+
+const RETENTION_VALUES: [&str; 3] = [
+    Preferences::RETENTION_FOREVER,
+    Preferences::RETENTION_SIX_MONTHS,
+    Preferences::RETENTION_ONE_YEAR,
+];
+
+/// What the retention values above are called on screen, in the same order.
+const RETENTION_LABELS: [&str; 3] = ["Forever", "6 months", "1 year"];
+
+const STARTUP_VALUES: [&str; 3] = [
+    Preferences::STARTUP_APP,
+    Preferences::STARTUP_DAEMON,
+    Preferences::STARTUP_OFF,
+];
+
+/// What the startup values above are called on screen, in the same order.
+const STARTUP_LABELS: [&str; 3] = ["App and tray", "Daemon only", "Off"];
+
+#[derive(Debug, Clone, Copy)]
+enum SwitchKind {
+    ReleaseCheck,
+    MinimizeOnClose,
+}
+
+/// The standard libadwaita Preferences dialog and its authoritative daemon-backed state.
+#[derive(Debug)]
+pub struct PreferencesDialog {
+    dialog: adw::PreferencesDialog,
+    proxy: DaemonProxy<'static>,
+    release_check: adw::SwitchRow,
+    minimize_on_close: adw::SwitchRow,
+    startup: adw::ComboRow,
+    retention: adw::ComboRow,
+    config_path: adw::ActionRow,
+    history_path: adw::ActionRow,
+    history_size: adw::ActionRow,
+    key_schema: adw::ActionRow,
+    token_schema: adw::ActionRow,
+    preferences: RefCell<Preferences>,
+    data: RefCell<DataInfo>,
+    suppress: Cell<bool>,
+}
+
+impl PreferencesDialog {
+    pub fn present(
+        parent: &impl IsA<gtk::Widget>,
+        proxy: DaemonProxy<'static>,
+        preferences: Preferences,
+        data: DataInfo,
+        on_closed: impl Fn() + 'static,
+    ) -> Rc<Self> {
+        let dialog = adw::PreferencesDialog::builder()
+            .title("Preferences")
+            .content_width(620)
+            .content_height(680)
+            .build();
+
+        let minimize_on_close = adw::SwitchRow::builder()
+            .title("Minimize to tray on close")
+            .subtitle("Keep Tidemark running when a tray icon can bring the window back.")
+            .build();
+        let startup_mode = adw::ComboRow::builder()
+            .title("Start at login")
+            .subtitle("Choose what starts with your graphical session.")
+            .model(&gtk::StringList::new(&STARTUP_LABELS))
+            .expression(gtk::PropertyExpression::new(
+                gtk::StringObject::static_type(),
+                None::<gtk::Expression>,
+                "string",
+            ))
+            .use_subtitle(true)
+            .build();
+
+        let behavior = adw::PreferencesGroup::builder().title("Behavior").build();
+        behavior.add(&minimize_on_close);
+        let startup = adw::PreferencesGroup::builder().title("Startup").build();
+        startup.add(&startup_mode);
+        let general = adw::PreferencesPage::builder()
+            .title("General")
+            .icon_name("preferences-system-symbolic")
+            .build();
+        general.add(&behavior);
+        general.add(&startup);
+        dialog.add(&general);
+
+        let release_check = adw::SwitchRow::builder()
+            .title("Check for updates")
+            .subtitle("Ask GitHub for the latest Tidemark release once an hour.")
+            .build();
+        let release_group = adw::PreferencesGroup::builder()
+            .title("Release Updates")
+            .build();
+        release_group.add(&release_check);
+        let updates = adw::PreferencesPage::builder()
+            .title("Updates")
+            .icon_name("software-update-available-symbolic")
+            .build();
+        updates.add(&release_group);
+        dialog.add(&updates);
+
+        let retention = adw::ComboRow::builder()
+            .title("Keep history")
+            .subtitle("Older readings are deleted after this period.")
+            .model(&gtk::StringList::new(&RETENTION_LABELS))
+            .expression(gtk::PropertyExpression::new(
+                gtk::StringObject::static_type(),
+                None::<gtk::Expression>,
+                "string",
+            ))
+            .use_subtitle(true)
+            .build();
+        let clear = gtk::Button::builder()
+            .label("Clear History")
+            .valign(gtk::Align::Center)
+            .css_classes(["destructive-action"])
+            .build();
+        let clear_row = adw::ActionRow::builder()
+            .title("Recorded quota history")
+            .subtitle("Delete readings and notification records. Accounts and credentials stay.")
+            .build();
+        clear_row.add_suffix(&clear);
+
+        let history_group = adw::PreferencesGroup::builder().title("History").build();
+        history_group.add(&retention);
+        history_group.add(&clear_row);
+
+        let config_path = path_row("Configuration file");
+        let history_path = path_row("History database");
+        let history_size = adw::ActionRow::builder().title("Database size").build();
+        let files = adw::PreferencesGroup::builder().title("Files").build();
+        files.add(&config_path);
+        files.add(&history_path);
+        files.add(&history_size);
+
+        let key_schema = path_row("API keys");
+        let token_schema = path_row("OAuth sessions");
+        let keyring = adw::PreferencesGroup::builder()
+            .title("System Keyring")
+            .description("Secrets stay in the desktop Secret Service, not in config.toml.")
+            .build();
+        keyring.add(&key_schema);
+        keyring.add(&token_schema);
+
+        let data_page = adw::PreferencesPage::builder()
+            .title("Data")
+            .icon_name("folder-documents-symbolic")
+            .build();
+        data_page.add(&history_group);
+        data_page.add(&files);
+        data_page.add(&keyring);
+        dialog.add(&data_page);
+
+        let settings = Rc::new(Self {
+            dialog: dialog.clone(),
+            proxy,
+            release_check,
+            minimize_on_close,
+            startup: startup_mode,
+            retention,
+            config_path,
+            history_path,
+            history_size,
+            key_schema,
+            token_schema,
+            preferences: RefCell::new(preferences.clone()),
+            data: RefCell::new(data.clone()),
+            suppress: Cell::new(false),
+        });
+
+        settings.connect_switch(&settings.release_check, SwitchKind::ReleaseCheck);
+        settings.connect_switch(&settings.minimize_on_close, SwitchKind::MinimizeOnClose);
+        settings.connect_startup();
+        settings.connect_retention();
+        settings.connect_clear(&clear);
+        settings.apply(&preferences, &data);
+
+        dialog.connect_closed({
+            let weak = Rc::downgrade(&settings);
+            move |_| {
+                if weak.upgrade().is_some() {
+                    on_closed();
+                }
+            }
+        });
+        dialog.present(Some(parent));
+        settings
+    }
+
+    pub fn apply(&self, preferences: &Preferences, data: &DataInfo) {
+        *self.preferences.borrow_mut() = preferences.clone();
+        *self.data.borrow_mut() = data.clone();
+        self.suppress.set(true);
+        self.release_check
+            .set_active(preferences.release_check && data.release_check_available);
+        self.minimize_on_close
+            .set_active(preferences.minimize_on_close);
+        apply_named_choice(
+            &self.startup,
+            &STARTUP_LABELS,
+            startup_index(&preferences.startup_mode),
+            &preferences.startup_mode,
+        );
+        apply_named_choice(
+            &self.retention,
+            &RETENTION_LABELS,
+            retention_index(&preferences.history_retention),
+            &preferences.history_retention,
+        );
+        self.suppress.set(false);
+
+        self.release_check
+            .set_sensitive(data.release_check_available);
+        self.release_check
+            .set_subtitle(if data.release_check_available {
+                "Ask GitHub for the latest Tidemark release once an hour."
+            } else {
+                "Release checks are disabled in this build."
+            });
+        self.config_path
+            .set_subtitle(&display_path(&data.config_path));
+        self.history_path
+            .set_subtitle(&display_path(&data.history_path));
+        self.history_size
+            .set_subtitle(&format_bytes(data.history_bytes));
+        self.key_schema.set_subtitle(&data.key_schema);
+        self.token_schema.set_subtitle(&data.token_schema);
+    }
+
+    fn connect_switch(self: &Rc<Self>, row: &adw::SwitchRow, kind: SwitchKind) {
+        row.connect_active_notify({
+            let weak = Rc::downgrade(self);
+            move |row| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                if settings.suppress.get() {
+                    return;
+                }
+                settings.change_switch(kind, row.is_active());
+            }
+        });
+    }
+
+    fn change_switch(self: Rc<Self>, kind: SwitchKind, enabled: bool) {
+        let row = self.switch_row(kind).clone();
+        row.set_sensitive(false);
+        glib::spawn_future_local(async move {
+            let result = match kind {
+                SwitchKind::ReleaseCheck => self.proxy.set_release_check(enabled).await,
+                SwitchKind::MinimizeOnClose => self.proxy.set_minimize_on_close(enabled).await,
+            };
+            if let Err(error) = result {
+                let preferences = self.preferences.borrow().clone();
+                let data = self.data.borrow().clone();
+                self.apply(&preferences, &data);
+                self.toast(&error.to_string());
+            } else {
+                let mut preferences = self.preferences.borrow_mut();
+                match kind {
+                    SwitchKind::ReleaseCheck => preferences.release_check = enabled,
+                    SwitchKind::MinimizeOnClose => preferences.minimize_on_close = enabled,
+                }
+            }
+            if !matches!(kind, SwitchKind::ReleaseCheck)
+                || self.data.borrow().release_check_available
+            {
+                row.set_sensitive(true);
+            }
+        });
+    }
+
+    fn switch_row(&self, kind: SwitchKind) -> &adw::SwitchRow {
+        match kind {
+            SwitchKind::ReleaseCheck => &self.release_check,
+            SwitchKind::MinimizeOnClose => &self.minimize_on_close,
+        }
+    }
+
+    fn connect_startup(self: &Rc<Self>) {
+        self.startup.connect_selected_notify({
+            let weak = Rc::downgrade(self);
+            move |row| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                if settings.suppress.get() {
+                    return;
+                }
+                let Some(mode) = STARTUP_VALUES.get(row.selected() as usize) else {
+                    return;
+                };
+                let mode = (*mode).to_owned();
+                row.set_sensitive(false);
+                let row = row.clone();
+                glib::spawn_future_local(async move {
+                    if let Err(error) = settings.proxy.set_startup_mode(&mode).await {
+                        let preferences = settings.preferences.borrow().clone();
+                        let data = settings.data.borrow().clone();
+                        settings.apply(&preferences, &data);
+                        settings.toast(&error.to_string());
+                    } else {
+                        settings.preferences.borrow_mut().startup_mode = mode;
+                    }
+                    row.set_sensitive(true);
+                });
+            }
+        });
+    }
+
+    fn connect_retention(self: &Rc<Self>) {
+        self.retention.connect_selected_notify({
+            let weak = Rc::downgrade(self);
+            move |row| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                if settings.suppress.get() {
+                    return;
+                }
+                let Some(retention) = RETENTION_VALUES.get(row.selected() as usize) else {
+                    return;
+                };
+                let retention = (*retention).to_owned();
+                row.set_sensitive(false);
+                let row = row.clone();
+                glib::spawn_future_local(async move {
+                    if let Err(error) = settings.proxy.set_history_retention(&retention).await {
+                        let preferences = settings.preferences.borrow().clone();
+                        let data = settings.data.borrow().clone();
+                        settings.apply(&preferences, &data);
+                        settings.toast(&error.to_string());
+                    } else {
+                        settings.preferences.borrow_mut().history_retention = retention;
+                    }
+                    row.set_sensitive(true);
+                });
+            }
+        });
+    }
+
+    fn connect_clear(self: &Rc<Self>, button: &gtk::Button) {
+        button.connect_clicked({
+            let weak: Weak<Self> = Rc::downgrade(self);
+            move |button| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                button.set_sensitive(false);
+                let button = button.clone();
+                glib::spawn_future_local(async move {
+                    let confirmation = adw::AlertDialog::builder()
+                        .heading("Clear history?")
+                        .body("This permanently deletes recorded quota history and notification records. Provider accounts and credentials are not affected.")
+                        .build();
+                    confirmation.add_responses(&[("cancel", "Cancel"), ("clear", "Clear History")]);
+                    confirmation.set_default_response(Some("cancel"));
+                    confirmation.set_close_response("cancel");
+                    confirmation.set_response_appearance(
+                        "clear",
+                        adw::ResponseAppearance::Destructive,
+                    );
+                    if confirmation.choose_future(Some(&settings.dialog)).await == "clear" {
+                        match settings.proxy.clear_history().await {
+                            Ok(()) => {
+                                settings.toast("History cleared");
+                                if let Ok(data) = settings.proxy.get_data_info().await {
+                                    let preferences = settings.preferences.borrow().clone();
+                                    settings.apply(&preferences, &data);
+                                }
+                            }
+                            Err(error) => settings.toast(&error.to_string()),
+                        }
+                    }
+                    button.set_sensitive(true);
+                });
+            }
+        });
+    }
+
+    fn toast(&self, message: &str) {
+        self.dialog.add_toast(adw::Toast::new(message));
+    }
+}
+
+fn path_row(title: &str) -> adw::ActionRow {
+    adw::ActionRow::builder().title(title).build()
+}
+
+fn display_path(path: &str) -> String {
+    if path.is_empty() {
+        "Unavailable until the daemon is restarted".into()
+    } else {
+        path.into()
+    }
+}
+
+/// Shows a named daemon choice on a combo row.
+///
+/// A value this build does not know is kept visible and untouchable rather than guessed:
+/// the row is emptied of choices so it cannot show or select a different one, disabled so
+/// it cannot be changed by accident, and says what the daemon actually reported. A known
+/// value puts the choices back, selects its own, and leaves the row editable.
+///
+/// Emptying the row is what it takes: `AdwComboRow` holds a model with a valid selection
+/// in it, and setting the position to [`gtk::INVALID_LIST_POSITION`] with the labels still
+/// there leaves the first one selected — the very guess this avoids.
+fn apply_named_choice(row: &adw::ComboRow, labels: &[&str], known: Option<u32>, raw: &str) {
+    match known {
+        Some(index) => {
+            if row.model().is_none() {
+                row.set_model(Some(&gtk::StringList::new(labels)));
+            }
+            row.set_use_subtitle(true);
+            row.set_selected(index);
+            row.set_sensitive(true);
+        }
+        None => {
+            row.set_model(None::<&gtk::StringList>);
+            row.set_use_subtitle(false);
+            row.set_subtitle(&format!(
+                "Unsupported value {raw:?} reported by the daemon."
+            ));
+            row.set_sensitive(false);
+        }
+    }
+}
+
+fn retention_index(value: &str) -> Option<u32> {
+    RETENTION_VALUES
+        .iter()
+        .position(|candidate| *candidate == value)
+        .map(|index| index as u32)
+}
+
+fn startup_index(value: &str) -> Option<u32> {
+    STARTUP_VALUES
+        .iter()
+        .position(|candidate| *candidate == value)
+        .map(|index| index as u32)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    match bytes {
+        0..=1023 => format!("{bytes} bytes"),
+        MIB..=u64::MAX if bytes < GIB => format!("{:.1} MiB", bytes as f64 / MIB as f64),
+        GIB..=u64::MAX => format!("{:.1} GiB", bytes as f64 / GIB as f64),
+        _ => format!("{:.1} KiB", bytes as f64 / KIB as f64),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_retention_policy_selects_its_named_row() {
+        assert_eq!(retention_index(Preferences::RETENTION_FOREVER), Some(0));
+        assert_eq!(retention_index(Preferences::RETENTION_SIX_MONTHS), Some(1));
+        assert_eq!(retention_index(Preferences::RETENTION_ONE_YEAR), Some(2));
+        assert_eq!(retention_index("eventually"), None);
+    }
+
+    #[test]
+    fn every_startup_mode_selects_its_named_row() {
+        assert_eq!(startup_index(Preferences::STARTUP_APP), Some(0));
+        assert_eq!(startup_index(Preferences::STARTUP_DAEMON), Some(1));
+        assert_eq!(startup_index(Preferences::STARTUP_OFF), Some(2));
+        assert_eq!(startup_index("everything"), None);
+    }
+
+    #[test]
+    fn database_sizes_are_readable_without_losing_small_values() {
+        assert_eq!(format_bytes(0), "0 bytes");
+        assert_eq!(format_bytes(512), "512 bytes");
+        assert_eq!(format_bytes(1536), "1.5 KiB");
+        assert_eq!(format_bytes(2 * 1024 * 1024), "2.0 MiB");
+    }
+    /// Whether a display is available for building widgets; the row state below can only
+    /// be observed on real ones. Every widget assertion lives in a single test because
+    /// GTK belongs to the thread that initialized it and the harness gives each test its
+    /// own thread.
+    fn widgets() -> bool {
+        static READY: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| adw::init().is_ok());
+        *READY
+    }
+
+    fn choice_row(labels: &[&str]) -> adw::ComboRow {
+        adw::ComboRow::builder()
+            .model(&gtk::StringList::new(labels))
+            .expression(gtk::PropertyExpression::new(
+                gtk::StringObject::static_type(),
+                None::<gtk::Expression>,
+                "string",
+            ))
+            .use_subtitle(true)
+            .build()
+    }
+
+    #[test]
+    fn unknown_named_choices_are_kept_visible_and_untouchable() {
+        if !widgets() {
+            eprintln!("skipped: no display is available");
+            return;
+        }
+
+        for (labels, known, raw) in [
+            (
+                &STARTUP_LABELS,
+                startup_index(Preferences::STARTUP_DAEMON),
+                "launcher",
+            ),
+            (
+                &RETENTION_LABELS,
+                retention_index(Preferences::RETENTION_ONE_YEAR),
+                "decade",
+            ),
+        ] {
+            let row = choice_row(labels);
+
+            apply_named_choice(&row, labels, None, raw);
+
+            assert_eq!(row.selected(), gtk::INVALID_LIST_POSITION);
+            assert!(row.model().is_none());
+            assert!(!row.is_sensitive());
+            assert!(
+                row.subtitle()
+                    .is_some_and(|subtitle| subtitle.contains(&format!("{raw:?}"))),
+                "the raw value should stay visible, got: {:?}",
+                row.subtitle()
+            );
+
+            // A known value reported later selects its row and can be changed again.
+            apply_named_choice(&row, labels, known, "ignored");
+            assert_eq!(row.selected(), known.unwrap());
+            assert!(row.model().is_some());
+            assert!(row.is_sensitive());
+            assert!(row.uses_subtitle());
+        }
+    }
+}

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -11,12 +11,14 @@
 //! data — the relative timestamps, and the pace marks, which keep moving while nothing else
 //! changes.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
 use gtk::{gio, glib};
-use tidemark_types::{ProviderDefinition, ProviderStatus, Timestamp};
+use tidemark_types::{
+    DataInfo, Preferences as AppPreferences, ProviderDefinition, ProviderStatus, Timestamp, ids,
+};
 
 use crate::about;
 use crate::bus::{self, DaemonProxy, Update};
@@ -24,6 +26,7 @@ use crate::card::Card;
 use crate::detail::DetailDialog;
 use crate::grid::CardGrid;
 use crate::model;
+use crate::preferences::PreferencesDialog;
 use crate::provider_settings::ProviderSettings;
 use crate::tray::{self, Tray};
 use crate::update::{self, UpdateNotice};
@@ -41,6 +44,10 @@ fn account_index(statuses: &[ProviderStatus], provider: &str, account: &str) -> 
     statuses
         .iter()
         .position(|status| status.provider == provider && status.account == account)
+}
+
+fn should_minimize_on_close(tray_available: bool, preference: bool) -> bool {
+    tray_available && preference
 }
 
 #[derive(Debug)]
@@ -85,6 +92,7 @@ pub struct MainWindow {
     refresh: gtk::Button,
     release: gtk::Button,
     providers: gtk::Button,
+    preferences_action: gio::SimpleAction,
     /// The cards in the order they are on screen. The one order this process has: the tray
     /// menu and the settings list are both drawn from it, and it is what a drag permutes.
     cards: RefCell<Vec<Rc<Card>>>,
@@ -94,8 +102,12 @@ pub struct MainWindow {
     /// page. `None` while nothing is answering on the bus.
     daemon_version: RefCell<Option<String>>,
     update_notice: RefCell<UpdateNotice>,
+    preferences: RefCell<AppPreferences>,
+    data_info: RefCell<DataInfo>,
+    minimize_on_close: Cell<bool>,
     /// The provider dialog while it is open, so live catalog and status changes reach it.
     provider_settings: DialogSlot<ProviderSettings>,
+    preferences_dialog: DialogSlot<PreferencesDialog>,
     /// The account detail dialog while it is open, so its chart follows daemon updates.
     detail_dialog: DialogSlot<DetailDialog>,
     /// The panel icon, once a status-notifier host has accepted it. `None` in a session
@@ -154,7 +166,12 @@ impl MainWindow {
         // looks for About without being told where it is. `primary` is what makes F10 open
         // it, which is the shortcut the shell's own menus answer to.
         let menu = gio::Menu::new();
-        menu.append(Some("_About Tidemark"), Some("win.about"));
+        let preferences_section = gio::Menu::new();
+        preferences_section.append(Some("_Preferences"), Some("win.preferences"));
+        menu.append_section(None, &preferences_section);
+        let about_section = gio::Menu::new();
+        about_section.append(Some("_About Tidemark"), Some("win.about"));
+        menu.append_section(None, &about_section);
         let primary_menu = gtk::MenuButton::builder()
             .icon_name("open-menu-symbolic")
             .tooltip_text("Main Menu")
@@ -181,6 +198,9 @@ impl MainWindow {
             .content(&view)
             .build();
 
+        let preferences_action = gio::SimpleAction::new("preferences", None);
+        preferences_action.set_enabled(false);
+
         let main = Rc::new(Self {
             window,
             stack,
@@ -189,12 +209,24 @@ impl MainWindow {
             refresh,
             release,
             providers,
+            preferences_action,
             cards: RefCell::new(Vec::new()),
             definitions: RefCell::new(Vec::new()),
             daemon: RefCell::new(None),
             daemon_version: RefCell::new(None),
             update_notice: RefCell::new(UpdateNotice::new(env!("CARGO_PKG_VERSION"))),
+            preferences: RefCell::new(AppPreferences::default()),
+            data_info: RefCell::new(DataInfo {
+                config_path: String::new(),
+                history_path: String::new(),
+                history_bytes: 0,
+                key_schema: ids::SECRET_SCHEMA.into(),
+                token_schema: ids::TOKEN_SCHEMA.into(),
+                release_check_available: false,
+            }),
+            minimize_on_close: Cell::new(true),
             provider_settings: DialogSlot::default(),
+            preferences_dialog: DialogSlot::default(),
             detail_dialog: DialogSlot::default(),
             tray: RefCell::new(None),
         });
@@ -203,6 +235,7 @@ impl MainWindow {
         main.connect_refresh_button();
         main.connect_update_button();
         main.connect_providers_button();
+        main.connect_preferences_action();
         main.connect_about_action();
         main.start_clock();
         main.start_tray(background);
@@ -221,12 +254,23 @@ impl MainWindow {
     /// Acts on one message from the daemon.
     fn handle(self: &Rc<Self>, update: Update) {
         match update {
-            Update::Connected(proxy, daemon_version, available, definitions, statuses) => {
+            Update::Connected(
+                proxy,
+                daemon_version,
+                available,
+                preferences,
+                data,
+                definitions,
+                statuses,
+            ) => {
                 *self.daemon.borrow_mut() = Some(proxy);
                 self.daemon_version.replace(daemon_version.clone());
                 *self.definitions.borrow_mut() = definitions;
+                self.preferences_action.set_enabled(true);
                 self.refresh.set_sensitive(true);
                 self.providers.set_sensitive(true);
+                self.apply_preferences(preferences);
+                self.apply_data(data);
                 self.show_update(&available);
                 self.show_all(statuses);
 
@@ -271,9 +315,12 @@ impl MainWindow {
             Update::Removed { provider, account } => self.show_removed(&provider, &account),
             Update::Reordered(providers) => self.show_order(&providers),
             Update::Available(version) => self.show_update(&version),
+            Update::Preferences(preferences) => self.apply_preferences(preferences),
+            Update::Data(data) => self.apply_data(data),
             Update::Waiting(reason) => {
                 *self.daemon.borrow_mut() = None;
                 self.daemon_version.replace(None);
+                self.preferences_action.set_enabled(false);
                 self.refresh.set_sensitive(false);
                 self.providers.set_sensitive(false);
                 self.show_update("");
@@ -497,6 +544,54 @@ impl MainWindow {
         });
     }
 
+    fn connect_preferences_action(self: &Rc<Self>) {
+        let weak: Weak<Self> = Rc::downgrade(self);
+        self.preferences_action.connect_activate(move |_, _| {
+            let Some(main) = weak.upgrade() else {
+                return;
+            };
+            if let Some(dialog) = main.preferences_dialog.get() {
+                dialog.apply(&main.preferences.borrow(), &main.data_info.borrow());
+                return;
+            }
+            let Some(proxy) = main.daemon.borrow().clone() else {
+                return;
+            };
+            let on_closed = {
+                let weak = weak.clone();
+                move || {
+                    if let Some(main) = weak.upgrade() {
+                        main.preferences_dialog.clear();
+                    }
+                }
+            };
+            let dialog = PreferencesDialog::present(
+                &main.window,
+                proxy,
+                main.preferences.borrow().clone(),
+                main.data_info.borrow().clone(),
+                on_closed,
+            );
+            assert!(main.preferences_dialog.insert_if_empty(dialog));
+        });
+        self.window.add_action(&self.preferences_action);
+    }
+
+    fn apply_preferences(&self, preferences: AppPreferences) {
+        self.minimize_on_close.set(preferences.minimize_on_close);
+        *self.preferences.borrow_mut() = preferences;
+        if let Some(dialog) = self.preferences_dialog.get() {
+            dialog.apply(&self.preferences.borrow(), &self.data_info.borrow());
+        }
+    }
+
+    fn apply_data(&self, data: DataInfo) {
+        *self.data_info.borrow_mut() = data;
+        if let Some(dialog) = self.preferences_dialog.get() {
+            dialog.apply(&self.preferences.borrow(), &self.data_info.borrow());
+        }
+    }
+
     /// Installs `win.about`, the one entry in the primary menu.
     ///
     /// A window action rather than an application one: what the dialog reports — which
@@ -716,12 +811,19 @@ impl MainWindow {
     }
 
     /// Turns the close button into a hide, now that there is an icon to get back from.
-    fn close_to_tray(&self) {
-        self.window.connect_close_request(|window| {
+    fn close_to_tray(self: &Rc<Self>) {
+        let weak = Rc::downgrade(self);
+        self.window.connect_close_request(move |window| {
+            let Some(main) = weak.upgrade() else {
+                return glib::Propagation::Proceed;
+            };
+            if !should_minimize_on_close(main.tray.borrow().is_some(), main.minimize_on_close.get())
+            {
+                return glib::Propagation::Proceed;
+            }
             window.set_visible(false);
-            // The window stays in the application's window list while it is merely hidden,
-            // which is what keeps the process alive with nothing on screen. `Quit` in the
-            // tray menu is the way out, and the only one.
+            // A working tray is already guaranteed by the only caller. The preference is
+            // read at close time, so changing it needs no reconnect or restart.
             glib::Propagation::Stop
         });
     }
@@ -762,7 +864,7 @@ mod tests {
 
     use tidemark_types::{AccountId, ProviderId, ProviderStatus};
 
-    use super::{DialogSlot, account_index};
+    use super::{DialogSlot, account_index, should_minimize_on_close};
 
     fn status(provider: &str, account: &str) -> ProviderStatus {
         ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
@@ -782,5 +884,11 @@ mod tests {
         assert!(!slot.insert_if_empty(Rc::new(2)));
         slot.clear();
         assert!(slot.insert_if_empty(Rc::new(3)));
+    }
+    #[test]
+    fn close_hides_only_when_both_the_tray_and_preference_allow_it() {
+        assert!(should_minimize_on_close(true, true));
+        assert!(!should_minimize_on_close(true, false));
+        assert!(!should_minimize_on_close(false, true));
     }
 }

--- a/crates/tidemarkd/Cargo.toml
+++ b/crates/tidemarkd/Cargo.toml
@@ -11,6 +11,10 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["update-check"]
+update-check = ["dep:reqwest", "dep:semver"]
+
 [dependencies]
 tidemark-types = { path = "../tidemark-types" }
 tidemark-core = { version = "0.1.1", path = "../tidemark-core" }
@@ -20,5 +24,10 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 serde_json = "1.0.151"
 thiserror = "2.0.20"
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy"] }
-semver = "1.0.27"
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy"], optional = true }
+semver = { version = "1.0.27", optional = true }
+
+[dev-dependencies]
+# Only to hold a second write lock against the history database in tests: the same
+# version tidemark-core links, so one build of the C library serves the whole workspace.
+rusqlite = "0.40.2"

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -17,8 +17,8 @@ use tidemark_core::providers::{Credential, Provider, ProviderError};
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_core::storage::{History, IngestReport};
 use tidemark_types::{
-    AccountId, CredentialKind, HistoryPoint, ProviderId, ProviderOption, ProviderState,
-    ProviderStatus, Snapshot, Timestamp, WindowKey, WindowStatus,
+    AccountId, CredentialKind, HistoryPoint, Preferences, ProviderId, ProviderOption,
+    ProviderState, ProviderStatus, Snapshot, Timestamp, WindowKey, WindowStatus,
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
@@ -55,6 +55,15 @@ pub enum Publication {
     /// A sequence rather than a status, because that is what changed: the readings are
     /// exactly as they were, and a client redrawing a grid needs the positions.
     Reordered(Vec<String>),
+}
+
+/// One application-wide preference mutation.
+#[derive(Debug)]
+pub enum Preference {
+    ReleaseCheck(bool),
+    MinimizeOnClose(bool),
+    StartupMode(String),
+    HistoryRetention(String),
 }
 
 /// What the D-Bus interface asks the loop to do.
@@ -131,6 +140,15 @@ pub enum Command {
         window: String,
         /// Completion with oldest-first points, or a named account/storage error.
         reply: oneshot::Sender<Result<Vec<HistoryPoint>, String>>,
+    },
+    /// Persists one application-wide preference.
+    SetPreference {
+        preference: Preference,
+        reply: oneshot::Sender<Result<Preferences, String>>,
+    },
+    /// Deletes every stored historical reading and notification marker.
+    ClearHistory {
+        reply: oneshot::Sender<Result<(), String>>,
     },
     /// Stop the loop.
     Shutdown,
@@ -503,6 +521,55 @@ impl Engine {
         Ok(())
     }
 
+    /// Persists one application preference in the same serial queue as every other config
+    /// mutation. Returning the complete set lets the service publish one coherent view.
+    ///
+    /// The immediate retention prune is maintenance after the commit, not part of it: a
+    /// database that will not prune must not report an already-durable preference as
+    /// failed — daily maintenance retries the pruning, and the caller's platform state
+    /// (release watch, startup integration) must follow the durable config.
+    pub async fn set_preference(&mut self, preference: Preference) -> Result<Preferences, String> {
+        let retention_changed = matches!(&preference, Preference::HistoryRetention(_));
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        match preference {
+            Preference::ReleaseCheck(enabled) => config.set_release_check(enabled),
+            Preference::MinimizeOnClose(enabled) => config.set_minimize_on_close(enabled),
+            Preference::StartupMode(mode) => config.set_startup_mode(&mode),
+            Preference::HistoryRetention(retention) => config.set_history_retention(&retention),
+        }
+        .map_err(|error| error.to_string())?;
+        let preferences = config.preferences().map_err(|error| error.to_string())?;
+        if retention_changed
+            && let Err(error) = self.prune_for_retention(&preferences.history_retention)
+        {
+            tracing::error!(%error, "could not apply history retention");
+        }
+        Ok(preferences)
+    }
+
+    fn prune_for_retention(&mut self, retention: &str) -> Result<(), String> {
+        let days = match retention {
+            Preferences::RETENTION_FOREVER => return Ok(()),
+            Preferences::RETENTION_SIX_MONTHS => 183,
+            Preferences::RETENTION_ONE_YEAR => 365,
+            _ => return Err(format!("unknown history retention {retention:?}")),
+        };
+        let cutoff = Timestamp::from_unix(Timestamp::now().as_unix() - days * 24 * 3600)
+            .map_err(|error| error.to_string())?;
+        let removed = self
+            .history
+            .prune_before(cutoff)
+            .map_err(|error| error.to_string())?;
+        if removed > 0 {
+            tracing::info!(removed, retention, "pruned history beyond retention");
+        }
+        Ok(())
+    }
+
+    fn clear_history(&mut self) -> Result<(), String> {
+        self.history.clear().map_err(|error| error.to_string())
+    }
+
     /// Reads the active history segment for one configured account/window pair.
     ///
     /// The engine owns the database, so even this short read goes through its command queue
@@ -572,6 +639,14 @@ impl Engine {
                     }
                     Some(Command::CurrentSegment { provider, account, window, reply }) => {
                         let result = self.current_segment(&provider, &account, &window);
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::SetPreference { preference, reply }) => {
+                        let result = self.set_preference(preference).await;
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::ClearHistory { reply }) => {
+                        let result = self.clear_history();
                         let _ = reply.send(result);
                     }
                     Some(Command::Shutdown) | None => return,
@@ -1043,6 +1118,16 @@ impl Engine {
             Ok(0) => {}
             Ok(removed) => tracing::info!(removed, "thinned history older than ninety days"),
             Err(error) => tracing::error!(%error, "could not thin the history"),
+        }
+        match Config::at(self.config_path.clone()).and_then(|config| config.preferences()) {
+            Ok(preferences) => {
+                if let Err(error) = self.prune_for_retention(&preferences.history_retention) {
+                    tracing::error!(%error, "could not apply history retention");
+                }
+            }
+            Err(error) => {
+                tracing::error!(%error, "could not read history retention during maintenance")
+            }
         }
     }
 
@@ -2155,5 +2240,116 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+    #[tokio::test]
+    async fn application_preferences_are_serialized_through_the_engine() {
+        let mut harness = Harness::empty("application-preferences").await;
+
+        harness
+            .engine
+            .set_preference(Preference::ReleaseCheck(false))
+            .await
+            .expect("release check changed");
+        harness
+            .engine
+            .set_preference(Preference::MinimizeOnClose(false))
+            .await
+            .expect("close behavior changed");
+        harness
+            .engine
+            .set_preference(Preference::StartupMode(Preferences::STARTUP_DAEMON.into()))
+            .await
+            .expect("startup mode changed");
+        let preferences = harness
+            .engine
+            .set_preference(Preference::HistoryRetention(
+                Preferences::RETENTION_SIX_MONTHS.into(),
+            ))
+            .await
+            .expect("history retention changed");
+
+        assert_eq!(
+            preferences,
+            Preferences {
+                release_check: false,
+                minimize_on_close: false,
+                startup_mode: Preferences::STARTUP_DAEMON.into(),
+                history_retention: Preferences::RETENTION_SIX_MONTHS.into(),
+            }
+        );
+        assert_eq!(
+            Config::at(harness.config_path)
+                .expect("reloaded")
+                .preferences()
+                .expect("readable"),
+            preferences
+        );
+    }
+    #[tokio::test]
+    async fn daily_maintenance_applies_the_configured_history_retention() {
+        let mut harness = Harness::empty("retention-maintenance").await;
+        let mut config = Config::at(harness.config_path.clone()).expect("config opens");
+        config
+            .set_history_retention(Preferences::RETENTION_SIX_MONTHS)
+            .expect("retention configured");
+        let mut old = snapshot(42.0, 3600);
+        old.captured_at =
+            Timestamp::from_unix(Timestamp::now().as_unix() - 200 * 24 * 3600).expect("valid");
+        harness.engine.history.ingest(&old).expect("history seeded");
+
+        harness.engine.thin_if_due();
+
+        assert_eq!(harness.engine.history.point_count().expect("counted"), 0);
+    }
+    #[tokio::test]
+    async fn a_committed_preference_is_not_failed_by_a_retention_prune() {
+        let dir =
+            std::env::temp_dir().join(format!("tidemark-engine-prune-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        let history_path = dir.join("history.db");
+        let config_path = dir.join("config.toml");
+        Config::at(config_path.clone()).expect("config opens");
+        let (updates, _queue) = mpsc::channel(64);
+        let notices = Arc::new(Recorder::default());
+        let mut engine = Engine::new(
+            Vec::new(),
+            History::open(&history_path).expect("file-backed history opens"),
+            unlocked(),
+            updates,
+            config_path.clone(),
+            Arc::clone(&notices) as Arc<dyn Notifier>,
+        );
+
+        // A second connection holds the database's one write lock, so the immediate
+        // prune that follows a preference commit cannot write.
+        let competing = rusqlite::Connection::open(&history_path).expect("second connection");
+        competing
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("write lock held");
+
+        let preferences = engine
+            .set_preference(Preference::HistoryRetention(
+                Preferences::RETENTION_SIX_MONTHS.into(),
+            ))
+            .await
+            .expect("the commit itself succeeded");
+
+        competing
+            .execute_batch("ROLLBACK")
+            .expect("write lock freed");
+        assert!(preferences.minimize_on_close);
+        assert_eq!(
+            preferences.history_retention,
+            Preferences::RETENTION_SIX_MONTHS
+        );
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("config rereads")
+                .preferences()
+                .expect("readable"),
+            preferences
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -16,6 +16,8 @@ mod notify;
 mod registry;
 mod scheduler;
 mod service;
+mod startup;
+#[cfg(feature = "update-check")]
 mod update;
 
 use std::error::Error;
@@ -27,7 +29,7 @@ use tidemark_core::secrets::Secrets;
 use tidemark_core::storage::History;
 use tidemark_types::ids;
 use tokio::signal::unix::{SignalKind, signal};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use zbus::object_server::SignalEmitter;
 
 use crate::engine::{Command, Engine, Publication};
@@ -40,16 +42,47 @@ const COMMAND_QUEUE: usize = 16;
 /// Finished statuses waiting to be published. One per account per poll.
 const UPDATE_QUEUE: usize = 64;
 
-/// Applies one successful check and returns the signal payload only when state changed.
+#[cfg(feature = "update-check")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReleaseWait {
+    Ready,
+    Disabled,
+    Closed,
+}
+
+#[cfg(feature = "update-check")]
+async fn wait_for_release_check(
+    enabled: &mut watch::Receiver<bool>,
+    delay: std::time::Duration,
+) -> ReleaseWait {
+    loop {
+        if !*enabled.borrow_and_update() {
+            if enabled.changed().await.is_err() {
+                return ReleaseWait::Closed;
+            }
+            continue;
+        }
+        return tokio::select! {
+            _ = tokio::time::sleep(delay) => ReleaseWait::Ready,
+            changed = enabled.changed() => {
+                if changed.is_err() {
+                    ReleaseWait::Closed
+                } else {
+                    ReleaseWait::Disabled
+                }
+            }
+        };
+    }
+}
+/// Applies one finished check, whatever its outcome. Whether the result may still be
+/// published is decided inside [`PublishedUpdate::publish`], against the same lock a
+/// disable takes — never against an enabled flag copied before an await.
+#[cfg(feature = "update-check")]
 async fn publish_result(
     published: &PublishedUpdate,
     result: Result<Option<String>, update::CheckError>,
 ) -> Result<Option<String>, update::CheckError> {
-    let next = result?;
-    Ok(published
-        .replace(next.clone())
-        .await
-        .then(|| next.unwrap_or_default()))
+    Ok(published.publish(result?).await)
 }
 
 fn main() -> std::process::ExitCode {
@@ -94,6 +127,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     // and the first thing this daemon would do with the wrong region is report a rejected
     // key. Once running, a later bad edit is reported and the previous settings stand.
     let config = Config::at(config_path.clone())?;
+    let preferences = config.preferences()?;
     let secrets: Arc<dyn Secrets> = Arc::new(keyring::Keyring::default());
     let accounts = registry::accounts(&secrets, &config)?;
     let configured = accounts
@@ -121,6 +155,15 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let (updates, mut update_queue) = mpsc::channel::<Publication>(UPDATE_QUEUE);
     let published = Published::default();
     let published_update = PublishedUpdate::default();
+    let release_check_enabled = preferences.release_check && cfg!(feature = "update-check");
+    // The checker's sleep/wake control and the publishable state start from the same
+    // durable preference.
+    published_update.set_enabled(release_check_enabled).await;
+    let (release_checks, release_check_changes) = watch::channel(release_check_enabled);
+    #[cfg(feature = "update-check")]
+    let mut release_check_changes = release_check_changes;
+    #[cfg(not(feature = "update-check"))]
+    let _release_check_changes = release_check_changes;
 
     let connection = zbus::connection::Builder::session()?
         .name(ids::DAEMON_BUS_NAME)?
@@ -133,6 +176,13 @@ async fn run() -> Result<(), Box<dyn Error>> {
                 configured,
                 commands.clone(),
                 Arc::clone(&secrets),
+            )
+            .with_preferences(
+                config_path.clone(),
+                history_path.clone(),
+                Arc::new(startup::System),
+                release_checks.clone(),
+                cfg!(feature = "update-check"),
             ),
         )?
         .build()
@@ -180,14 +230,21 @@ async fn run() -> Result<(), Box<dyn Error>> {
         }
     });
 
+    #[cfg(feature = "update-check")]
     let release_checker = match update::Checker::production() {
         Ok(checker) => {
             let published_update = published_update.clone();
             let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH)?;
             Some(tokio::spawn(async move {
-                tokio::time::sleep(update::INITIAL_DELAY).await;
+                let mut delay = update::INITIAL_DELAY;
                 loop {
-                    match publish_result(&published_update, checker.check().await).await {
+                    match wait_for_release_check(&mut release_check_changes, delay).await {
+                        ReleaseWait::Ready => {}
+                        ReleaseWait::Disabled => continue,
+                        ReleaseWait::Closed => return,
+                    }
+                    let result = checker.check().await;
+                    match publish_result(&published_update, result).await {
                         Ok(Some(version)) => {
                             if let Err(error) = Daemon::update_changed(&emitter, &version).await {
                                 tracing::warn!(%error, "could not announce update availability");
@@ -196,7 +253,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
                         Ok(None) => {}
                         Err(error) => tracing::info!(%error, "release check failed"),
                     }
-                    tokio::time::sleep(update::INTERVAL).await;
+                    delay = update::INTERVAL;
                 }
             }))
         }
@@ -205,6 +262,8 @@ async fn run() -> Result<(), Box<dyn Error>> {
             None
         }
     };
+    #[cfg(not(feature = "update-check"))]
+    let release_checker: Option<tokio::task::JoinHandle<()>> = None;
 
     let mut term = signal(SignalKind::terminate())?;
     let mut interrupt = signal(SignalKind::interrupt())?;
@@ -248,14 +307,18 @@ async fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "update-check"))]
 mod tests {
     use super::*;
 
     #[tokio::test]
     async fn a_failed_release_check_preserves_the_previous_update() {
         let published = PublishedUpdate::default();
-        assert!(published.replace(Some("0.2.0".into())).await);
+        published.set_enabled(true).await;
+        assert_eq!(
+            published.publish(Some("0.2.0".into())).await,
+            Some("0.2.0".into())
+        );
 
         let result = publish_result(&published, Err(update::CheckError::Version)).await;
 
@@ -266,7 +329,7 @@ mod tests {
     #[tokio::test]
     async fn only_a_changed_release_result_needs_a_signal() {
         let published = PublishedUpdate::default();
-
+        published.set_enabled(true).await;
         assert_eq!(
             publish_result(&published, Ok(Some("0.3.0".into())))
                 .await
@@ -283,5 +346,42 @@ mod tests {
             publish_result(&published, Ok(None)).await.unwrap(),
             Some(String::new())
         );
+    }
+    #[tokio::test]
+    async fn disabling_release_checks_interrupts_the_wait() {
+        let (enabled, mut changes) = tokio::sync::watch::channel(true);
+        let waiting = tokio::spawn(async move {
+            wait_for_release_check(&mut changes, std::time::Duration::from_secs(30)).await
+        });
+        tokio::task::yield_now().await;
+
+        enabled.send_replace(false);
+
+        tokio::time::timeout(std::time::Duration::from_millis(100), waiting)
+            .await
+            .expect("disable wakes the wait")
+            .expect("task did not panic");
+    }
+    #[tokio::test]
+    async fn a_result_from_before_a_disable_stays_unpublished() {
+        let published = PublishedUpdate::default();
+        published.set_enabled(true).await;
+        assert_eq!(
+            published.publish(Some("0.2.0".into())).await,
+            Some("0.2.0".into())
+        );
+
+        // The daemon disables checks: the flag and the known release are cleared in one
+        // write, and a check that started earlier and finishes afterwards is dropped
+        // under that same lock rather than through an enabled flag it copied beforehand.
+        assert!(published.set_enabled(false).await);
+
+        assert_eq!(
+            publish_result(&published, Ok(Some("0.3.0".into())))
+                .await
+                .expect("the check itself succeeded"),
+            None
+        );
+        assert_eq!(published.get().await, "");
     }
 }

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -32,21 +32,25 @@
 //! login silently fails on a machine with an unusual desktop.
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use tidemark_core::config::Config;
 use tidemark_core::oauth::Login;
 use tidemark_core::providers::Credential;
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_types::{
-    AccountId, CredentialKind, HistoryPoint, ProviderDefinition, ProviderId, ProviderStatus,
+    AccountId, CredentialKind, DataInfo, HistoryPoint, Preferences, ProviderDefinition, ProviderId,
+    ProviderStatus, ids,
 };
-use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
 use tokio::task::{AbortHandle, JoinHandle};
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
 
-use crate::engine::{Command, stored_kind};
+use crate::engine::{Command, Preference, stored_kind};
 use crate::registry;
+use crate::startup::Startup;
 
 type AccountKey = (String, String);
 type AccountMutation = Arc<Mutex<()>>;
@@ -113,24 +117,48 @@ impl Published {
     }
 }
 
-/// The newer application release, when a successful check found one.
+/// The newer application release, when a successful check found one, and whether release
+/// checks are on at all.
+///
+/// One lock guards both, so a check that was already running when checks were disabled
+/// can never publish after the disable: the disable and the publication are ordered by
+/// the lock, not by an enabled flag copied before an await. The watch channel in
+/// [`PreferencesRuntime`](struct@crate::service) remains the checker's sleep-and-wake
+/// control; this is the state a client can observe.
 #[derive(Debug, Clone, Default)]
-pub struct PublishedUpdate(Arc<RwLock<Option<String>>>);
+pub struct PublishedUpdate(Arc<RwLock<UpdateState>>);
+
+#[derive(Debug, Default)]
+struct UpdateState {
+    enabled: bool,
+    release: Option<String>,
+}
 
 impl PublishedUpdate {
     /// The D-Bus representation: an empty string means no newer release is known.
     pub async fn get(&self) -> String {
-        self.0.read().await.clone().unwrap_or_default()
+        self.0.read().await.release.clone().unwrap_or_default()
     }
 
-    /// Replaces the known release and reports whether clients need a signal.
-    pub async fn replace(&self, next: Option<String>) -> bool {
+    /// Switches release checks on or off. Disabling forgets any known release in the
+    /// same write that latches the flag, so nothing published afterwards can bring it
+    /// back. Reports whether clients must be told a known release went away.
+    pub async fn set_enabled(&self, enabled: bool) -> bool {
         let mut held = self.0.write().await;
-        if *held == next {
-            return false;
+        held.enabled = enabled;
+        !enabled && held.release.take().is_some()
+    }
+
+    /// Applies one finished check and returns the signal payload only when clients need
+    /// one. A result that reaches this after checks were disabled is dropped here, under
+    /// the same lock the disable took.
+    pub async fn publish(&self, next: Option<String>) -> Option<String> {
+        let mut held = self.0.write().await;
+        if !held.enabled || held.release == next {
+            return None;
         }
-        *held = next;
-        true
+        held.release = next;
+        Some(held.release.clone().unwrap_or_default())
     }
 }
 
@@ -155,6 +183,15 @@ impl Pending {
     }
 }
 
+#[derive(Debug)]
+struct PreferencesRuntime {
+    config_path: PathBuf,
+    history_path: PathBuf,
+    startup: Arc<dyn Startup>,
+    release_checks: watch::Sender<bool>,
+    release_check_available: bool,
+}
+
 /// The object served at `/io/github/zbndev/Tidemark`.
 #[derive(Debug)]
 pub struct Daemon {
@@ -166,6 +203,8 @@ pub struct Daemon {
     secrets: Arc<dyn Secrets>,
     logins: Mutex<HashMap<AccountKey, Pending>>,
     mutations: Mutex<HashMap<AccountKey, AccountMutation>>,
+    preferences: Option<PreferencesRuntime>,
+    preference_mutation: Mutex<()>,
 }
 
 impl Daemon {
@@ -187,6 +226,89 @@ impl Daemon {
             secrets,
             logins: Mutex::new(HashMap::new()),
             mutations: Mutex::new(HashMap::new()),
+            preferences: None,
+            preference_mutation: Mutex::new(()),
+        }
+    }
+
+    /// Adds the paths and system integrations behind the application preferences API.
+    pub fn with_preferences(
+        mut self,
+        config_path: PathBuf,
+        history_path: PathBuf,
+        startup: Arc<dyn Startup>,
+        release_checks: watch::Sender<bool>,
+        release_check_available: bool,
+    ) -> Self {
+        self.preferences = Some(PreferencesRuntime {
+            config_path,
+            history_path,
+            startup,
+            release_checks,
+            release_check_available,
+        });
+        self
+    }
+
+    fn preferences_runtime(&self) -> fdo::Result<&PreferencesRuntime> {
+        self.preferences
+            .as_ref()
+            .ok_or_else(|| fdo::Error::Failed("application preferences are unavailable".into()))
+    }
+
+    async fn preference_request(&self, preference: Preference) -> fdo::Result<Preferences> {
+        let (reply, answer) = oneshot::channel();
+        self.commands
+            .send(Command::SetPreference { preference, reply })
+            .await
+            .map_err(|_| fdo::Error::Failed("the poll loop has stopped".into()))?;
+        answer
+            .await
+            .map_err(|_| fdo::Error::Failed("the poll loop dropped the request".into()))?
+            .map_err(fdo::Error::Failed)
+    }
+
+    async fn publish_preferences(
+        &self,
+        emitter: &SignalEmitter<'_>,
+        preferences: Preferences,
+    ) -> fdo::Result<()> {
+        Self::preferences_changed(emitter, preferences).await?;
+        Ok(())
+    }
+
+    async fn change_startup_mode(&self, mode: &str) -> fdo::Result<Preferences> {
+        // The caller holds `preference_mutation` across this whole change and the
+        // `PreferencesChanged` that follows it, so no other mutation can commit between
+        // this one and its publication.
+        if !Preferences::valid_startup(mode) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "unknown startup mode {mode:?}"
+            )));
+        }
+        let runtime = self.preferences_runtime()?;
+        let previous = Config::at(runtime.config_path.clone())
+            .and_then(|config| config.preferences())
+            .map_err(|error| fdo::Error::Failed(error.to_string()))?;
+        if let Err(error) = runtime.startup.set_startup_mode(mode) {
+            if let Err(rollback_error) = runtime.startup.set_startup_mode(&previous.startup_mode) {
+                tracing::error!(%rollback_error, "could not roll back a startup preference");
+            }
+            return Err(fdo::Error::Failed(error));
+        }
+        match self
+            .preference_request(Preference::StartupMode(mode.into()))
+            .await
+        {
+            Ok(preferences) => Ok(preferences),
+            Err(error) => {
+                if let Err(rollback_error) =
+                    runtime.startup.set_startup_mode(&previous.startup_mode)
+                {
+                    tracing::error!(%rollback_error, "could not roll back a startup preference");
+                }
+                Err(error)
+            }
         }
     }
 
@@ -393,6 +515,29 @@ impl Daemon {
     /// The newer published application release, or an empty string when none is known.
     async fn get_update(&self) -> String {
         self.update.get().await
+    }
+
+    /// Application-wide preferences persisted in `config.toml`.
+    async fn get_preferences(&self) -> fdo::Result<Preferences> {
+        let runtime = self.preferences_runtime()?;
+        Config::at(runtime.config_path.clone())
+            .and_then(|config| config.preferences())
+            .map_err(|error| fdo::Error::Failed(error.to_string()))
+    }
+
+    /// Paths and storage facts for the Preferences data page.
+    async fn get_data_info(&self) -> fdo::Result<DataInfo> {
+        let runtime = self.preferences_runtime()?;
+        let mut wal = runtime.history_path.as_os_str().to_os_string();
+        wal.push("-wal");
+        Ok(DataInfo {
+            config_path: runtime.config_path.to_string_lossy().into_owned(),
+            history_path: runtime.history_path.to_string_lossy().into_owned(),
+            history_bytes: file_size(&runtime.history_path) + file_size(PathBuf::from(wal)),
+            key_schema: ids::SECRET_SCHEMA.into(),
+            token_schema: ids::TOKEN_SCHEMA.into(),
+            release_check_available: runtime.release_check_available,
+        })
     }
 
     /// Stored points in the open segment of one window.
@@ -679,6 +824,86 @@ impl Daemon {
         Ok(())
     }
 
+    /// Enables or disables the daemon's GitHub release checks.
+    async fn set_release_check(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        enabled: bool,
+    ) -> fdo::Result<()> {
+        let _guard = self.preference_mutation.lock().await;
+        let runtime = self.preferences_runtime()?;
+        if enabled && !runtime.release_check_available {
+            return Err(fdo::Error::NotSupported(
+                "this build has no release checker".into(),
+            ));
+        }
+        let preferences = self
+            .preference_request(Preference::ReleaseCheck(enabled))
+            .await?;
+        let release_forgotten = self.update.set_enabled(enabled).await;
+        runtime.release_checks.send_replace(enabled);
+        if release_forgotten {
+            Self::update_changed(&emitter, "").await?;
+        }
+        self.publish_preferences(&emitter, preferences).await
+    }
+
+    /// Chooses whether close hides a window that has a working tray icon.
+    async fn set_minimize_on_close(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        enabled: bool,
+    ) -> fdo::Result<()> {
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::MinimizeOnClose(enabled))
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
+    /// Chooses the one coherent login-start mode: app, daemon only, or off.
+    async fn set_startup_mode(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        mode: &str,
+    ) -> fdo::Result<()> {
+        // One lock spans the change, the engine round trip and the publication: releasing
+        // it between the commit and the signal would let a later mutation publish first
+        // and clients see an older snapshot after a newer one.
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self.change_startup_mode(mode).await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
+    /// Sets the named history retention policy and prunes old rows immediately.
+    async fn set_history_retention(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        retention: &str,
+    ) -> fdo::Result<()> {
+        if !Preferences::valid_retention(retention) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "unknown history retention {retention:?}"
+            )));
+        }
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::HistoryRetention(retention.into()))
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
+    /// Deletes every historical reading and refreshes the published storage facts.
+    async fn clear_history(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> fdo::Result<()> {
+        self.config_request(|reply| Command::ClearHistory { reply })
+            .await?;
+        Self::data_changed(&emitter, self.get_data_info().await?).await?;
+        Ok(())
+    }
+
     /// Puts the configured providers in the order a client's user arranged them in.
     ///
     /// The order is the `providers` array in `config.toml` — the same array that says which
@@ -756,9 +981,26 @@ impl Daemon {
         providers: Vec<String>,
     ) -> zbus::Result<()>;
 
+    /// Application preferences changed.
+    #[zbus(signal)]
+    pub async fn preferences_changed(
+        emitter: &SignalEmitter<'_>,
+        preferences: Preferences,
+    ) -> zbus::Result<()>;
+
+    /// Paths or storage facts changed.
+    #[zbus(signal)]
+    pub async fn data_changed(emitter: &SignalEmitter<'_>, data: DataInfo) -> zbus::Result<()>;
+
     /// Availability of a newer published release changed; empty means there is none.
     #[zbus(signal)]
     pub async fn update_changed(emitter: &SignalEmitter<'_>, version: &str) -> zbus::Result<()>;
+}
+
+fn file_size(path: impl AsRef<std::path::Path>) -> u64 {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
 }
 
 /// The pair an in-progress login is filed under.
@@ -779,6 +1021,43 @@ mod tests {
     /// without a Secret Service and without a bus.
     #[derive(Debug, Default)]
     struct FakeSecrets(std::sync::Mutex<HashMap<(String, String, String), String>>);
+
+    #[derive(Debug, Default)]
+    struct FakeStartup {
+        attempts: std::sync::Mutex<Vec<String>>,
+        fail_next: std::sync::Mutex<bool>,
+    }
+
+    impl FakeStartup {
+        fn failing_once() -> Self {
+            Self {
+                attempts: std::sync::Mutex::new(Vec::new()),
+                fail_next: std::sync::Mutex::new(true),
+            }
+        }
+
+        fn attempts(&self) -> Vec<String> {
+            self.attempts
+                .lock()
+                .expect("no test panics holding this")
+                .clone()
+        }
+    }
+
+    impl Startup for FakeStartup {
+        fn set_startup_mode(&self, mode: &str) -> Result<(), String> {
+            self.attempts
+                .lock()
+                .expect("no test panics holding this")
+                .push(mode.to_owned());
+            let mut fail_next = self.fail_next.lock().expect("no test panics holding this");
+            if std::mem::take(&mut *fail_next) {
+                Err("simulated startup integration failure".into())
+            } else {
+                Ok(())
+            }
+        }
+    }
 
     impl FakeSecrets {
         fn held(&self) -> Vec<(String, String, String, String)> {
@@ -900,10 +1179,35 @@ mod tests {
     async fn update_publication_changes_only_when_the_value_changes() {
         let update = PublishedUpdate::default();
         assert_eq!(update.get().await, "");
-        assert!(update.replace(Some("0.2.0".into())).await);
-        assert!(!update.replace(Some("0.2.0".into())).await);
+        update.set_enabled(true).await;
+        assert_eq!(
+            update.publish(Some("0.2.0".into())).await,
+            Some("0.2.0".into())
+        );
+        assert_eq!(update.publish(Some("0.2.0".into())).await, None);
         assert_eq!(update.get().await, "0.2.0");
-        assert!(update.replace(None).await);
+        assert_eq!(update.publish(None).await, Some(String::new()));
+        assert_eq!(update.get().await, "");
+    }
+
+    #[tokio::test]
+    async fn a_disabled_release_check_drops_results_and_forgets_the_release() {
+        let update = PublishedUpdate::default();
+        update.set_enabled(true).await;
+        assert_eq!(
+            update.publish(Some("0.2.0".into())).await,
+            Some("0.2.0".into())
+        );
+
+        // Disabling both latches the flag and forgets the release in one write...
+        assert!(update.set_enabled(false).await);
+        assert_eq!(update.get().await, "");
+        // ...and a result that was already in flight lands nowhere.
+        assert_eq!(update.publish(Some("0.3.0".into())).await, None);
+        assert_eq!(update.get().await, "");
+
+        // Re-enabling starts from nothing until a check succeeds again.
+        assert!(!update.set_enabled(true).await);
         assert_eq!(update.get().await, "");
     }
 
@@ -1853,7 +2157,11 @@ mod tests {
         let published = Published::default();
         published.upsert(status("zai")).await;
         let published_update = PublishedUpdate::default();
-        assert!(published_update.replace(Some("0.2.0".into())).await);
+        published_update.set_enabled(true).await;
+        assert_eq!(
+            published_update.publish(Some("0.2.0".into())).await,
+            Some("0.2.0".into())
+        );
         let (commands, mut command_queue) = mpsc::channel(4);
 
         let Ok(server) = serve(Daemon::new(
@@ -1947,7 +2255,7 @@ mod tests {
         let mut update_signals = pin!(update_signals);
         let emitter = SignalEmitter::new(&server, ids::OBJECT_PATH).expect("a valid path");
 
-        assert!(published_update.replace(None).await);
+        assert!(published_update.set_enabled(false).await);
         Daemon::update_changed(&emitter, "")
             .await
             .expect("the update signal goes out");
@@ -2096,5 +2404,296 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+    #[tokio::test]
+    async fn application_preferences_and_data_are_read_from_the_daemons_paths() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-service-preferences-{}.toml",
+            std::process::id()
+        ));
+        let history_path = std::env::temp_dir().join(format!(
+            "tidemark-service-history-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+        let _ = std::fs::remove_file(&history_path);
+        let mut config = Config::at(config_path.clone()).expect("empty config");
+        config.set_release_check(false).expect("configured");
+        std::fs::write(&history_path, [0_u8; 32]).expect("history fixture");
+
+        let (commands, _queue) = mpsc::channel(4);
+        let (release_checks, _release_changes) = watch::channel(false);
+        let daemon = Daemon::new(
+            Published::default(),
+            PublishedUpdate::default(),
+            Vec::new(),
+            Vec::new(),
+            commands,
+            Arc::new(FakeSecrets::default()),
+        )
+        .with_preferences(
+            config_path.clone(),
+            history_path.clone(),
+            Arc::new(crate::startup::System),
+            release_checks,
+            true,
+        );
+
+        assert!(
+            !daemon
+                .get_preferences()
+                .await
+                .expect("preferences")
+                .release_check
+        );
+        let data = daemon.get_data_info().await.expect("data");
+        assert_eq!(data.config_path, config_path.to_string_lossy());
+        assert_eq!(data.history_path, history_path.to_string_lossy());
+        assert_eq!(data.history_bytes, 32);
+        assert!(data.release_check_available);
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_file(history_path);
+    }
+
+    #[tokio::test]
+    async fn a_preference_change_waits_for_the_engine_result() {
+        let (daemon, _secrets, mut commands) = daemon_over(Vec::new()).await;
+        let daemon = Arc::new(daemon);
+        let changing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move {
+                daemon
+                    .preference_request(Preference::MinimizeOnClose(false))
+                    .await
+            }
+        });
+
+        let Command::SetPreference { preference, reply } =
+            commands.recv().await.expect("preference reaches engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert!(matches!(preference, Preference::MinimizeOnClose(false)));
+        assert!(!changing.is_finished(), "D-Bus waits for persistence");
+        let preferences = Preferences {
+            minimize_on_close: false,
+            ..Default::default()
+        };
+        reply
+            .send(Ok(preferences.clone()))
+            .expect("caller waits for reply");
+        assert_eq!(
+            changing
+                .await
+                .expect("task did not panic")
+                .expect("accepted"),
+            preferences
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_startup_integration_restores_the_previous_mode() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-service-startup-rollback-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+        let startup = Arc::new(FakeStartup::failing_once());
+        let (commands, _queue) = mpsc::channel(1);
+        let (release_checks, _release_changes) = watch::channel(true);
+        let daemon = Daemon::new(
+            Published::default(),
+            PublishedUpdate::default(),
+            Vec::new(),
+            Vec::new(),
+            commands,
+            Arc::new(FakeSecrets::default()),
+        )
+        .with_preferences(
+            config_path.clone(),
+            config_path.with_extension("db"),
+            startup.clone(),
+            release_checks,
+            true,
+        );
+
+        assert!(
+            daemon
+                .change_startup_mode(Preferences::STARTUP_DAEMON)
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            startup.attempts(),
+            vec![
+                Preferences::STARTUP_DAEMON.to_owned(),
+                Preferences::STARTUP_APP.to_owned()
+            ]
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_rejected_startup_preference_restores_the_previous_integration() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-service-startup-persistence-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+        let startup = Arc::new(FakeStartup::default());
+        let (commands, mut queue) = mpsc::channel(1);
+        let (release_checks, _release_changes) = watch::channel(true);
+        let daemon = Arc::new(
+            Daemon::new(
+                Published::default(),
+                PublishedUpdate::default(),
+                Vec::new(),
+                Vec::new(),
+                commands,
+                Arc::new(FakeSecrets::default()),
+            )
+            .with_preferences(
+                config_path.clone(),
+                config_path.with_extension("db"),
+                startup.clone(),
+                release_checks,
+                true,
+            ),
+        );
+        let changing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move {
+                daemon
+                    .change_startup_mode(Preferences::STARTUP_DAEMON)
+                    .await
+            }
+        });
+
+        let Command::SetPreference { preference, reply } = queue
+            .recv()
+            .await
+            .expect("startup preference reaches engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert!(matches!(
+            &preference,
+            Preference::StartupMode(mode) if mode == Preferences::STARTUP_DAEMON
+        ));
+        reply
+            .send(Err("simulated config failure".into()))
+            .expect("caller waits for reply");
+
+        assert!(changing.await.expect("task did not panic").is_err());
+        assert_eq!(
+            startup.attempts(),
+            vec![
+                Preferences::STARTUP_DAEMON.to_owned(),
+                Preferences::STARTUP_APP.to_owned()
+            ]
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+    /// The mutation lock is held from the commit to the `PreferencesChanged` that carries
+    /// it: a second mutation must not be able to commit while an older snapshot is still
+    /// unpublished, or clients can see the older state after the newer one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_startup_change_holds_the_mutation_guard_until_it_has_published() {
+        let Ok(connection) = zbus::Connection::session().await else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+        for round in 0..4 {
+            let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH).expect("a valid path");
+            let flood_emitter =
+                SignalEmitter::new(&connection, ids::OBJECT_PATH).expect("a valid path");
+            let config_path = std::env::temp_dir().join(format!(
+                "tidemark-service-startup-order-{round}-{}.toml",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&config_path);
+            let (commands, mut queue) = mpsc::channel(2);
+            let (release_checks, _changes) = watch::channel(true);
+            let daemon = Arc::new(
+                Daemon::new(
+                    Published::default(),
+                    PublishedUpdate::default(),
+                    Vec::new(),
+                    Vec::new(),
+                    commands,
+                    Arc::new(FakeSecrets::default()),
+                )
+                .with_preferences(
+                    config_path.clone(),
+                    config_path.with_extension("db"),
+                    Arc::new(FakeStartup::default()),
+                    release_checks,
+                    true,
+                ),
+            );
+
+            let changing = {
+                let daemon = Arc::clone(&daemon);
+                tokio::spawn(async move {
+                    daemon
+                        .set_startup_mode(emitter, Preferences::STARTUP_DAEMON)
+                        .await
+                })
+            };
+            let Command::SetPreference { reply, .. } =
+                queue.recv().await.expect("the change reaches the engine")
+            else {
+                panic!("unexpected command");
+            };
+
+            // Every signal emission takes the process-wide single serial-number permit
+            // zbus hands out, so a crowd of concurrent emissions parks the publication
+            let flood = (0..400)
+                .map(|_| {
+                    let emitter = flood_emitter.clone();
+                    tokio::spawn(async move {
+                        let _ = Daemon::preferences_changed(&emitter, Preferences::default()).await;
+                    })
+                })
+                .collect::<Vec<_>>();
+            reply
+                .send(Ok(Preferences {
+                    startup_mode: Preferences::STARTUP_DAEMON.into(),
+                    ..Default::default()
+                }))
+                .expect("caller waits for reply");
+
+            // From the moment the engine has committed, the guard must stay held until
+            // the signal has gone out; a free lock while the change is still unfinished
+            // is an older snapshot still unpublished while a newer mutation could commit.
+            // The short wait after a catch only separates a real escape from the instant
+            // between a finished task's lock release and its completion flag.
+            let mut escaped = false;
+            for _ in 0..20_000 {
+                if let Ok(guard) = daemon.preference_mutation.try_lock() {
+                    drop(guard);
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                    escaped = !changing.is_finished();
+                    break;
+                }
+                if changing.is_finished() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            for task in flood {
+                let _ = task.await;
+            }
+            changing
+                .await
+                .expect("task did not panic")
+                .expect("startup mode changed");
+            assert!(
+                !escaped,
+                "round {round}: publication left the mutation lock"
+            );
+            let _ = std::fs::remove_file(config_path);
+        }
     }
 }

--- a/crates/tidemarkd/src/startup.rs
+++ b/crates/tidemarkd/src/startup.rs
@@ -1,0 +1,143 @@
+//! User-session startup integrations controlled by application preferences.
+
+use std::path::Path;
+use std::process::Command;
+
+use tidemark_core::paths;
+use tidemark_types::{Preferences, ids};
+
+/// Applies the coherent login-start mode outside `config.toml`.
+pub trait Startup: std::fmt::Debug + Send + Sync {
+    fn set_startup_mode(&self, mode: &str) -> Result<(), String>;
+}
+
+#[derive(Debug, Default)]
+pub struct System;
+
+impl Startup for System {
+    fn set_startup_mode(&self, mode: &str) -> Result<(), String> {
+        let (desktop, daemon) =
+            startup_targets(mode).ok_or_else(|| format!("unknown startup mode {mode:?}"))?;
+        let config_dir = paths::config_dir().map_err(|error| error.to_string())?;
+        let config_home = config_dir
+            .parent()
+            .ok_or_else(|| format!("{} has no parent", config_dir.display()))?;
+        set_desktop_autostart_in(config_home, desktop)?;
+        set_daemon_autostart(daemon)
+    }
+}
+
+fn startup_targets(mode: &str) -> Option<(bool, bool)> {
+    match mode {
+        Preferences::STARTUP_APP => Some((true, false)),
+        Preferences::STARTUP_DAEMON => Some((false, true)),
+        Preferences::STARTUP_OFF => Some((false, false)),
+        _ => None,
+    }
+}
+
+fn set_daemon_autostart(enabled: bool) -> Result<(), String> {
+    let output = Command::new("systemctl")
+        .args(systemctl_arguments(enabled))
+        .output()
+        .map_err(|error| format!("could not run systemctl: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(format!(
+        "systemctl could not {} tidemarkd.service: {}",
+        if enabled { "enable" } else { "disable" },
+        stderr.trim()
+    ))
+}
+
+fn systemctl_arguments(enabled: bool) -> [&'static str; 3] {
+    [
+        "--user",
+        if enabled { "enable" } else { "disable" },
+        "tidemarkd.service",
+    ]
+}
+
+fn set_desktop_autostart_in(config_home: &Path, enabled: bool) -> Result<(), String> {
+    let directory = config_home.join("autostart");
+    let path = directory.join(format!("{}.desktop", ids::APP_ID));
+    if enabled {
+        return match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!("could not remove {}: {error}", path.display())),
+        };
+    }
+
+    std::fs::create_dir_all(&directory)
+        .map_err(|error| format!("could not create {}: {error}", directory.display()))?;
+    let temporary = path.with_extension(format!("desktop.tmp-{}", std::process::id()));
+    std::fs::write(&temporary, "[Desktop Entry]\nHidden=true\n")
+        .map_err(|error| format!("could not write {}: {error}", temporary.display()))?;
+    std::fs::rename(&temporary, &path).map_err(|error| {
+        let _ = std::fs::remove_file(&temporary);
+        format!("could not replace {}: {error}", path.display())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("tidemark-startup-{name}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn disabling_desktop_autostart_writes_the_standard_xdg_override() {
+        let directory = scratch("desktop-off");
+        let _ = std::fs::remove_dir_all(&directory);
+
+        set_desktop_autostart_in(&directory, false).expect("disabled");
+
+        let override_path = directory
+            .join("autostart")
+            .join("io.github.zbndev.Tidemark.desktop");
+        assert_eq!(
+            std::fs::read_to_string(override_path).expect("override exists"),
+            "[Desktop Entry]\nHidden=true\n"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn enabling_desktop_autostart_removes_the_user_override() {
+        let directory = scratch("desktop-on");
+        let override_path = directory
+            .join("autostart")
+            .join("io.github.zbndev.Tidemark.desktop");
+        std::fs::create_dir_all(override_path.parent().expect("has parent")).expect("directory");
+        std::fs::write(&override_path, "[Desktop Entry]\nHidden=true\n").expect("seeded");
+
+        set_desktop_autostart_in(&directory, true).expect("enabled");
+
+        assert!(!override_path.exists());
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn daemon_autostart_uses_the_user_systemd_unit() {
+        assert_eq!(
+            systemctl_arguments(true),
+            ["--user", "enable", "tidemarkd.service"]
+        );
+        assert_eq!(
+            systemctl_arguments(false),
+            ["--user", "disable", "tidemarkd.service"]
+        );
+    }
+    #[test]
+    fn three_startup_modes_have_unambiguous_targets() {
+        assert_eq!(startup_targets("app"), Some((true, false)));
+        assert_eq!(startup_targets("daemon"), Some((false, true)));
+        assert_eq!(startup_targets("off"), Some((false, false)));
+        assert_eq!(startup_targets("everything"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- add a native libadwaita Preferences dialog for close behavior, startup mode, release checks, history retention, data paths, and history clearing
- keep `config.toml` authoritative and route every mutation through the daemon's serialized D-Bus/engine path
- model login startup as one coherent `app` / `daemon` / `off` choice with transactional platform rollback
- make release disabling race-safe, history clearing atomic, and retention maintenance best-effort after preference commits
- support packager builds without update checking via the default-on `update-check` feature

## Verification
- `cargo test --workspace` — 969 passed
- `cargo test -p tidemarkd --no-default-features` — 137 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-layering.sh`
- native Wayland smoke with `grim`: General/Startup rendered `Off` from daemon state
- D-Bus E2E cycled `app` → `daemon` → `off`, verifying `config.toml`, XDG override presence, and `UnitFileState`; restored `off`

## Startup semantics
The packaged `/etc/xdg/autostart` entry is the positive app entry. `app` removes the per-user override; `daemon` and `off` write `~/.config/autostart/io.github.zbndev.Tidemark.desktop` with `Hidden=true`. Only `daemon` enables `tidemarkd.service`; `UnitFilePreset=enabled` is distribution policy and remains unchanged.