### PR TITLE
fix(providers): render balance-based usage accurately

### DIFF
--- a/crates/tidemark-core/src/providers/keyed/deepseek.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepseek.rs
@@ -11,14 +11,13 @@
 //! acquired a different way, and out of this plan's scope. What a key can read is the
 //! balance, and that is all this reads.
 //!
-//! # This card is empty on purpose
+//! # The card reading
 //!
-//! A balance has no limit behind it: there is nothing to divide by, so there is no share to
-//! draw a bar against. The design's rule for that shape is a detail section and no window —
-//! see `docs/superpowers/specs/2026-08-21-keyed-provider-port-design.md`. The source draws
-//! a bar anyway, at nought per cent while funded and a hundred once empty, and its
-//! depletion is real information; if that is wanted here it is a change to how a balance is
-//! drawn, not to this parser.
+//! A balance has no limit behind it: DeepSeek reports what is *left* — total, granted,
+//! topped up — and never what was spent, so there is no denominator and no share to
+//! compute. Inventing one would be inventing a quota. The snapshot therefore carries no
+//! window. It files the selected amount under [`DetailSection::BALANCE`], which lets the
+//! card print the money without a percentage or bar.
 //!
 //! # What the payload does not tell you
 //!
@@ -118,17 +117,26 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
     let rows = match chosen {
         // No row at all is an account with nothing in it, not an unreadable response: the
         // source reports exactly that, in dollars, with the sentence that says what to do.
-        None => vec![DetailRow {
-            label: "Balance".to_owned(),
-            value: "$0.00 — add credits at platform.deepseek.com".to_owned(),
-        }],
-        Some(balance) if balance.total <= 0.0 => vec![DetailRow {
-            label: "Balance".to_owned(),
-            value: format!(
-                "{} — add credits at platform.deepseek.com",
-                balance.amount(0.0)
-            ),
-        }],
+        None => vec![
+            DetailRow {
+                label: "Balance".to_owned(),
+                value: "$0.00".to_owned(),
+            },
+            DetailRow {
+                label: "Status".to_owned(),
+                value: "Add credits at platform.deepseek.com".to_owned(),
+            },
+        ],
+        Some(balance) if balance.total <= 0.0 => vec![
+            DetailRow {
+                label: "Balance".to_owned(),
+                value: balance.amount(0.0),
+            },
+            DetailRow {
+                label: "Status".to_owned(),
+                value: "Add credits at platform.deepseek.com".to_owned(),
+            },
+        ],
         Some(balance) if !envelope.is_available => vec![
             DetailRow {
                 label: "Balance".to_owned(),
@@ -159,10 +167,9 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
         provider: ProviderId::new(PROVIDER_ID),
         account: AccountId::default(),
         captured_at,
-        // No limit was reported, so there is no share to draw. See the module doc.
         windows: Vec::new(),
         details: vec![DetailSection {
-            title: DetailSection::PLAN.to_owned(),
+            title: DetailSection::BALANCE.to_owned(),
             rows,
         }],
     })
@@ -232,14 +239,14 @@ mod tests {
     }
 
     #[test]
-    fn a_balance_with_no_limit_draws_no_bar_and_says_what_it_is() {
+    fn a_funded_balance_is_an_amount_only_reading() {
         let snapshot = parse(USD, at(1_800_000_000)).expect("parses");
         assert!(
             snapshot.windows.is_empty(),
-            "nothing said what the balance is out of; a bar would be invented"
+            "a remaining balance says nothing about a percentage"
         );
         assert_eq!(snapshot.details.len(), 1);
-        assert_eq!(snapshot.details[0].title, DetailSection::PLAN);
+        assert_eq!(snapshot.details[0].title, "Balance");
         assert_eq!(
             rows(&snapshot),
             [
@@ -283,18 +290,23 @@ mod tests {
         let snapshot = parse(zeroed, at(1_800_000_000)).expect("parses");
         assert_eq!(
             rows(&snapshot),
-            [(
-                "Balance".to_owned(),
-                "$0.00 — add credits at platform.deepseek.com".to_owned()
-            )]
+            [
+                ("Balance".to_owned(), "$0.00".to_owned()),
+                (
+                    "Status".to_owned(),
+                    "Add credits at platform.deepseek.com".to_owned()
+                ),
+            ]
         );
+        assert!(snapshot.windows.is_empty());
 
         // "empty balance_infos returns unavailable snapshot": no row at all is an account
         // with nothing in it, not an unreadable response.
         let none = r#"{"is_available":true,"balance_infos":[]}"#;
         let snapshot = parse(none, at(1_800_000_000)).expect("parses");
-        assert_eq!(rows(&snapshot).len(), 1);
-        assert!(rows(&snapshot)[0].1.starts_with("$0.00 —"));
+        assert_eq!(rows(&snapshot)[0].1, "$0.00");
+        assert_eq!(rows(&snapshot)[1].0, "Status");
+        assert!(snapshot.windows.is_empty());
     }
 
     #[test]
@@ -310,6 +322,7 @@ mod tests {
                 ("Status".to_owned(), "Unavailable for API calls".to_owned()),
             ]
         );
+        assert!(snapshot.windows.is_empty());
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/openrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/openrouter.rs
@@ -21,12 +21,19 @@
 //!
 //! # The reading
 //!
-//! A key with a limit is a fixed balance — spend against a stated budget — drawn as one
-//! lengthless window keyed `balance`, because a budget has no length to key on and
-//! never resets. Spend is the server-reported `limit_remaining` first, clamped to the
-//! limit, so a negative remaining reads as an exhausted quota; then the usage matching
-//! the declared reset window; then cumulative `usage`. A key without a limit is a row
-//! saying so and no window.
+//! The account's credits are the reading every OpenRouter key can produce: money added
+//! against money spent, which is a share, so they are drawn — one lengthless window keyed
+//! `credits`, `total_usage` over `total_credits`, because a topped-up balance has no length
+//! to key on and never resets. An account that has spent against no credits at all is drawn
+//! full rather than empty, the same way the other prepaid ports draw a configuration that
+//! reports spend with no allowance behind it.
+//!
+//! A key with a limit adds a second window — spend against a stated budget, keyed `balance`,
+//! lengthless for the same reason. Spend there is the server-reported `limit_remaining`
+//! first, clamped to the limit, so a negative remaining reads as an exhausted quota; then
+//! the usage matching the declared reset window; then cumulative `usage`. A key without a
+//! limit — the common case, and what a plain key reports — is a row saying so and no second
+//! window; the credits window is what the card leads with either way.
 //!
 //! # The base URL
 //!
@@ -229,6 +236,36 @@ impl Credits {
     fn balance(self) -> f64 {
         (self.total_credits - self.total_usage).max(0.0)
     }
+
+    /// The credits as a window: spent over added. Lengthless and resetless — money added
+    /// does not roll over into anything — so `named("credits")`, keyed apart from the key's
+    /// own `balance` budget because the two measure different money.
+    ///
+    /// Credits of nought are the degenerate case: nothing spent is an untouched account at
+    /// nought per cent, and spend recorded against no credits at all is drawn full, so a
+    /// configuration that cannot be measured is visible rather than reassuring.
+    fn window(self) -> Window {
+        let used_percent = if self.total_credits > 0.0 {
+            (self.total_usage / self.total_credits * 100.0).clamp(0.0, 100.0)
+        } else if self.total_usage > 0.0 {
+            100.0
+        } else {
+            0.0
+        };
+        Window {
+            key: WindowKey::named("credits"),
+            title: "Credits".to_owned(),
+            subtitle: Some(format!(
+                "{} of {} used · {} left",
+                usd(self.total_usage),
+                usd(self.total_credits),
+                usd(self.balance())
+            )),
+            used_percent,
+            resets_at: None,
+            length: None,
+        }
+    }
 }
 
 /// Reads the credits body. Pure, and strict: this request is the point of the fetch, so
@@ -359,7 +396,9 @@ fn snapshot(credits: &Credits, key: &KeyState, captured_at: Timestamp) -> Snapsh
         KeyState::Data(data) => Budget::of(data),
         KeyState::Degraded(_) => None,
     };
-    let mut windows = Vec::new();
+    // Credits lead: they are the reading the account always has, and the card draws the
+    // first lengthless window it is given.
+    let mut windows = vec![credits.window()];
     if let Some(budget) = &budget {
         windows.push(budget.window());
     }
@@ -579,10 +618,22 @@ mod tests {
     }
 
     #[test]
-    fn a_key_with_a_limit_is_one_balance_window() {
+    fn the_credits_are_the_first_window_and_a_key_limit_the_second() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_LIMIT_USAGE)));
-        assert_eq!(snapshot.windows.len(), 1);
-        let window = &snapshot.windows[0];
+        assert_eq!(snapshot.windows.len(), 2);
+
+        let credits = &snapshot.windows[0];
+        assert_eq!(credits.key.as_str(), "credits");
+        assert_eq!(credits.title, "Credits");
+        assert_eq!(credits.used_percent, 40.0, "$40 spent of the $100 added");
+        assert_eq!(credits.length, None);
+        assert_eq!(credits.resets_at, None);
+        assert_eq!(
+            credits.subtitle.as_deref(),
+            Some("$40.00 of $100.00 used · $60.00 left")
+        );
+
+        let window = &snapshot.windows[1];
         assert_eq!(window.key.as_str(), "balance");
         assert_eq!(window.title, "API key budget");
         assert_eq!(window.used_percent, 25.0);
@@ -591,6 +642,24 @@ mod tests {
         assert_eq!(
             window.subtitle.as_deref(),
             Some("$5.00 of $20.00 used · $15.00 left")
+        );
+    }
+
+    #[test]
+    fn credits_with_nothing_behind_them_are_drawn_by_whether_anything_was_spent() {
+        let untouched = Credits {
+            total_credits: 0.0,
+            total_usage: 0.0,
+        };
+        assert_eq!(untouched.window().used_percent, 0.0);
+        let spent = Credits {
+            total_credits: 0.0,
+            total_usage: 4.0,
+        };
+        assert_eq!(
+            spent.window().used_percent,
+            100.0,
+            "spend against no credits is a broken configuration, drawn full"
         );
     }
 
@@ -606,9 +675,11 @@ mod tests {
     }
 
     #[test]
-    fn a_key_without_a_limit_has_no_window_and_says_so() {
+    fn a_key_without_a_limit_still_draws_the_credits_and_says_so() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_EMPTY)));
-        assert!(snapshot.windows.is_empty());
+        assert_eq!(snapshot.windows.len(), 1);
+        assert_eq!(snapshot.windows[0].key.as_str(), "credits");
+        assert_eq!(snapshot.windows[0].used_percent, 40.0);
         assert_eq!(
             row_of(&snapshot, "API key budget").value,
             "No limit configured"
@@ -618,7 +689,7 @@ mod tests {
     #[test]
     fn the_server_reported_remaining_drives_the_window() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_REMAINING)));
