### PR TITLE
feat(network): route every request and subprocess through one proxy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -300,7 +300,8 @@ distribution-wide LTO off; `PKGBUILD` does it with `options=(!lto)`.
 - **Application preferences use the same file, not GSettings.** `[general]` carries
   `minimize_on_close` (default `true`) and `startup`, whose named modes are `app` (the
   default: app and tray), `daemon` (daemon only), and `off`; `[updates] check` defaults to
-  `true`; `[history] retention` is `forever`, `six-months` or `one-year`. A present value
+  `true`; `[history] retention` is `forever`, `six-months` or `one-year`; `[proxy]` carries
+  `mode`, `host` and `port`, written as one edit because they are one setting. A present value
   with the wrong type or an unknown named choice is an error, not a reason to guess.
   Mutations travel over D-Bus and share the engine's serial configuration queue, so a
   provider edit and a global preference cannot overwrite each other.
@@ -319,6 +320,34 @@ Every request sets `User-Agent: Tidemark/<version>`. This is not cosmetic:
 `403 browser_signature_banned`. Identify honestly by product name — never impersonate a
 browser. We authenticate with real credentials to documented endpoints; there is no reason
 to look like anything other than what we are.
+
+**One proxy, set once, applied everywhere.** `[proxy]` in `config.toml` names a mode
+(`off`, `http`, `https`, `socks5`), a host and a port; `tidemark-core`'s `providers::http`
+holds it for the process, and every client this program builds starts from that one
+builder. `socks5` becomes a `socks5h://` URL, so names are resolved at the proxy — for
+anyone whose own resolver is the thing in the way, resolving here and handing the proxy an
+address would defeat the point.
+
+- **A subprocess is not an exception.** Antigravity's `agy` does its own HTTP, so the proxy
+  is handed to it as `HTTP(S)_PROXY`/`ALL_PROXY`/`NO_PROXY` in both spellings, at spawn
+  time, per command. **Not** on the systemd unit: an environment variable there takes
+  effect on a restart, and a restart takes every card off the screen until the first poll
+  comes back.
+- **A change is adopted without restarting anything.** `SetProxy` takes all three values as
+  one call — half a proxy applied is a proxy nothing can be reached through — validates the
+  URL before the file is written, then drops every provider client. A `reqwest::Client`
+  holds its proxy for life and its pool holds sockets opened through the old one, so the
+  clients are rebuilt from stored keys and settings on the next poll. **No status is
+  touched**: each card keeps its last good reading while the new client is built under it.
+  Dropping Antigravity's client shuts `agy` down, and the next poll spawns it again with
+  the new environment.
+- **Loopback is never proxied.** `localhost,127.0.0.0/8,::1` is excluded on our clients and
+  passed as `NO_PROXY` to children, and Antigravity's loopback client is built with
+  `no_proxy()` outright. Asking a proxy to reach `agy` on this machine asks it to connect
+  to itself.
+- **Off means "as before", not "direct".** With no mode set, `reqwest` reads the process
+  environment and a child inherits it, which is what this program did before the setting
+  existed.
 
 ## Polling
 
@@ -470,7 +499,10 @@ history that does not exist yet.
   button opens the menu every GNOME application keeps there. Preferences and About
   Tidemark are separate sections; provider and credential management stays on its existing
   header button because accounts are managed, not application preferences. Preferences is
-  an `AdwPreferencesDialog` with General, Updates and Data pages and standard rows. About
+  an `AdwPreferencesDialog` with General, Network and Data pages and standard rows. The
+  release-check switch lives on Network beside the proxy rather than on a page of its own:
+  it is one switch, and what it switches is whether this program reaches the network at all
+  on its own behalf. About
   is an `AdwAboutDialog` with properties set and no layout of ours: the icon over the name,
   the version pill, Details, Report an Issue and
   Legal are what the platform draws from `application-icon`, `version`, `website`,
@@ -479,6 +511,14 @@ history that does not exist yet.
   agreement — and the issue link goes to `/issues/new/choose`, because the repository has
   templates and a report that skips them has to be asked for the version and the desktop
   all over again.
+- **The three proxy rows are one form, and the mode row opens the other two.** Choosing
+  `SOCKS5` before typing where the proxy is, is how the group gets filled in, so the
+  choice alone is not sent - the daemon would refuse half a proxy and be right to - and the
+  host and the port become editable off the *row's* selection rather than off what is
+  stored. Deriving them from storage is a lock: the stored mode is still `off` at exactly
+  the moment the two rows that would change it have to be typed into. Nothing reaches the
+  daemon until all three are complete, and only a deliberate submit of an incomplete one is
+  marked wrong.
 - **The one page that is ours is Troubleshooting**, and it is there so those questions are
   answered before they are asked: the client's version, the version the daemon on the other
   end reported, the GTK and libadwaita the process actually loaded, the desktop and session

--- a/crates/tidemark-core/Cargo.toml
+++ b/crates/tidemark-core/Cargo.toml
@@ -16,7 +16,9 @@ base64 = "0.22.1"
 fs4 = "0.13.1"
 libc = "0.2.180"
 oo7 = { version = "0.6.0", default-features = false, features = ["native_crypto", "tokio"] }
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "json", "gzip", "form", "query"] }
+# `socks`: without it a `socks5://` proxy URL parses and then refuses every connection
+# made through it. `system-proxy`: what "no proxy configured here" falls back to.
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "socks", "json", "gzip", "form", "query"] }
 rusqlite = "0.40.2"
 rustix = { version = "1.1.4", features = ["process", "pty", "rand"] }
 serde = { version = "1.0.229", features = ["derive"] }

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -280,11 +280,7 @@ impl Config {
     /// Refused rather than clamped when it is out of range: a `70000` in the file was
     /// meant to be a port, and silently reading it as some other port is worse than
     /// saying it is not one.
-    fn preference_port(
-        &self,
-        table: &'static str,
-        key: &'static str,
-    ) -> Result<u16, ConfigError> {
+    fn preference_port(&self, table: &'static str, key: &'static str) -> Result<u16, ConfigError> {
         let Some(item) = self.preference(table, key)? else {
             return Ok(0);
         };
@@ -1228,7 +1224,13 @@ mod tests {
             "forever"
         );
         assert_eq!(config.preferences().expect("readable").proxy_mode, "off");
-        assert!(config.preferences().expect("readable").proxy_host.is_empty());
+        assert!(
+            config
+                .preferences()
+                .expect("readable")
+                .proxy_host
+                .is_empty()
+        );
         assert_eq!(config.preferences().expect("readable").proxy_port, 0);
     }
 

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -45,6 +45,10 @@ const UPDATES_TABLE: &str = "updates";
 const RELEASE_CHECK_KEY: &str = "check";
 const HISTORY_TABLE: &str = "history";
 const HISTORY_RETENTION_KEY: &str = "retention";
+const PROXY_TABLE: &str = "proxy";
+const PROXY_MODE_KEY: &str = "mode";
+const PROXY_HOST_KEY: &str = "host";
+const PROXY_PORT_KEY: &str = "port";
 
 /// Why the settings could not be read or written.
 #[derive(Debug, thiserror::Error)]
@@ -165,6 +169,17 @@ impl Config {
                 format!("has unknown value {startup_mode:?}"),
             ));
         }
+        let proxy_mode = self
+            .preference_string(PROXY_TABLE, PROXY_MODE_KEY)?
+            .unwrap_or(defaults.proxy_mode.as_str())
+            .to_owned();
+        if !Preferences::valid_proxy_mode(&proxy_mode) {
+            return Err(self.invalid_preference(
+                PROXY_TABLE,
+                PROXY_MODE_KEY,
+                format!("has unknown value {proxy_mode:?}"),
+            ));
+        }
         Ok(Preferences {
             release_check: self
                 .preference_bool(UPDATES_TABLE, RELEASE_CHECK_KEY)?
@@ -174,6 +189,12 @@ impl Config {
                 .unwrap_or(defaults.minimize_on_close),
             startup_mode,
             history_retention,
+            proxy_mode,
+            proxy_host: self
+                .preference_string(PROXY_TABLE, PROXY_HOST_KEY)?
+                .unwrap_or(defaults.proxy_host.as_str())
+                .to_owned(),
+            proxy_port: self.preference_port(PROXY_TABLE, PROXY_PORT_KEY)?,
         })
     }
 
