### PR TITLE
fix(card): keep a card the same width whatever the daemon says

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -468,6 +468,16 @@ history that does not exist yet.
   a height and their footers line up; the cost is a short card in a single-column window
   carrying the height of the tallest one. The last row is left ragged: a filler card would
   be something to click on that does nothing.
+- **A card's width is the card's, not the daemon's.** The cell is the widest card's
+  *minimum* width — its own width request — and never its natural width, because a natural
+  width is the width of whatever text arrived: a provider that answered with an error
+  message longer than a card, or a window title nobody sized a card for, used to set the
+  width of every card on screen and collapse three columns into one. So every label that
+  shows a string from the daemon ellipsizes, and the one that shows prose whole wraps at any
+  character and stops after three lines — a D-Bus error name and a URL have no space in them
+  to wrap at, and a label that cannot shorten itself asks for the width of its text as its
+  *minimum*. The rest of a long message is in the provider's settings pane, and in the
+  tooltip.
 - **A window the provider did not send is not drawn.** No placeholder, no explanation. The
   window set is whatever arrived; the card rearranges silently when it changes. Needs
   hysteresis in the daemon so a single malformed response does not make a window blink.

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -11,6 +11,12 @@
 //! nearly exhausted one, a failure with a last good reading underneath it, and an account
 //! that has never answered at all.
 //!
+//! Three of them are here because a card's size must not depend on them: an error message
+//! longer than a card and unbreakable by word wrapping, a window whose title and absolutes
+//! are longer than the room they have, and a state string this build does not know and shows
+//! verbatim. All three arrive from another process, and each one of them widened every card
+//! on screen once.
+//!
 //! ```sh
 //! systemctl --user stop tidemarkd        # it owns the name; only one process can
 //! cargo run -p tidemark --example mock-daemon