-        let window = &snapshot.windows[0];
+        let window = &snapshot.windows[1];
         assert!(
             (window.used_percent - 9.0914810042).abs() < 1e-9,
             "{}",
@@ -632,11 +703,11 @@ mod tests {
     fn a_missing_remaining_falls_back_to_the_reset_window_usage() {
         for body in [KEY_MONTHLY_NO_REMAINING, KEY_MONTHLY_ONLY] {
             let snapshot = snapshot_with(&KeyState::Data(key_data(body)));
-            assert_eq!(snapshot.windows.len(), 1, "{body}");
+            assert_eq!(snapshot.windows.len(), 2, "{body}");
             assert!(
-                (snapshot.windows[0].used_percent - 9.0914810042).abs() < 1e-9,
+                (snapshot.windows[1].used_percent - 9.0914810042).abs() < 1e-9,
                 "{body}: {}",
-                snapshot.windows[0].used_percent
+                snapshot.windows[1].used_percent
             );
             assert_eq!(row_of(&snapshot, "API key remaining").value, "$454.54");
         }
@@ -645,7 +716,7 @@ mod tests {
     #[test]
     fn a_negative_remaining_is_an_exhausted_quota() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_NEGATIVE_REMAINING)));
-        assert_eq!(snapshot.windows[0].used_percent, 100.0);
+        assert_eq!(snapshot.windows[1].used_percent, 100.0);
         assert_eq!(row_of(&snapshot, "API key remaining").value, "$0.00");
     }
 