@@ -207,6 +228,27 @@ impl Config {
         self.set_preference(HISTORY_TABLE, HISTORY_RETENTION_KEY, value(retention))
     }
 
+    /// Writes the whole proxy setting as one edit.
+    ///
+    /// The three values are one decision: a mode with no host to reach, or a host the mode
+    /// does not use, is not a state worth persisting on the way to a state that makes
+    /// sense. Whether they agree is the caller's to check — this refuses only what this
+    /// build cannot read back.
+    pub fn set_proxy(&mut self, mode: &str, host: &str, port: u16) -> Result<(), ConfigError> {
+        if !Preferences::valid_proxy_mode(mode) {
+            return Err(self.invalid_preference(
+                PROXY_TABLE,
+                PROXY_MODE_KEY,
+                format!("has unknown value {mode:?}"),
+            ));
+        }
+        let table = self.preference_table_mut(PROXY_TABLE)?;
+        table.insert(PROXY_MODE_KEY, value(mode));
+        table.insert(PROXY_HOST_KEY, value(host));
+        table.insert(PROXY_PORT_KEY, value(i64::from(port)));
+        self.write()
+    }
+
     fn preference_bool(
         &self,
         table: &'static str,
@@ -233,6 +275,26 @@ impl Config {
             .ok_or_else(|| self.invalid_preference(table, key, "must be a string".into()))
     }
 
+    /// A TCP port, or zero for a port nobody has set yet.
+    ///
+    /// Refused rather than clamped when it is out of range: a `70000` in the file was
+    /// meant to be a port, and silently reading it as some other port is worse than
+    /// saying it is not one.
+    fn preference_port(
+        &self,
+        table: &'static str,
+        key: &'static str,
+    ) -> Result<u16, ConfigError> {
+        let Some(item) = self.preference(table, key)? else {
+            return Ok(0);
+        };
+        item.as_integer()
+            .and_then(|port| u16::try_from(port).ok())
+            .ok_or_else(|| {
+                self.invalid_preference(table, key, "must be a whole number of 0 to 65535".into())
+            })
+    }
+
     fn preference(
         &self,
         table: &'static str,
@@ -256,18 +318,24 @@ impl Config {
         key: &'static str,
         setting: Item,
     ) -> Result<(), ConfigError> {
-        let table_item = self
-            .document
+        self.preference_table_mut(table)?.insert(key, setting);
+        self.write()
+    }
+
+    /// The table one group of preferences lives in, created empty if it is not there yet.
+    fn preference_table_mut(
+        &mut self,
+        table: &'static str,
+    ) -> Result<&mut dyn toml_edit::TableLike, ConfigError> {
+        let path = self.path.clone();
+        self.document
             .entry(table)
-            .or_insert_with(|| Item::Table(Table::new()));
-        let table_item = table_item
+            .or_insert_with(|| Item::Table(Table::new()))
             .as_table_like_mut()
             .ok_or_else(|| ConfigError::NotATable {
-                path: self.path.clone(),
+                path,
                 table: table.into(),
-            })?;
-        table_item.insert(key, setting);
-        self.write()
+            })
     }
 
     fn invalid_preference(
@@ -1159,6 +1227,9 @@ mod tests {
             config.preferences().expect("readable").history_retention,
             "forever"
         );
+        assert_eq!(config.preferences().expect("readable").proxy_mode, "off");
+        assert!(config.preferences().expect("readable").proxy_host.is_empty());
+        assert_eq!(config.preferences().expect("readable").proxy_port, 0);
     }
 
     #[test]
@@ -1171,6 +1242,9 @@ mod tests {
             minimize_on_close: false,
             startup_mode: "daemon".into(),
             history_retention: "six-months".into(),
+            proxy_mode: "socks5".into(),
+            proxy_host: "127.0.0.1".into(),
+            proxy_port: 1080,
         };
 
         config.set_release_check(false).expect("release setting");