@@ -236,6 +242,10 @@ fn statuses() -> Vec<ProviderStatus> {
     codex.auth_source = Some("oauth".to_owned());
     codex.external_present = Some(true);
     codex.has_credential = Some(true);
+    // A state this build has never heard of, which the card shows verbatim because the
+    // daemon is the one that can name it. Long on purpose: the title row has a mark, a name
+    // and a plan on it already, and the chip is the part that gives way.
+    codex.state = "waiting-for-billing-cycle".to_owned();
 
     let mut kimi = account(
         "kimi",
@@ -251,11 +261,17 @@ fn statuses() -> Vec<ProviderStatus> {
         Some("Asked to wait 20 minutes.".into()),
     );
 
+    // The case that used to widen every card on screen, in the words the keyring actually
+    // used: a message longer than a card, with a D-Bus error name in it that word wrapping
+    // cannot break. The card is meant to wrap it at any character and keep its size.
     let mut antigravity =
         ProviderStatus::pending(&ProviderId::new("antigravity"), &AccountId::default());
     antigravity.set_state(
-        ProviderState::NoCredential,
-        Some("Sign in to Antigravity to see its quota.".into()),
+        ProviderState::KeyringUnavailable,
+        Some(
+            "the keyring is unavailable: service error org.freedesktop.zbus.Error: i/o error"
+                .into(),
+        ),
     );
     // The empty half of the CLI screen: nothing signed in either way, so the pane has a
     // command to run and nothing found.
@@ -266,8 +282,12 @@ fn statuses() -> Vec<ProviderStatus> {
     // The account that reports a fixed balance rather than only a percentage: the absolutes
     // behind the 41% are drawn under the bar, in the provider's own words. No live provider
     // fills this in yet, so the mock is the only place the case can be looked at.
-    let mut zai_five_hour = window("5 hours", 18_000, 41.0, Some(9_000));
-    zai_five_hour.subtitle = Some("410 / 1,000 prompts".to_owned());
+    //
+    // Both strings are longer than the card is wide, deliberately: the provider chooses how
+    // it phrases a window and its absolutes, and neither may choose how wide a card is.
+    let mut zai_five_hour = window("5 hours (Coding Plan)", 18_000, 41.0, Some(9_000));
+    zai_five_hour.subtitle =
+        Some("410 of 1,000 prompts and 2,450,000 of 5,000,000 tokens".to_owned());
 
     let zai = account(
         "zai",

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -5,7 +5,7 @@
 //! a pace mark; the remaining windows as thin rows; and a line along the bottom saying when
 //! the reading was taken.
 //!
-//! Two rules are structural here rather than remembered.
+//! Three rules are structural here rather than remembered.
 //!
 //! **The last good reading stays on screen.** A card is never blanked because a poll
 //! failed; the numbers keep standing and the chip changes. The only card with no numbers on
@@ -14,6 +14,13 @@
 //! **A window the provider did not send is not drawn.** The rows are rebuilt from whatever
 //! arrived, so a provider that stops reporting a window loses a row without explanation,
 //! and one that starts reporting a new one gains it the same way.
+//!
+//! **Nothing a daemon says changes the size of a card.** Every string on a card arrives from
+//! another process — a provider's name, a plan, a window title, an error message — and every
+//! label that shows one either ellipsizes or wraps at any character, so a string too long
+//! for the space shortens itself. It has to: `grid::CardGrid` gives every cell the widest
+//! card's *minimum* width, so a label that answered "as wide as my text" would be answering
+//! for every card on screen.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -40,10 +47,20 @@ const MARK_GAP: i32 = 6;
 /// test below.
 const PILL_PADDING: i32 = 2;
 
-/// Narrowest a card is allowed to get. Three of these plus spacing is what "three columns"
-/// costs, and it is what stops the grid from packing three unreadable columns into a window
-/// that only has room for two.
+/// How wide a card is. Not a floor: the grid gives every cell exactly this, so three of
+/// these plus spacing is what "three columns" costs, and no card can widen its neighbours.
+///
+/// That is only true while **every line on a card can shorten itself** — the rule the
+/// `ellipsize`, `wrap_mode` and `width_chars` calls below exist for. A label that can do
+/// neither reports the width of its text as its minimum, `grid::CardGrid::cell_width` takes
+/// the widest minimum on screen, and one provider's long error message becomes every card's
+/// width. That is the bug this constant used to lose to.
 const MIN_WIDTH: i32 = 300;
+/// Most lines of a daemon message a card will lay out before ellipsizing it. Three is two
+/// more than any live message needs; what it stops is a paragraph deciding how tall every
+/// card in the row is. The whole of it stays readable in the provider's settings pane, which
+/// has the width and the scroller for it.
+const BLANK_LINES: i32 = 3;
 
 /// The account a card opens, retained separately from the readings that update in place.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,18 +125,29 @@ impl Card {
         provider_name: String,
         on_activate: Rc<dyn Fn(String, String)>,
     ) -> Self {
+        // All three ellipsize. None of them is expected to: a provider's name, its plan and
+        // a state chip all fit the row this build ships. They ellipsize because the three
+        // strings come from the *daemon* — a catalog entry, a plan the provider named, and,
+        // for a state this build has never heard of, that state verbatim — and a label that
+        // cannot shorten itself sets the width of every card in the grid. See `MIN_WIDTH`.
+        //
+        // Where the row does run short, GTK gives each label its minimum and shares what is
+        // left smallest-need-first, so the name is the last thing to lose characters.
         let name = gtk::Label::builder()
             .halign(gtk::Align::Start)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
             .css_classes(["heading"])
             .build();
         let plan = gtk::Label::builder()
             .halign(gtk::Align::Start)
             .valign(gtk::Align::End)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
             .css_classes(["caption", "quota-plan"])
             .build();
         let chip = gtk::Label::builder()
             .halign(gtk::Align::End)
             .hexpand(true)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
             .css_classes(["caption", "quota-chip"])
             .build();
 
@@ -171,8 +199,12 @@ impl Card {
         // them. Presentation the provider owns: it is set, never parsed and never
         // reformatted. A provider that reports only a percentage leaves it hidden, so the
         // card keeps the height it has always had.
+        //
+        // One line, ellipsized: the provider decides how long this string is, and neither
+        // the card's width nor its height is the provider's to decide.
         let absolutes = gtk::Label::builder()
             .halign(gtk::Align::Start)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
             .css_classes(["caption", "dim-label"])
             .build();
 
@@ -187,9 +219,20 @@ impl Card {
 
         // Shown in place of the reading, never alongside it: an account that has never
         // answered has nothing to put a number on.
+        //
+        // The one place on a card where daemon prose is printed whole, and therefore the
+        // one that has to be told, twice, that it may not resize the card. `WordChar` is
+        // what breaks the strings these messages are actually made of — a D-Bus error name,
+        // a URL, a token with no space in it anywhere. Plain word wrapping cannot break any
+        // of those, so it asks for the width of the longest one instead, and asking is
+        // enough: a minimum width is a minimum for every card in the grid. `lines` with an
+        // ellipsis bounds the other axis; see `BLANK_LINES`.
         let blank = gtk::Label::builder()
             .halign(gtk::Align::Start)
             .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .lines(BLANK_LINES)
             .xalign(0.0)
             .css_classes(["dim-label"])
             .build();
@@ -342,7 +385,12 @@ impl Card {
             None => {
                 self.reading.set_visible(false);
                 self.blank.set_visible(true);
-                self.blank.set_label(&blank_message(status));
+                let message = blank_message(status);
+                // The card shows the first `BLANK_LINES` of it; the tooltip is where the
+                // rest of a long one is, so that truncating it costs nothing on the way to
+                // the settings pane.
+                self.blank.set_tooltip_text(Some(&message));
+                self.blank.set_label(&message);
                 self.rebuild_rows(&[])
             }
         };

--- a/crates/tidemark/src/grid.rs
+++ b/crates/tidemark/src/grid.rs
@@ -290,7 +290,7 @@ mod imp {
             if count == 0 {
                 return (0, 0, -1, -1);
             }
-            let cell_width = self.natural_width();
+            let cell_width = self.cell_width();
             match orientation {
                 // One column is the minimum, because a card is as narrow as it is going to
                 // get. The natural width is however many columns there are cards for, up to
@@ -323,7 +323,7 @@ mod imp {
             if slots.is_empty() {
                 return;
             }
-            let cell_width = self.natural_width();
+            let cell_width = self.cell_width();
             let cell_height = self.natural_height(cell_width);
             let columns = columns(width, cell_width, SPACING, MAX_COLUMNS);
             self.columns.set(columns);
@@ -379,12 +379,23 @@ fn content_left(width: i32, columns: usize, cell_width: f64) -> f64 {
 }
 
 impl imp::CardGrid {
-    /// The widest card's natural width, which every cell gets.
-    fn natural_width(&self) -> i32 {
+    /// The width every cell gets: the widest card's **minimum** width.
+    ///
+    /// Minimum and not natural, and that is the whole of the rule that keeps cards the same
+    /// size. A card's natural width is a function of the text it was handed — a provider
+    /// that answers with a long error message, or a window title nobody sized the card for,
+    /// asks for a wider card — and every cell in this grid is the same width, so under
+    /// `natural` one long string from one daemon widened every card on screen. A minimum is
+    /// the card's own width request and nothing the daemon said, so a card that cannot fit
+    /// what it was given shortens it, which is what `card.rs` ellipsizes and wraps for.
+    ///
+    /// Height is still natural, below: a card that needs two lines gets two lines, and its
+    /// neighbours match it so the footers line up. Width is the axis with a right answer.
+    fn cell_width(&self) -> i32 {
         self.slots
             .borrow()
             .iter()
-            .map(|held| held.child.measure(gtk::Orientation::Horizontal, -1).1)
+            .map(|held| held.child.measure(gtk::Orientation::Horizontal, -1).0)
             .max()
             .unwrap_or(0)
     }


### PR DESCRIPTION
## The bug

Cards are meant to be one fixed cell wide. They were not: any provider that answered with a long string set the width of **every** card on screen, and three columns collapsed into one. Reported live from Z.ai timing out, and reproduced from a keyring failure:

> the keyring is unavailable: service error org.freedesktop.zbus.Error: i/o error

The message also never wrapped, although the label has `wrap(true)`.

## Why

Two things, the second hiding the first.

1. `grid::CardGrid` took the cell width from the widest card's **natural** width. One cell width serves every card, so one card decided for all of them.
2. A label's natural width is the width of the text it was handed — and `ellipsize` does not change that, it only lowers the *minimum*. Measured on GTK 4.22, for that 79-character message:

| label | min | nat |
|---|---|---|
| `wrap(true)` | 186 | **514** |
| `ellipsize(End)` | 10 | **514** |
| `wrap` + `max_width_chars(34)` | 186 | 266 |
| unbreakable token, `Word` + cap | **313** | 313 |
| unbreakable token, `WordChar` + cap | 21 | 306 |

So the card was granted 514 pixels and had no reason to wrap anything. The same applied to a window's provider-written absolutes and to a state string this build does not know and prints verbatim.

## The fix

- `grid.rs`: the cell is the widest card's **minimum** width — the card's own width request, 300 pixels, and nothing the daemon said. Height stays natural, so cards in a row still share a height and their footers still line up.
- `card.rs`: the invariant that makes that true is that every line on a card can shorten itself. The name, the plan, the state chip and a window's absolutes ellipsize; the message shown in place of a reading wraps at any character, because a D-Bus error name or a URL has no space to wrap at and plain word wrapping demands the whole token as its *minimum*. That message stops after three lines, with the rest in a tooltip and, as before, whole in the provider's settings pane.
- The rule is written down where it can be found again: the header of `card.rs` (third structural rule) and `CONTEXT.md` § Interface.
- `mock-daemon` grows the three cases that cause this, none of which can be produced on demand: an unbreakable message longer than a card, a window whose title and absolutes overrun their room, and an unknown state string.

## Verification

Same mock data, fix stashed and restored:

- **before** — one column, cards ~545 px wide, exactly the reported symptom;
- **after** — three columns, every card 300 px, the error wrapped onto two lines, the chip `waiting-for-billin…`, the absolutes `…2,450,000 of 5,000…`;
- a 240-character message stops at three lines with an ellipsis and the grid geometry does not move;
- no `Gtk-WARNING` about under-allocation in the client's log.

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test -p tidemark` (112 passed) and `scripts/check-layering.sh` are clean.

## Notes for review

- Cards are now *always* exactly 300 px, where before they stretched slightly with their text in a wide window. That is what `MIN_WIDTH` and `MAX_COLUMNS = 3` were written for, but it is a visible change.
- The tooltip on the blank message repeats the text when the message is short. Setting it only on a real truncation means reading `layout().is_ellipsized()` after allocation; happy to add that hook if the duplication is not wanted.