@@ -662,7 +733,8 @@ mod tests {
     #[test]
     fn a_degraded_key_request_leaves_the_credits_and_says_why() {
         let snapshot = snapshot_with(&KeyState::Degraded("HTTP 500".to_owned()));
-        assert!(snapshot.windows.is_empty());
+        assert_eq!(snapshot.windows.len(), 1, "the credits still measure");
+        assert_eq!(snapshot.windows[0].key.as_str(), "credits");
         assert_eq!(row_of(&snapshot, "Remaining").value, "$60.00");
         assert_eq!(
             row_of(&snapshot, "API key budget").value,

--- a/crates/tidemark-types/src/snapshot.rs
+++ b/crates/tidemark-types/src/snapshot.rs
@@ -81,10 +81,17 @@ impl DetailSection {
     /// The heading a provider files its subscription level under.
     ///
     /// A convention rather than a field, because "plan" means something different at every
-    /// provider — a level, a tier, a seat, a credit balance — and the adapters already
-    /// phrase it in the provider's own words. What a client needs is only *which section*
-    /// to lift onto the card, so that is all this pins down. See [`crate::ProviderStatus::plan`].
+    /// provider — a level, a tier, or a seat — and the adapters already phrase it in the
+    /// provider's own words. What a client needs is only *which section* to lift onto the
+    /// card, so that is all this pins down. See [`crate::ProviderStatus::plan`].
     pub const PLAN: &'static str = "Plan";
+
+    /// The heading for an amount-only balance reading.
+    ///
+    /// The first row is the provider-formatted amount a card may show when there is no rate
+    /// window and therefore no honest percentage or bar. Status prose belongs in later rows:
+    /// the card never parses a formatted amount to separate money from an explanation.
+    pub const BALANCE: &'static str = "Balance";
 }
 
 /// What to call a provider in front of a person.

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -526,6 +526,18 @@ impl ProviderStatus {
             .map(|row| row.value.as_str())
     }
 
+    /// An amount-only balance to show instead of an invented percentage.
+    ///
+    /// By convention this is the first row of [`DetailSection::BALANCE`]. It remains detail
+    /// data on the wire, so older clients simply keep it in the detail dialog.
+    pub fn balance(&self) -> Option<&str> {
+        self.details
+            .iter()
+            .find(|section| section.title == DetailSection::BALANCE)
+            .and_then(|section| section.rows.first())
+            .map(|row| row.value.as_str())
+    }
+
     /// The state, or `None` if this build does not know the string a newer daemon sent.
     pub fn state(&self) -> Option<ProviderState> {
         ProviderState::from_wire(&self.state)

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -26,7 +26,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use gtk::prelude::*;
-use tidemark_types::{ProviderStatus, Timestamp, Window};
+use tidemark_types::{DetailSection, ProviderState, ProviderStatus, Timestamp, Window};
 
 use crate::bar::QuotaBar;
 use crate::format;
@@ -375,14 +375,26 @@ impl Card {
 
         self.set_absolutes(absolutes_for(status).as_deref());
 
-        let secondary = match windows.split_first() {
-            Some((dominant, rest)) => {
+        let balance = balance_for(status);
+        let secondary = match (windows.split_first(), balance) {
+            (Some((dominant, rest)), _) => {
                 self.reading.set_visible(true);
                 self.blank.set_visible(false);
+                self.bar.widget().set_visible(true);
                 self.dominant_title.set_label(&dominant.title);
                 self.rebuild_rows(rest)
             }
-            None => {
+            (None, Some(balance)) => {
+                self.reading.set_visible(true);
+                self.blank.set_visible(false);
+                self.headline.set_label(balance);
+                self.dominant_title.set_label(DetailSection::BALANCE);
+                self.bar.widget().set_visible(false);
+                self.reset.set_visible(false);
+                self.set_absolutes(None);
+                self.rebuild_rows(&[])
+            }
+            (None, None) => {
                 self.reading.set_visible(false);
                 self.blank.set_visible(true);
                 let message = blank_message(status);
@@ -538,15 +550,23 @@ fn align_to_baseline(name: &gtk::Label, mark: &gtk::Image, plan: &gtk::Label) {
     });
 }
 
-/// What to say on a card that has no numbers to show.
+/// An amount-only balance from a successful reading.
 ///
-/// The daemon's own explanation when it gave one — it knows why, and it is more specific
-/// than anything this side could infer from the state alone.
+/// Failed polls leave the last good details in place. Those details must not hide the
+/// daemon's current explanation, so only an `Ok` state may promote its balance to the card.
+fn balance_for(status: &ProviderStatus) -> Option<&str> {
+    (status.state() == Some(ProviderState::Ok))
+        .then(|| status.balance())
+        .flatten()
+}
+
+/// What to say on a card that has no quota window or amount-only balance.
 fn blank_message(status: &ProviderStatus) -> String {
-    match status.message.as_deref() {
-        Some(message) => message.to_owned(),
-        None => "No reading yet.".to_owned(),
-    }
+    status
+        .message
+        .as_deref()
+        .unwrap_or("No reading yet.")
+        .to_owned()
 }
 
 #[cfg(test)]
@@ -555,7 +575,9 @@ mod tests {
     use std::rc::Rc;
 
     use super::*;
-    use tidemark_types::{AccountId, ProviderId, ProviderState, WindowStatus};
+    use tidemark_types::{
+        AccountId, DetailRow, DetailSection, ProviderId, ProviderState, WindowStatus,
+    };
 
     /// When the readings below were taken. Fixed so that nothing here depends on the wall
     /// clock.
@@ -600,6 +622,21 @@ mod tests {
             Some("No key is stored for zai.".into()),
         );
         assert_eq!(blank_message(&status), "No key is stored for zai.");
+    }
+
+    #[test]
+    fn a_balance_only_reading_shows_its_amount_instead_of_a_placeholder() {
+        let mut status = status_with(Vec::new());
+        status.details = vec![DetailSection {
+            title: DetailSection::BALANCE.to_owned(),
+            rows: vec![DetailRow {
+                label: "Balance".to_owned(),
+                value: "$1.93".to_owned(),
+            }],
+        }];
+        status.set_state(ProviderState::Ok, None);
+
+        assert_eq!(balance_for(&status), Some("$1.93"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose OpenRouter account credits as the dominant monetary usage window while preserving an optional per-key budget
- publish DeepSeek balances without an invented percentage when the API provides no denominator
- render successful amount-only balances on GTK cards without a quota bar, reset time, or percentage while preserving quota-window and current-failure precedence

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `dbus-run-session -- cargo test --workspace`
- `./scripts/check-layering.sh`
- live GTK smoke test with configured OpenRouter and DeepSeek accounts

## Live result

- OpenRouter: account credit consumption is shown as `61%` with `$9.16 of $15.00 used · $5.84 left`
- DeepSeek: balance is shown as `$1.93` with the `Balance` label and no percentage or bar