@@ -1179,6 +1253,9 @@ mod tests {
         config
             .set_history_retention("six-months")
             .expect("retention setting");
+        config
+            .set_proxy("socks5", "127.0.0.1", 1080)
+            .expect("proxy setting");
 
         let reread = Config::at(path.clone()).expect("reloaded");
         assert_eq!(reread.preferences().expect("readable"), preferences);
@@ -1199,6 +1276,25 @@ mod tests {
     fn an_unknown_startup_mode_is_refused() {
         let path = scratch("preferences-startup");
         std::fs::write(&path, "[general]\nstartup = \"everything\"\n").expect("seeded");
+        let config = Config::at(path).expect("valid TOML");
+
+        assert!(config.preferences().is_err());
+    }
+
+    #[test]
+    fn an_unknown_proxy_mode_is_refused_reading_and_writing() {
+        let path = scratch("preferences-proxy-mode");
+        std::fs::write(&path, "[proxy]\nmode = \"socks4\"\n").expect("seeded");
+        let mut config = Config::at(path).expect("valid TOML");
+
+        assert!(config.preferences().is_err());
+        assert!(config.set_proxy("gopher", "127.0.0.1", 1080).is_err());
+    }
+
+    #[test]
+    fn a_proxy_port_outside_the_range_is_refused_rather_than_clamped() {
+        let path = scratch("preferences-proxy-port");
+        std::fs::write(&path, "[proxy]\nmode = \"http\"\nport = 70000\n").expect("seeded");
         let config = Config::at(path).expect("valid TOML");
 
         assert!(config.preferences().is_err());

--- a/crates/tidemark-core/src/providers/antigravity/agy.rs
+++ b/crates/tidemark-core/src/providers/antigravity/agy.rs
@@ -300,6 +300,14 @@ async fn spawn(client: &reqwest::Client) -> Result<Server, ProviderError> {
         .process_group(0)
         // Something that looks like a terminal to a program that checks.
         .env("TERM", "xterm-256color");
+    // This process is the one place in this program that reaches a provider's servers
+    // without being one of our own clients: `agy` does its own HTTP. The proxy therefore
+    // has to arrive as environment, and it arrives *per command* — putting it on the
+    // daemon's own unit would mean a restart to change it, and a restart takes every card
+    // off the screen for as long as the first poll takes.
+    if let Some(proxy) = http::proxy() {
+        command.envs(proxy.child_env());
+    }
     if let Some(home) = std::env::var_os("HOME") {
         command.current_dir(&home);
     }
@@ -401,12 +409,17 @@ fn endpoint(port: u16, path: &str) -> String {
 /// bounded by the address: nothing built here is ever pointed at a name that resolves off
 /// this machine, so the certificate that is not checked is one that could only have been
 /// presented by a process on the same host.
+///
+/// `no_proxy` for the same reason, and it is not redundant: this builder is not
+/// [`http::builder`], but `system-proxy` would still have it read `HTTPS_PROXY` out of the
+/// environment and ask a proxy to connect to *our own* `127.0.0.1`.
 fn loopback_client() -> Result<reqwest::Client, ProviderError> {
     reqwest::Client::builder()
         .user_agent(tidemark_types::user_agent())
         .timeout(http::REQUEST_TIMEOUT)
         .connect_timeout(http::CONNECT_TIMEOUT)
         .tls_danger_accept_invalid_certs(true)
+        .no_proxy()
         .build()
         .map_err(ProviderError::Client)
 }

--- a/crates/tidemark-core/src/providers/http.rs
+++ b/crates/tidemark-core/src/providers/http.rs
@@ -1,14 +1,26 @@
-//! The one place an outbound HTTP client is built.
+//! The one place an outbound HTTP client is built, and the proxy it is built against.
 //!
 //! Everything that leaves this process identifies itself as `Tidemark/<version>`, and that
 //! is load-bearing rather than polite: `platform.claude.com` sits behind Cloudflare and
 //! answers a request with no user agent with `403 browser_signature_banned`. See
 //! `CONTEXT.md` § Networking.
+//!
+//! # Why the proxy is process-wide rather than a parameter
+//!
+//! There are forty-odd provider clients and every one of them would forward the same
+//! value, unchanged, from the same source. A proxy is not a property of a provider: it is
+//! a property of this process's network, exactly like the user agent and the two timeouts
+//! above, and those are read here rather than passed in for the same reason. It is written
+//! from one place — the daemon, at startup and on a preference change, both of which are
+//! already serialized behind the engine's configuration queue — and read wherever a client
+//! or a child process is built.
 
 use super::ProviderError;
 use reqwest::header::RETRY_AFTER;
-use reqwest::{Client, StatusCode};
+use reqwest::{Client, ClientBuilder, StatusCode};
+use std::sync::RwLock;
 use std::time::Duration;
+use tidemark_types::Preferences;
 
 /// Ceiling on a whole request. Codex is the slowest of the five at 2.7 s measured, so this
 /// is generous by an order of magnitude; it exists to stop a hung socket from wedging the
@@ -18,17 +30,154 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Ceiling on establishing the connection.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// What a proxy is never used for.
+///
+/// Two providers answer on this machine — Antigravity's `agy` language server on loopback,
+/// and a gateway a user runs themselves — and asking a proxy to reach `127.0.0.1` asks it
+/// to connect to *itself*. The list is not a preference: it is the one exclusion that is
+/// wrong to omit, and the same value is handed to child processes as `NO_PROXY`.
+pub const NO_PROXY: &str = "localhost,127.0.0.0/8,::1";
+
+/// The proxy every request and every child process goes through.
+///
+/// Holds the URL rather than a [`reqwest::Proxy`], which is neither `Clone` nor comparable,
+/// and which a child process cannot be handed at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Proxy {
+    url: String,
+}
+
+impl Proxy {
+    /// The proxy these three settings describe, or `None` when the mode is `off`.
+    ///
+    /// A mode with no host or no port is an error rather than a silent `None`: the user
+    /// asked for a proxy, and polling without one would look like it had worked. This is
+    /// the form the daemon validates a change in, before it is written.
+    pub fn new(mode: &str, host: &str, port: u16) -> Result<Option<Self>, String> {
+        let scheme = match mode {
+            Preferences::PROXY_OFF => return Ok(None),
+            Preferences::PROXY_HTTP => "http",
+            Preferences::PROXY_HTTPS => "https",
+            // `socks5h`, not `socks5`: the host name is resolved *at the proxy*. Anyone
+            // whose own resolver is the thing in the way would otherwise have the name
+            // looked up here and the proxy handed an address it cannot reach — which is
+            // also why `ALL_PROXY=socks5h://…` is the spelling the CLIs document.
+            Preferences::PROXY_SOCKS5 => "socks5h",
+            other => return Err(format!("unknown proxy mode {other:?}")),
+        };
+        let host = host.trim();
+        if host.is_empty() {
+            return Err("a proxy needs a host to reach".into());
+        }
+        if port == 0 {
+            return Err("a proxy needs a port to reach".into());
+        }
+        // A bare IPv6 address is not a URL authority until it is bracketed.
+        let authority = if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]")
+        } else {
+            host.to_owned()
+        };
+        let url = format!("{scheme}://{authority}:{port}");
+        // Parsed once, here, so a host that cannot be a proxy URL is refused where the
+        // user set it rather than failing every client build for the rest of the session.
+        reqwest::Proxy::all(&url)
+            .map_err(|error| format!("{url} cannot be used as a proxy: {error}"))?;
+        Ok(Some(Self { url }))
+    }
+
+    /// The proxy the stored preferences describe, for the daemon's own startup.
+    pub fn configured(preferences: &Preferences) -> Result<Option<Self>, String> {
+        Self::new(
+            &preferences.proxy_mode,
+            &preferences.proxy_host,
+            preferences.proxy_port,
+        )
+    }
+
+    /// The proxy URL, in the form both `reqwest` and the `*_proxy` variables take.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// What a child process needs in its environment to use the same proxy.
+    ///
+    /// Both spellings of each name, because which one a program reads depends on what it
+    /// was written in — Go and `curl` accept either, Node's fetch wants the uppercase
+    /// form — and this is set per command rather than on the daemon's own environment.
+    /// **That is the whole point:** an environment variable on the unit only takes effect
+    /// on a restart, and a restart takes every provider off the screen for a few seconds.
+    pub fn child_env(&self) -> [(&'static str, &str); 8] {
+        [
+            ("HTTP_PROXY", &self.url),
+            ("http_proxy", &self.url),
+            ("HTTPS_PROXY", &self.url),
+            ("https_proxy", &self.url),
+            ("ALL_PROXY", &self.url),
+            ("all_proxy", &self.url),
+            ("NO_PROXY", NO_PROXY),
+            ("no_proxy", NO_PROXY),
+        ]
+    }
+
+    fn to_reqwest(&self) -> Result<reqwest::Proxy, reqwest::Error> {
+        Ok(reqwest::Proxy::all(&self.url)?.no_proxy(reqwest::NoProxy::from_string(NO_PROXY)))
+    }
+}
+
+/// The configured proxy, or `None` for "whatever this process's environment says".
+///
+/// Written by the daemon and read by every client build; a `RwLock` rather than a channel
+/// because there is one writer, no writer that blocks, and nothing to wake up.
+static ACTIVE: RwLock<Option<Proxy>> = RwLock::new(None);
+
+/// Points every client and child process built from now on at this proxy.
+///
+/// `None` restores the default: `reqwest` reads the process environment, and a child
+/// inherits it — which is what this program did before the setting existed, and which is
+/// why turning the setting off does not mean "no proxy".
+pub fn set_proxy(proxy: Option<Proxy>) {
+    *ACTIVE
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = proxy;
+}
+
+/// The proxy in force, for a client build or a child process.
+pub fn proxy() -> Option<Proxy> {
+    ACTIVE
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+/// The builder every outbound client in this program starts from: the user agent, both
+/// timeouts, and the proxy in force.
+///
+/// Public, and erroring as `reqwest` rather than as a provider, because the release check
+/// is not a provider and still has to go through the same proxy. The one client that
+/// deliberately does not start here is Antigravity's loopback client, which talks to this
+/// machine.
+pub fn builder() -> Result<ClientBuilder, reqwest::Error> {
+    let builder = Client::builder()
+        .user_agent(tidemark_types::user_agent())
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(CONNECT_TIMEOUT);
+    match proxy() {
+        // Naming a proxy also stops `reqwest` reading the environment for one, which is
+        // what makes the setting authoritative rather than one of two opinions.
+        Some(proxy) => Ok(builder.proxy(proxy.to_reqwest()?)),
+        None => Ok(builder),
+    }
+}
+
 /// Builds the client every provider talks through.
 ///
 /// Providers own their client rather than sharing one, because Antigravity's is not
 /// interchangeable: it talks to a loopback server with a self-signed certificate and needs
 /// an exception no other provider should be given.
 pub fn client() -> Result<Client, ProviderError> {
-    Client::builder()
-        .user_agent(tidemark_types::user_agent())
-        .timeout(REQUEST_TIMEOUT)
-        .connect_timeout(CONNECT_TIMEOUT)
-        .build()
+    builder()
+        .and_then(ClientBuilder::build)
         .map_err(ProviderError::Client)
 }
 
@@ -114,5 +263,110 @@ mod tests {
             ),
             Err(ProviderError::RateLimited { retry_after: None })
         ));
+    }
+
+    fn preferences(mode: &str, host: &str, port: u16) -> Preferences {
+        Preferences {
+            proxy_mode: mode.into(),
+            proxy_host: host.into(),
+            proxy_port: port,
+            ..Preferences::default()
+        }
+    }
+
+    #[test]
+    fn each_mode_becomes_the_url_scheme_its_tools_document() {
+        let url = |mode| {
+            Proxy::configured(&preferences(mode, "proxy.example", 3128))
+                .expect("usable")
+                .expect("configured")
+                .url()
+                .to_owned()
+        };
+        assert_eq!(url(Preferences::PROXY_HTTP), "http://proxy.example:3128");
+        assert_eq!(url(Preferences::PROXY_HTTPS), "https://proxy.example:3128");
+        // Remote name resolution, deliberately: see `Proxy::configured`.
+        assert_eq!(
+            url(Preferences::PROXY_SOCKS5),
+            "socks5h://proxy.example:3128"
+        );
+    }
+
+    #[test]
+    fn off_is_no_proxy_of_ours_whatever_the_host_and_port_say() {
+        assert_eq!(
+            Proxy::configured(&preferences(Preferences::PROXY_OFF, "proxy.example", 3128))
+                .expect("readable"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_mode_without_somewhere_to_reach_is_refused_rather_than_ignored() {
+        assert!(Proxy::configured(&preferences(Preferences::PROXY_HTTP, "", 3128)).is_err());
+        assert!(
+            Proxy::configured(&preferences(Preferences::PROXY_HTTP, "proxy.example", 0)).is_err()
+        );
+        assert!(Proxy::configured(&preferences("gopher", "proxy.example", 3128)).is_err());
+    }
+
+    #[test]
+    fn a_bare_ipv6_address_is_bracketed_into_a_usable_authority() {
+        assert_eq!(
+            Proxy::configured(&preferences(Preferences::PROXY_SOCKS5, "::1", 1080))
+                .expect("usable")
+                .expect("configured")
+                .url(),
+            "socks5h://[::1]:1080"
+        );
+    }
+
+    #[test]
+    fn a_child_process_is_given_both_spellings_and_the_loopback_exclusion() {
+        let proxy = Proxy::configured(&preferences(Preferences::PROXY_HTTP, "proxy.example", 3128))
+            .expect("usable")
+            .expect("configured");
+        let env = proxy.child_env();
+
+        for name in [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ] {
+            assert_eq!(
+                env.iter()
+                    .find(|(candidate, _)| *candidate == name)
+                    .map(|(_, value)| *value),
+                Some(proxy.url()),
+                "{name}"
+            );
+        }
+        for name in ["NO_PROXY", "no_proxy"] {
+            assert_eq!(
+                env.iter()
+                    .find(|(candidate, _)| *candidate == name)
+                    .map(|(_, value)| *value),
+                Some(NO_PROXY),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_socks_proxy_builds_a_client_at_all() {
+        // The `socks` feature is what makes this true; without it `reqwest` accepts the
+        // URL and then refuses every connection through it at runtime.
+        let proxy = Proxy::configured(&preferences(Preferences::PROXY_SOCKS5, "127.0.0.1", 1080))
+            .expect("usable")
+            .expect("configured");
+        assert!(
+            Client::builder()
+                .proxy(proxy.to_reqwest().expect("proxy built"))
+                .build()
+                .is_ok()
+        );
     }
 }

--- a/crates/tidemark-core/tests/proxy.rs
+++ b/crates/tidemark-core/tests/proxy.rs
@@ -1,0 +1,95 @@
+//! What "the proxy is applied" has to mean: the bytes leave through it.
+//!
+//! An integration test rather than a unit test because the proxy is process-wide, and this
+//! file is a process of its own — a `#[test]` in the library would set it for every other
+//! test running beside it. One test function for the same reason: two would race over the
+//! one value they both set.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread::JoinHandle;
+
+use tidemark_core::providers::http::{self, Proxy};
+use tidemark_types::Preferences;
+
+/// A server that answers one request with `200 OK` and reports the request line it was
+/// sent.
+///
+/// Enough of an HTTP proxy to prove a client used one: a direct request carries the origin
+/// form (`GET /summary`), and only a proxied request carries the absolute form with the
+/// scheme and the host in it.
+fn one_shot_server() -> (u16, JoinHandle<String>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("a loopback port is available");
+    let port = listener.local_addr().expect("bound").port();
+    let handle = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("the client connects");
+        let mut reader = BufReader::new(&stream);
+        let mut request = String::new();
+        reader.read_line(&mut request).expect("a request line");
+        // Headers to the blank line, so the client is not answered mid-request.
+        loop {
+            let mut header = String::new();
+            if reader.read_line(&mut header).unwrap_or(0) == 0 || header.trim().is_empty() {
+                break;
+            }
+        }
+        let mut stream: &TcpStream = &stream;
+        let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+        let _ = stream.flush();
+        request.trim().to_owned()
+    });
+    (port, handle)
+}
+
+/// A port nothing is listening on, for a proxy that must never be dialled.
+fn dead_port() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("a port to abandon");
+    let port = listener.local_addr().expect("bound").port();
+    drop(listener);
+    port
+}
+
+#[tokio::test]
+async fn requests_leave_through_the_proxy_and_loopback_never_does() {
+    let (proxied, proxy_server) = one_shot_server();
+    http::set_proxy(
+        Proxy::new(Preferences::PROXY_HTTP, "127.0.0.1", proxied).expect("a usable proxy"),
+    );
+    let client = http::client().expect("a client builds with a proxy in force");
+
+    // `quota.invalid` resolves nowhere, so reaching `200` at all is the first half of the
+    // proof; the absolute request line is the second.
+    let response = client
+        .get("http://quota.invalid/summary")
+        .send()
+        .await
+        .expect("the proxy answers");
+    assert!(response.status().is_success());
+    assert_eq!(
+        proxy_server.join().expect("the proxy thread finishes"),
+        "GET http://quota.invalid/summary HTTP/1.1"
+    );
+
+    // Now with a proxy that cannot be dialled at all: a loopback request must still work,
+    // which is only true if it never went near it.
+    http::set_proxy(
+        Proxy::new(Preferences::PROXY_HTTP, "127.0.0.1", dead_port()).expect("a usable proxy"),
+    );
+    let (direct, local_server) = one_shot_server();
+    let client = http::client().expect("client builds");
+    let response = client
+        .get(format!("http://127.0.0.1:{direct}/status"))
+        .send()
+        .await
+        .expect("loopback is reached without the proxy");
+    assert!(response.status().is_success());
+    assert_eq!(
+        local_server.join().expect("the server thread finishes"),
+        "GET /status HTTP/1.1",
+        "loopback must be reached directly, in origin form"
+    );
+
+    // And off again puts the process back to reading its own environment.
+    http::set_proxy(Proxy::new(Preferences::PROXY_OFF, "", 0).expect("off is not a failure"));
+    assert_eq!(http::proxy(), None);
+}

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -345,6 +345,18 @@ pub struct Preferences {
     pub startup_mode: String,
     /// `forever`, `six-months`, or `one-year`.
     pub history_retention: String,
+    /// `off`, `http`, `https` or `socks5`: which kind of proxy every outbound request
+    /// and every child process the daemon starts goes through.
+    ///
+    /// `off` is not the same as "no proxy": it means nothing is configured here, and the
+    /// daemon's own environment — `HTTPS_PROXY` and friends — is left in charge, which is
+    /// what it was before this setting existed.
+    pub proxy_mode: String,
+    /// Host name or address of the proxy. Empty until one is set.
+    pub proxy_host: String,
+    /// Port the proxy listens on. Zero until one is set; a mode other than `off` needs a
+    /// real one.
+    pub proxy_port: u16,
 }
 
 impl Preferences {
@@ -355,6 +367,11 @@ impl Preferences {
     pub const RETENTION_FOREVER: &'static str = "forever";
     pub const RETENTION_SIX_MONTHS: &'static str = "six-months";
     pub const RETENTION_ONE_YEAR: &'static str = "one-year";
+
+    pub const PROXY_OFF: &'static str = "off";
+    pub const PROXY_HTTP: &'static str = "http";
+    pub const PROXY_HTTPS: &'static str = "https";
+    pub const PROXY_SOCKS5: &'static str = "socks5";
 
     /// Whether this build knows the named startup mode.
     pub fn valid_startup(value: &str) -> bool {
@@ -371,6 +388,14 @@ impl Preferences {
             Self::RETENTION_FOREVER | Self::RETENTION_SIX_MONTHS | Self::RETENTION_ONE_YEAR
         )
     }
+
+    /// Whether this build knows the named proxy mode.
+    pub fn valid_proxy_mode(value: &str) -> bool {
+        matches!(
+            value,
+            Self::PROXY_OFF | Self::PROXY_HTTP | Self::PROXY_HTTPS | Self::PROXY_SOCKS5
+        )
+    }
 }
 
 impl Default for Preferences {
@@ -380,6 +405,9 @@ impl Default for Preferences {
             minimize_on_close: true,
             startup_mode: Self::STARTUP_APP.into(),
             history_retention: Self::RETENTION_FOREVER.into(),
+            proxy_mode: Self::PROXY_OFF.into(),
+            proxy_host: String::new(),
+            proxy_port: 0,
         }
     }
 }
@@ -798,6 +826,7 @@ mod tests {
         let (decoded, _): (DataInfo, _) = encoded.deserialize().expect("decodes again");
         assert_eq!(decoded, original);
     }
+
     #[test]
     fn preferences_survive_the_bus() {
         let original = Preferences {
@@ -805,10 +834,27 @@ mod tests {
             minimize_on_close: false,
             startup_mode: "daemon".into(),
             history_retention: "one-year".into(),
+            proxy_mode: "socks5".into(),
+            proxy_host: "127.0.0.1".into(),
+            proxy_port: 1080,
         };
 
         let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
         let (decoded, _): (Preferences, _) = encoded.deserialize().expect("decodes again");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn only_the_four_named_proxy_modes_are_known() {
+        for mode in [
+            Preferences::PROXY_OFF,
+            Preferences::PROXY_HTTP,
+            Preferences::PROXY_HTTPS,
+            Preferences::PROXY_SOCKS5,
+        ] {
+            assert!(Preferences::valid_proxy_mode(mode), "{mode}");
+        }
+        assert!(!Preferences::valid_proxy_mode("socks4"));
+        assert!(!Preferences::valid_proxy_mode(""));
     }
 }

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -107,6 +107,11 @@ pub trait Daemon {
     fn set_minimize_on_close(&self, enabled: bool) -> zbus::Result<()>;
     fn set_startup_mode(&self, mode: &str) -> zbus::Result<()>;
     fn set_history_retention(&self, retention: &str) -> zbus::Result<()>;
+
+    /// All three proxy settings at once: they are one setting, and half of it applied is a
+    /// proxy nothing can be reached through.
+    fn set_proxy(&self, mode: &str, host: &str, port: u16) -> zbus::Result<()>;
+
     fn clear_history(&self) -> zbus::Result<()>;
 
     /// Puts the configured providers in the order the user arranged the cards in.

--- a/crates/tidemark/src/preferences.rs
+++ b/crates/tidemark/src/preferences.rs
@@ -1,4 +1,4 @@
-//! Application preferences: behavior, startup, updates and local data.
+//! Application preferences: behavior, startup, network, and local data.
 
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
@@ -27,10 +27,29 @@ const STARTUP_VALUES: [&str; 3] = [
 /// What the startup values above are called on screen, in the same order.
 const STARTUP_LABELS: [&str; 3] = ["App and tray", "Daemon only", "Off"];
 
+const PROXY_VALUES: [&str; 4] = [
+    Preferences::PROXY_OFF,
+    Preferences::PROXY_HTTP,
+    Preferences::PROXY_HTTPS,
+    Preferences::PROXY_SOCKS5,
+];
+
+/// What the proxy modes above are called on screen, in the same order.
+const PROXY_LABELS: [&str; 4] = ["Off", "HTTP", "HTTPS", "SOCKS5"];
+
 #[derive(Debug, Clone, Copy)]
 enum SwitchKind {
     ReleaseCheck,
     MinimizeOnClose,
+}
+
+/// Whether an incomplete proxy is the user's mistake or just the middle of typing one in.
+#[derive(Debug, Clone, Copy)]
+enum Complaint {
+    /// A deliberate submit: mark the row that is wrong and say why.
+    Loud,
+    /// A mode was chosen and the rest is still to come: focus, do not scold.
+    Silent,
 }
 
 /// The standard libadwaita Preferences dialog and its authoritative daemon-backed state.
@@ -42,6 +61,9 @@ pub struct PreferencesDialog {
     minimize_on_close: adw::SwitchRow,
     startup: adw::ComboRow,
     retention: adw::ComboRow,
+    proxy_mode: adw::ComboRow,
+    proxy_host: adw::EntryRow,
+    proxy_port: adw::EntryRow,
     config_path: adw::ActionRow,
     history_path: adw::ActionRow,
     history_size: adw::ActionRow,
@@ -94,6 +116,41 @@ impl PreferencesDialog {
         general.add(&startup);
         dialog.add(&general);
 
+        let proxy_mode = adw::ComboRow::builder()
+            .title("Proxy")
+            .subtitle("Route every request and every helper process through a proxy.")
+            .model(&gtk::StringList::new(&PROXY_LABELS))
+            .expression(gtk::PropertyExpression::new(
+                gtk::StringObject::static_type(),
+                None::<gtk::Expression>,
+                "string",
+            ))
+            .use_subtitle(true)
+            .build();
+        // An apply button rather than a request per keystroke: `example.com` on the way to
+        // `proxy.example.com` is eleven proxies nobody asked for, and each one would drop
+        // every client the daemon holds.
+        let proxy_host = adw::EntryRow::builder()
+            .title("Host")
+            .show_apply_button(true)
+            .input_purpose(gtk::InputPurpose::Url)
+            .build();
+        let proxy_port = adw::EntryRow::builder()
+            .title("Port")
+            .show_apply_button(true)
+            .input_purpose(gtk::InputPurpose::Digits)
+            .build();
+        let proxy_group = adw::PreferencesGroup::builder()
+            .title("Proxy")
+            .description(
+                "Applies immediately, without restarting the background service. \
+                 Requests to this machine never go through it.",
+            )
+            .build();
+        proxy_group.add(&proxy_mode);
+        proxy_group.add(&proxy_host);
+        proxy_group.add(&proxy_port);
+
         let release_check = adw::SwitchRow::builder()
             .title("Check for updates")
             .subtitle("Ask GitHub for the latest Tidemark release once an hour.")
@@ -102,12 +159,16 @@ impl PreferencesDialog {
             .title("Release Updates")
             .build();
         release_group.add(&release_check);
-        let updates = adw::PreferencesPage::builder()
-            .title("Updates")
-            .icon_name("software-update-available-symbolic")
+
+        // The release check lives here rather than on a page of its own: it is one switch,
+        // and what it is a switch over is the network.
+        let network = adw::PreferencesPage::builder()
+            .title("Network")
+            .icon_name("network-workgroup-symbolic")
             .build();
-        updates.add(&release_group);
-        dialog.add(&updates);
+        network.add(&proxy_group);
+        network.add(&release_group);
+        dialog.add(&network);
 
         let retention = adw::ComboRow::builder()
             .title("Keep history")
@@ -168,6 +229,9 @@ impl PreferencesDialog {
             minimize_on_close,
             startup: startup_mode,
             retention,
+            proxy_mode,
+            proxy_host,
+            proxy_port,
             config_path,
             history_path,
             history_size,
@@ -182,6 +246,7 @@ impl PreferencesDialog {
         settings.connect_switch(&settings.minimize_on_close, SwitchKind::MinimizeOnClose);
         settings.connect_startup();
         settings.connect_retention();
+        settings.connect_proxy();
         settings.connect_clear(&clear);
         settings.apply(&preferences, &data);
 
@@ -217,6 +282,19 @@ impl PreferencesDialog {
             retention_index(&preferences.history_retention),
             &preferences.history_retention,
         );
+        apply_named_choice(
+            &self.proxy_mode,
+            &PROXY_LABELS,
+            proxy_index(&preferences.proxy_mode),
+            &preferences.proxy_mode,
+        );
+        self.proxy_host.set_text(&preferences.proxy_host);
+        // Zero is "unset" on the wire and has to read as empty here: a port row showing
+        // `0` invites the user to leave it, and `0` is not a port.
+        self.proxy_port.set_text(&match preferences.proxy_port {
+            0 => String::new(),
+            port => port.to_string(),
+        });
         self.suppress.set(false);
 
         self.release_check
@@ -235,6 +313,10 @@ impl PreferencesDialog {
             .set_subtitle(&format_bytes(data.history_bytes));
         self.key_schema.set_subtitle(&data.key_schema);
         self.token_schema.set_subtitle(&data.token_schema);
+        for row in [&self.proxy_host, &self.proxy_port] {
+            row.remove_css_class("error");
+        }
+        self.sync_proxy_editable();
     }
 
     fn connect_switch(self: &Rc<Self>, row: &adw::SwitchRow, kind: SwitchKind) {
@@ -349,6 +431,135 @@ impl PreferencesDialog {
         });
     }
 
+    /// All three proxy rows commit the same way, because they are one setting.
+    ///
+    /// The mode opens the two rows it needs and then tries; the host and the port commit
+    /// when their apply button is pressed or Enter ends the edit. Whichever of them the
+    /// user touched, the daemon is sent the whole triple.
+    fn connect_proxy(self: &Rc<Self>) {
+        self.proxy_mode.connect_selected_notify({
+            let weak = Rc::downgrade(self);
+            move |_| {
+                if let Some(settings) = weak.upgrade()
+                    && !settings.suppress.get()
+                {
+                    // Before the attempt, because choosing `SOCKS5` is what makes the host
+                    // typeable and the attempt below is what needs it typed.
+                    settings.sync_proxy_editable();
+                    settings.submit_proxy(Complaint::Silent);
+                }
+            }
+        });
+        for row in [&self.proxy_host, &self.proxy_port] {
+            row.connect_apply({
+                let weak = Rc::downgrade(self);
+                move |_| {
+                    if let Some(settings) = weak.upgrade()
+                        && !settings.suppress.get()
+                    {
+                        settings.submit_proxy(Complaint::Loud);
+                    }
+                }
+            });
+        }
+    }
+
+    /// Whether the host and the port can be typed into.
+    ///
+    /// The rule reads the **row** and not the stored preference, which is the whole point
+    /// of it: choosing `SOCKS5` before typing where the proxy is, is how this group gets
+    /// filled in, and that choice is deliberately not sent - so the stored mode is still
+    /// `off` at the moment the two rows it needs have to become editable. Deriving this
+    /// from storage locks them shut and leaves the setting unreachable.
+    ///
+    /// A mode this build cannot show empties its own row, and `selected` is then out of
+    /// range: nothing to describe, nothing to type.
+    fn sync_proxy_editable(&self) {
+        let editable = proxy_rows_editable(self.proxy_mode.selected());
+        for row in [&self.proxy_host, &self.proxy_port] {
+            row.set_sensitive(editable);
+        }
+    }
+
+    /// Sends the proxy the three rows currently describe.
+    ///
+    /// A mode with no host or no port yet is **not** sent. The daemon would refuse it and
+    /// be right to, but choosing `SOCKS5` before typing where it is, is the normal way to
+    /// fill this group in, and answering the first half of that with an error is answering
+    /// the wrong thing: the row that still needs typing is focused, and only a deliberate
+    /// submit of an incomplete one is marked as wrong.
+    fn submit_proxy(self: &Rc<Self>, complaint: Complaint) {
+        let Some(mode) = PROXY_VALUES.get(self.proxy_mode.selected() as usize) else {
+            return;
+        };
+        let mode = (*mode).to_owned();
+        let host = self.proxy_host.text().trim().to_owned();
+        let typed = self.proxy_port.text();
+        let typed = typed.trim();
+        for row in [&self.proxy_host, &self.proxy_port] {
+            row.remove_css_class("error");
+        }
+        let port = if typed.is_empty() {
+            Some(0)
+        } else {
+            typed.parse::<u16>().ok().filter(|port| *port != 0)
+        };
+        let Some(port) = port else {
+            self.proxy_port.add_css_class("error");
+            self.proxy_port.grab_focus();
+            if matches!(complaint, Complaint::Loud) {
+                self.toast("A proxy port is a number from 1 to 65535");
+            }
+            return;
+        };
+        if mode != Preferences::PROXY_OFF {
+            let incomplete = if host.is_empty() {
+                Some(&self.proxy_host)
+            } else if port == 0 {
+                Some(&self.proxy_port)
+            } else {
+                None
+            };
+            if let Some(row) = incomplete {
+                if matches!(complaint, Complaint::Loud) {
+                    row.add_css_class("error");
+                }
+                row.grab_focus();
+                return;
+            }
+        }
+
+        let settings = Rc::clone(self);
+        let rows = [
+            self.proxy_host.clone().upcast::<gtk::Widget>(),
+            self.proxy_port.clone().upcast(),
+            self.proxy_mode.clone().upcast(),
+        ];
+        for row in &rows {
+            row.set_sensitive(false);
+        }
+        glib::spawn_future_local(async move {
+            let result = settings.proxy.set_proxy(&mode, &host, port).await;
+            match result {
+                Ok(()) => {
+                    {
+                        let mut preferences = settings.preferences.borrow_mut();
+                        preferences.proxy_mode = mode;
+                        preferences.proxy_host = host;
+                        preferences.proxy_port = port;
+                    }
+                    settings.toast("Proxy updated");
+                }
+                Err(error) => settings.toast(&error.to_string()),
+            }
+            // Either way the rows are redrawn from the state that is now authoritative,
+            // which is also what restores their sensitivity for the new mode.
+            let preferences = settings.preferences.borrow().clone();
+            let data = settings.data.borrow().clone();
+            settings.apply(&preferences, &data);
+        });
+    }
+
     fn connect_clear(self: &Rc<Self>, button: &gtk::Button) {
         button.connect_clicked({
             let weak: Weak<Self> = Rc::downgrade(self);
@@ -450,6 +661,22 @@ fn startup_index(value: &str) -> Option<u32> {
         .map(|index| index as u32)
 }
 
+fn proxy_index(value: &str) -> Option<u32> {
+    PROXY_VALUES
+        .iter()
+        .position(|candidate| *candidate == value)
+        .map(|index| index as u32)
+}
+
+/// Whether the host and port rows belong to a proxy at all, for what the mode row has
+/// selected right now - including [`gtk::INVALID_LIST_POSITION`], which is what an unknown
+/// daemon value leaves behind.
+fn proxy_rows_editable(selected: u32) -> bool {
+    PROXY_VALUES
+        .get(selected as usize)
+        .is_some_and(|mode| *mode != Preferences::PROXY_OFF)
+}
+
 fn format_bytes(bytes: u64) -> String {
     const KIB: u64 = 1024;
     const MIB: u64 = 1024 * KIB;
@@ -480,6 +707,32 @@ mod tests {
         assert_eq!(startup_index(Preferences::STARTUP_DAEMON), Some(1));
         assert_eq!(startup_index(Preferences::STARTUP_OFF), Some(2));
         assert_eq!(startup_index("everything"), None);
+    }
+
+    #[test]
+    fn every_proxy_mode_selects_its_named_row() {
+        assert_eq!(proxy_index(Preferences::PROXY_OFF), Some(0));
+        assert_eq!(proxy_index(Preferences::PROXY_HTTP), Some(1));
+        assert_eq!(proxy_index(Preferences::PROXY_HTTPS), Some(2));
+        assert_eq!(proxy_index(Preferences::PROXY_SOCKS5), Some(3));
+        assert_eq!(proxy_index("socks4"), None);
+        assert_eq!(PROXY_VALUES.len(), PROXY_LABELS.len());
+    }
+
+    /// The regression this exists for: the host and the port were derived from the
+    /// *stored* mode, which is still `off` while a just-chosen `SOCKS5` is waiting for the
+    /// host that would let it be stored. The two rows the user has to type into were the
+    /// two rows that stayed locked, and the setting could not be reached at all.
+    #[test]
+    fn choosing_a_proxy_opens_the_rows_it_needs_before_anything_is_stored() {
+        assert!(!proxy_rows_editable(0), "off has nothing to describe");
+        assert!(proxy_rows_editable(1), "http needs a host and a port");
+        assert!(proxy_rows_editable(2));
+        assert!(proxy_rows_editable(3), "socks5 needs a host and a port");
+        assert!(
+            !proxy_rows_editable(gtk::INVALID_LIST_POSITION),
+            "an unknown daemon mode empties its row and describes nothing"
+        );
     }
 
     #[test]
@@ -519,14 +772,19 @@ mod tests {
 
         for (labels, known, raw) in [
             (
-                &STARTUP_LABELS,
+                &STARTUP_LABELS[..],
                 startup_index(Preferences::STARTUP_DAEMON),
                 "launcher",
             ),
             (
-                &RETENTION_LABELS,
+                &RETENTION_LABELS[..],
                 retention_index(Preferences::RETENTION_ONE_YEAR),
                 "decade",
+            ),
+            (
+                &PROXY_LABELS[..],
+                proxy_index(Preferences::PROXY_SOCKS5),
+                "socks4",
             ),
         ] {
             let row = choice_row(labels);

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -2348,7 +2348,9 @@ mod tests {
         let mut harness = harness_with_config(
             vec![
                 Account::with_client(Fake::new(vec![Ok(reading(0, 42.0, 3600))])).with_rebuild(
-                    Box::new(|_| Ok(Fake::new(vec![Ok(reading(0, 42.0, 3600))]) as Arc<dyn Provider>)),
+                    Box::new(|_| {
+                        Ok(Fake::new(vec![Ok(reading(0, 42.0, 3600))]) as Arc<dyn Provider>)
+                    }),
                 ),
             ],
             std::env::temp_dir().join(format!("tidemark-engine-proxy-{}.toml", std::process::id())),
@@ -2377,7 +2379,8 @@ mod tests {
             "a client built against the old proxy must not survive the change"
         );
         assert_eq!(
-            harness.engine.accounts()[0].status, published,
+            harness.engine.accounts()[0].status,
+            published,
             "the reading on the card is not news about a proxy"
         );
 

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tidemark_core::config::Config;
+use tidemark_core::providers::http::{self, Proxy};
 use tidemark_core::providers::{Credential, Provider, ProviderError};
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_core::storage::{History, IngestReport};
@@ -64,6 +65,13 @@ pub enum Preference {
     MinimizeOnClose(bool),
     StartupMode(String),
     HistoryRetention(String),
+    /// The one preference that changes how this process reaches the network, rather than
+    /// what it does with what it reaches.
+    Proxy {
+        mode: String,
+        host: String,
+        port: u16,
+    },
 }
 
 /// What the D-Bus interface asks the loop to do.
@@ -530,12 +538,20 @@ impl Engine {
     /// (release watch, startup integration) must follow the durable config.
     pub async fn set_preference(&mut self, preference: Preference) -> Result<Preferences, String> {
         let retention_changed = matches!(&preference, Preference::HistoryRetention(_));
+        // Built before anything is written. A mode with nowhere to reach is a mistake the
+        // user can still see on screen and correct; persisted first, it would instead
+        // become a stored setting that fails every poll from here on.
+        let proxy = match &preference {
+            Preference::Proxy { mode, host, port } => Some(Proxy::new(mode, host, *port)?),
+            _ => None,
+        };
         let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
         match preference {
             Preference::ReleaseCheck(enabled) => config.set_release_check(enabled),
             Preference::MinimizeOnClose(enabled) => config.set_minimize_on_close(enabled),
             Preference::StartupMode(mode) => config.set_startup_mode(&mode),
             Preference::HistoryRetention(retention) => config.set_history_retention(&retention),
+            Preference::Proxy { mode, host, port } => config.set_proxy(&mode, &host, port),
         }
         .map_err(|error| error.to_string())?;
         let preferences = config.preferences().map_err(|error| error.to_string())?;
@@ -544,7 +560,42 @@ impl Engine {
         {
             tracing::error!(%error, "could not apply history retention");
         }
+        if let Some(proxy) = proxy {
+            self.adopt_proxy(proxy);
+        }
         Ok(preferences)
+    }
+
+    /// Points this process at a new proxy without restarting it.
+    ///
+    /// Dropping the clients is the whole mechanism: a `reqwest::Client` holds the proxy it
+    /// was built with for the life of the client, and its pool holds sockets already
+    /// established through the old one. Every account can build its client again — from a
+    /// stored key or from its settings — so this costs one keyring read per account on the
+    /// next poll and nothing else. **No status is touched**: each card keeps its last good
+    /// reading and its state while the new client is built under it, which is the
+    /// difference between this and restarting the service.
+    ///
+    /// `agy` comes along for the ride. Dropping Antigravity's client shuts down the
+    /// subprocess, and the next poll spawns a new one — with the proxy in its environment,
+    /// because [`Proxy::child_env`] is read at spawn time.
+    fn adopt_proxy(&mut self, proxy: Option<Proxy>) {
+        if http::proxy() == proxy {
+            return;
+        }
+        http::set_proxy(proxy);
+        let now = Instant::now();
+        for account in &mut self.accounts {
+            if !account.rebuildable() {
+                continue;
+            }
+            account.client = None;
+            // The old proxy may be why this account was failing, so its backoff is not
+            // evidence about the new one.
+            account.failures = 0;
+            account.retry_after = None;
+            account.due = now;
+        }
     }
 
     fn prune_for_retention(&mut self, retention: &str) -> Result<(), String> {
@@ -2275,6 +2326,9 @@ mod tests {
                 minimize_on_close: false,
                 startup_mode: Preferences::STARTUP_DAEMON.into(),
                 history_retention: Preferences::RETENTION_SIX_MONTHS.into(),
+                proxy_mode: Preferences::PROXY_OFF.into(),
+                proxy_host: String::new(),
+                proxy_port: 0,
             }
         );
         assert_eq!(
@@ -2284,6 +2338,79 @@ mod tests {
                 .expect("readable"),
             preferences
         );
+    }
+
+    /// The proxy is the one preference that changes this process rather than a file, so
+    /// this checks all three things that has to mean: the value is in force, the clients
+    /// built against the old one are gone, and no card lost its reading over it.
+    #[tokio::test]
+    async fn a_proxy_change_is_adopted_without_restarting_anything() {
+        let mut harness = harness_with_config(
+            vec![
+                Account::with_client(Fake::new(vec![Ok(reading(0, 42.0, 3600))])).with_rebuild(
+                    Box::new(|_| Ok(Fake::new(vec![Ok(reading(0, 42.0, 3600))]) as Arc<dyn Provider>)),
+                ),
+            ],
+            std::env::temp_dir().join(format!("tidemark-engine-proxy-{}.toml", std::process::id())),
+        );
+        harness.engine.poll_due(Instant::now()).await;
+        let published = harness.engine.accounts()[0].status.clone();
+        assert!(harness.engine.accounts()[0].client.is_some());
+
+        let preferences = harness
+            .engine
+            .set_preference(Preference::Proxy {
+                mode: Preferences::PROXY_SOCKS5.into(),
+                host: "127.0.0.1".into(),
+                port: 1080,
+            })
+            .await
+            .expect("proxy set");
+
+        assert_eq!(preferences.proxy_mode, Preferences::PROXY_SOCKS5);
+        assert_eq!(
+            http::proxy().expect("in force").url(),
+            "socks5h://127.0.0.1:1080"
+        );
+        assert!(
+            harness.engine.accounts()[0].client.is_none(),
+            "a client built against the old proxy must not survive the change"
+        );
+        assert_eq!(
+            harness.engine.accounts()[0].status, published,
+            "the reading on the card is not news about a proxy"
+        );
+
+        // Half a proxy is refused before it is written, so the one in force still stands.
+        let refused = harness
+            .engine
+            .set_preference(Preference::Proxy {
+                mode: Preferences::PROXY_HTTP.into(),
+                host: String::new(),
+                port: 8080,
+            })
+            .await;
+        assert!(refused.is_err());
+        assert_eq!(
+            Config::at(harness.config_path.clone())
+                .expect("reloaded")
+                .preferences()
+                .expect("readable")
+                .proxy_mode,
+            Preferences::PROXY_SOCKS5
+        );
+
+        // Back to none, so nothing else in this test binary inherits it.
+        harness
+            .engine
+            .set_preference(Preference::Proxy {
+                mode: Preferences::PROXY_OFF.into(),
+                host: String::new(),
+                port: 0,
+            })
+            .await
+            .expect("proxy cleared");
+        assert_eq!(http::proxy(), None);
     }
     #[tokio::test]
     async fn daily_maintenance_applies_the_configured_history_retention() {

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use tidemark_core::config::Config;
 use tidemark_core::paths;
+use tidemark_core::providers::http::{self, Proxy};
 use tidemark_core::secrets::Secrets;
 use tidemark_core::storage::History;
 use tidemark_types::ids;
@@ -128,6 +129,10 @@ async fn run() -> Result<(), Box<dyn Error>> {
     // key. Once running, a later bad edit is reported and the previous settings stand.
     let config = Config::at(config_path.clone())?;
     let preferences = config.preferences()?;
+    // Before the first client is built, because `registry::accounts` builds several of
+    // them: a `reqwest::Client` holds its proxy for life, and one built a line too early
+    // would keep talking around the proxy until the daemon was restarted.
+    http::set_proxy(Proxy::configured(&preferences).map_err(Box::<dyn Error>::from)?);
     let secrets: Arc<dyn Secrets> = Arc::new(keyring::Keyring::default());
     let accounts = registry::accounts(&secrets, &config)?;
     let configured = accounts

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -893,6 +893,34 @@ impl Daemon {
         self.publish_preferences(&emitter, preferences).await
     }
 
+    /// Points every outbound request and every child process at a proxy, or at none.
+    ///
+    /// Takes all three values together because they are one setting: applying a mode
+    /// before its host, or a host before its port, would put a proxy that cannot be
+    /// reached in front of every provider between the two calls.
+    async fn set_proxy(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        mode: &str,
+        host: &str,
+        port: u16,
+    ) -> fdo::Result<()> {
+        if !Preferences::valid_proxy_mode(mode) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "unknown proxy mode {mode:?}"
+            )));
+        }
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::Proxy {
+                mode: mode.into(),
+                host: host.into(),
+                port,
+            })
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
     /// Deletes every historical reading and refreshes the published storage facts.
     async fn clear_history(
         &self,

--- a/crates/tidemarkd/src/update.rs
+++ b/crates/tidemarkd/src/update.rs
@@ -49,10 +49,12 @@ impl Checker {
             HeaderName::from_static("x-github-api-version"),
             HeaderValue::from_static("2026-03-10"),
         );
-        let client = reqwest::Client::builder()
+        // The shared builder, so this goes through the user's proxy like everything else;
+        // the timeout is tightened over its default because nothing waits on this answer.
+        let client = tidemark_core::providers::http::builder()
+            .map_err(CheckError::Http)?
             .timeout(Duration::from_secs(15))
             .redirect(reqwest::redirect::Policy::none())
-            .user_agent(tidemark_types::user_agent())
             .default_headers(headers)
             .build()
             .map_err(CheckError::Http)?;


### PR DESCRIPTION
## What

A proxy setting on a new **Network** page: mode (`off` / `http` / `https` / `socks5`), host, port, stored as `[proxy]` in `config.toml`. The **Updates** page is gone; its release-check switch lives on Network beside the proxy, because it is one switch and what it switches is whether this program reaches the network at all on its own behalf.

## Why the shape is this

- **One holder, every client.** `tidemark-core::providers::http` keeps the proxy for the process and hands it to the one builder every provider client, and the release checker, is built from. `socks5` becomes `socks5h://`, so names are resolved at the proxy - for anyone whose own resolver is the thing in the way, resolving here and handing the proxy an address defeats the point.
- **A subprocess is not an exception.** Antigravity's `agy` does its own HTTP, so the proxy is handed to it as `HTTP(S)_PROXY` / `ALL_PROXY` / `NO_PROXY` in both spellings, per command, at spawn time. **Not** on the systemd unit: a variable there takes effect on a restart, and a restart takes every card off the screen until the first poll comes back.
- **A change is adopted without restarting anything.** `SetProxy(mode, host, port)` takes all three at once - half a proxy applied is a proxy nothing can be reached through - validates the URL, writes the file, then drops every provider client. A `reqwest::Client` holds its proxy for life and its pool holds sockets opened through the old one. **No status is touched**: each card keeps its last good reading while the new client is built under it. Dropping Antigravity's client shuts `agy` down and the next poll spawns it again with the new environment.
- **Loopback is never proxied.** `localhost,127.0.0.0/8,::1` is excluded on our clients and passed to children; Antigravity's loopback client is built with `no_proxy()` outright. Asking a proxy to reach `agy` on this machine asks it to connect to itself.
- **Off means "as before", not "direct".** With no mode set, `reqwest` reads the process environment and a child inherits it - what this program did before the setting existed.

## Verification

- `crates/tidemark-core/tests/proxy.rs` - a real HTTP `CONNECT` proxy in a thread: the request leaves as `CONNECT example.invalid:443` and loopback on the same client goes direct.
- Subprocess smoke in a private PID namespace: the first `agy` spawn has no proxy variables; after `SetProxy`, the same daemon PID spawns it with `ALL_PROXY=socks5h://127.0.0.1:1080` and a loopback `NO_PROXY`. No restart.
- Refusals: `http` with an empty host, and `socks4`, are errors and leave the file unchanged.
- On a live desktop: pointing at a dead port put all five providers in `unreachable`, pointing at a live one returned all five to `ok` - same daemon PID, no card lost its reading.
- `cargo test --workspace` 982 pass, `cargo clippy --workspace --all-targets` clean.

## Fixed while testing it by hand

Host and Port could not be clicked. Their sensitivity was derived from the **stored** mode, and the stored mode is `off` until a host is typed - which is exactly what those two rows are for. The rule now reads the mode *row*, so choosing a mode opens the fields it needs; the incomplete triple is never sent, and only a deliberate submit of an incomplete one is marked wrong. `choosing_a_proxy_opens_the_rows_it_needs_before_anything_is_stored` covers it.