### PR TITLE
fix(grid): stop a reorder from stacking translucent cards

### DIFF
--- a/crates/tidemark/src/grid.rs
+++ b/crates/tidemark/src/grid.rs
@@ -61,6 +61,19 @@ pub const SLOT_CLASS: &str = "quota-slot";
 /// inside it. On the slot rather than the card because the grid holds slots and knows
 /// nothing about what is in them; `style.rs` matches `.quota-slot.dragging > .quota-card`.
 const DRAGGING_CLASS: &str = "dragging";
+/// The class the grid itself carries, which every rule in `style.rs` is scoped to. Added
+/// here rather than by whoever builds the grid, so a rule cannot quietly stop matching
+/// because a caller forgot it.
+pub const GRID_CLASS: &str = "quota-grid";
+/// Added to the *grid* for as long as any card is off its slot.
+///
+/// Every card, and not only the ones in motion. `.card` is 8% white over whatever is behind
+/// it in the dark style, and when two cards overlap the one on top may be either of them: a
+/// card the drag left standing still is painted above every card with a lower index, so a
+/// traveller sliding under one showed through it however opaque the traveller itself was
+/// made. The cheapest thing that is right is for no card to be translucent while any card
+/// is moving. `style.rs` matches `.quota-grid.reordering > .quota-slot > .quota-card`.
+const REORDERING_CLASS: &str = "reordering";
 
 /// How many columns fit, between one and `max`.
 ///
@@ -160,6 +173,26 @@ fn shift(index: usize, from: usize, to: usize) -> f64 {
         return 1.0;
     }
     0.0
+}
+
+/// The order the cards are painted in: the ones standing still, then the ones in motion,
+/// then the carried one, each group keeping its slot order.
+///
+/// Painting order is child order, and slot order is the wrong child order the moment a card
+/// leaves its slot. A card travelling to a slot on another row crosses the rows between,
+/// and every card the drag left alone with a higher index is painted after it — so the
+/// travelling card slid *under* its neighbours instead of over them. Nothing that is
+/// standing still should be over something that is moving.
+fn paint_order(motion: &[bool], carried: Option<usize>) -> Vec<usize> {
+    let carried = carried.filter(|index| *index < motion.len());
+    let mut order = Vec::with_capacity(motion.len());
+    for group in [false, true] {
+        order.extend(
+            (0..motion.len()).filter(|index| Some(*index) != carried && motion[*index] == group),
+        );
+    }
+    order.extend(carried);
+    order
 }
 
 /// How fast the scrolled view should follow a pointer this far into its edge, in pixels per
@@ -268,6 +301,7 @@ mod imp {
     impl ObjectImpl for CardGrid {
         fn constructed(&self) {
             self.parent_constructed();
+            self.obj().add_css_class(GRID_CLASS);
             self.obj().install_gesture();
         }
 
@@ -587,6 +621,9 @@ impl CardGrid {
             // the detail dialog. The card also moves to the end of the child list, which is
             // what puts it above its siblings for both painting and picking.
             gesture.set_state(gtk::EventSequenceState::Claimed);
+            // Cards are about to overlap, in both directions of z-order. Nothing on this
+            // grid is translucent until the last of them is back on a slot.
+            self.add_css_class(REORDERING_CLASS);
             let index = self.imp().drag.borrow().as_ref().map(|drag| drag.index);
             if let Some(index) = index {
                 let slots = self.imp().slots.borrow();
@@ -632,6 +669,7 @@ impl CardGrid {
         for (index, wanted) in shifts {
             self.animate_offset(index, wanted);
         }
+        self.raise_moving();
         self.queue_allocate();
     }
 
@@ -789,6 +827,7 @@ impl CardGrid {
                 autoscroll.remove();
             }
         }
+        self.remove_css_class(REORDERING_CLASS);
         for held in self.imp().slots.borrow().iter() {
             held.child.remove_css_class(DRAGGING_CLASS);
             held.target.set(0.0);
@@ -807,6 +846,30 @@ impl CardGrid {
         for held in self.imp().slots.borrow().iter() {
             held.child.insert_after(self, previous.as_ref());
             previous = Some(held.child.clone());
+        }
+    }
+
+    /// Rebuilds the child list in [`paint_order`], so a card in motion is painted over the
+    /// cards standing still. Once per change of destination, not once per frame: which
+    /// cards are moving only changes when the pointer crosses a slot boundary.
+    fn raise_moving(&self) {
+        let carried = self
+            .imp()
+            .drag
+            .borrow()
+            .as_ref()
+            .filter(|drag| drag.carrying || drag.settle.is_some())
+            .map(|drag| drag.index);
+        let slots = self.imp().slots.borrow();
+        let motion: Vec<bool> = slots
+            .iter()
+            .map(|held| held.offset.get() != 0.0 || held.target.get() != 0.0)
+            .collect();
+        let mut previous: Option<gtk::Widget> = None;
+        for index in paint_order(&motion, carried) {
+            let child = slots[index].child.clone();
+            child.insert_after(self, previous.as_ref());
+            previous = Some(child);
         }
     }
 
@@ -1012,12 +1075,45 @@ mod tests {
     }
 
     #[test]
+    fn a_card_in_motion_is_painted_over_the_cards_standing_still() {
+        // Card 1 is the one being carried, and card 3 is travelling to a slot on another
+        // row. Cards 4 and 5 are standing still with higher indices, which is what used to
+        // put them over the top of card 3.
+        let motion = [false, false, true, true, false, false];
+        assert_eq!(paint_order(&motion, Some(1)), [0, 4, 5, 2, 3, 1]);
+    }
+
+    #[test]
+    fn nothing_moving_leaves_the_cards_in_slot_order() {
+        assert_eq!(paint_order(&[false; 4], None), [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn a_carried_card_that_the_daemon_removed_underneath_the_drag_is_not_painted_twice() {
+        // `slots` can be replaced while a drag is in flight, and an index that is no longer
+        // in it would otherwise be appended to an order it is not a member of.
+        assert_eq!(paint_order(&[false, true], Some(7)), [0, 1]);
+    }
+
+    #[test]
     fn the_stylesheet_lifts_the_widget_the_drag_actually_marks() {
         // The class goes on the slot, and the rule that makes a carried card opaque has to
         // be written against the slot too. It was written against the card once, matched
         // nothing, and the only symptom was a translucent card mid-drag — which no test
         // reaches and no warning reports.
         let selector = format!(".{SLOT_CLASS}.{DRAGGING_CLASS} >");
+        assert!(
+            crate::style::STYLE.contains(&selector),
+            "the stylesheet has to select {selector}"
+        );
+    }
+
+    #[test]
+    fn the_stylesheet_makes_every_card_opaque_while_one_is_moving() {
+        // Same trap, one level up: this class goes on the grid, and a rule scoped to the
+        // slot instead would leave the cards a drag displaces translucent, which is a bug
+        // report and not a test failure.
+        let selector = format!(".{GRID_CLASS}.{REORDERING_CLASS} > .{SLOT_CLASS} >");
         assert!(
             crate::style::STYLE.contains(&selector),
             "the stylesheet has to select {selector}"

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -47,19 +47,41 @@ pub(crate) const STYLE: &str = "
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.18), 0 8px 20px 0 rgba(0, 0, 0, 0.34);
 }
 
-/* Held by the pointer: opaque, further off the surface, and not offset, because the grid is
-   already carrying it.
+/* While any card is off its slot: every card opaque, in the colour it already was.
 
-   The background is the point. `.card` takes `@card_bg_color`, which in the dark style is
-   8% white *over whatever is behind it* — correct for a card lying on the window, and wrong
-   for one being carried over its neighbours, which then show through it. A lifted card is
-   opaque, and `@popover_bg_color` is the platform's own name for a surface floating above
-   the content rather than a colour of our invention. The foreground is deliberately left
-   alone: the bar's track and its pace mark take the inherited text colour, and changing it
-   would make them shift tone for the length of a drag. */
+   `.card` takes `@card_bg_color`, which in the dark style is 8% white *over whatever is
+   behind it* — right for a card lying on the window, wrong the moment cards overlap, and a
+   reorder makes them overlap: a displaced card whose new slot is on another row travels
+   there diagonally, across both rows. It is not enough to make the travelling card opaque.
+   Painting order is child order, so a card the drag left standing still is *above* every
+   card with a lower index, and a traveller sliding under one showed through it however
+   opaque the traveller was. While anything is moving, nothing is translucent.
+
+   The colour is the composite the card already is — `@window_bg_color` for the window it
+   lies on, with `@card_bg_color` over it as an image, because a background image paints
+   over the background colour. So the rule is invisible: it goes on when a drag starts and
+   comes off when the last card lands, and no card changes tone either time. Which rules out
+   `@popover_bg_color`, the carried card's colour: eight cards stepping a shade lighter for
+   the length of a drag is worse than the overlap it would fix. */
+.quota-grid.reordering > .quota-slot > .quota-card {
+    background-color: @window_bg_color;
+    background-image: linear-gradient(@card_bg_color, @card_bg_color);
+}
+
+/* Held by the pointer: further off the surface, and not offset, because the grid is already
+   carrying it. `@popover_bg_color` is the platform's own name for a surface floating above
+   the content rather than a colour of our invention, and it is opaque, so the card above
+   the rest of them is the one card that may say so. Written after the rule above because
+   the two have the same specificity, and `background-image` back to `none` because that
+   rule sets one.
+
+   The foreground is deliberately left alone: the bar's track and its pace mark take the
+   inherited text colour, and changing it would make them shift tone for the length of a
+   drag. */
 .quota-grid > .quota-slot.dragging > .quota-card,
 .quota-grid > .quota-slot:hover.dragging > .quota-card {
     background-color: @popover_bg_color;
+    background-image: none;
     transform: none;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.24), 0 16px 36px 0 rgba(0, 0, 0, 0.44);
 }

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -127,7 +127,6 @@ impl MainWindow {
         grid.set_margin_start(12);
         grid.set_margin_end(12);
         grid.set_valign(gtk::Align::Start);
-        grid.add_css_class("quota-grid");
 
         let scroller = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Never)


### PR DESCRIPTION
## What was wrong

The carried card was made opaque when it turned out to show its neighbours through itself. The cards it *displaces* do the same thing, and worse: a card whose new slot is on another row travels there diagonally, across both rows, so it overlaps cards that are not moving at all. `.card` is `@card_bg_color` — 8% white over whatever is behind it in the dark style — so for the 250 ms of the reorder animation two cards read as one translucent pile.

Making only the travelling card opaque was not enough, because painting order is child order: a card the drag left standing still is painted above every card with a lower index. The traveller therefore showed *through* the resting cards it slid under, and was drawn *beneath* them into the bargain.

## What changed

- The grid carries `.reordering` for as long as any card is off its slot, and every card on it is painted the composite it already is: `@window_bg_color` as the background colour with `@card_bg_color` over it as a background image (a background image paints over the background colour). Opaque, and over the window indistinguishable from `.card`, so no card changes tone as the class goes on or comes off. `@popover_bg_color` — the carried card's colour — would have stepped eight cards a shade lighter for the length of every drag.
- The child list is rebuilt in `paint_order` on every change of destination: cards standing still, then cards in motion, then the carried one, each group keeping its slot order. Once per slot boundary the pointer crosses, not once per frame.
- `quota-grid` moves from `window.rs` onto the widget itself, since three rules are scoped to it and a caller that forgot it would silently unstyle them.

## Verification

- `paint_order` is a free function with three tests, in the module's existing style: movers over resters, identity when nothing moves, and a carried index the daemon removed underneath the drag.
- Both stylesheet selectors are asserted against `style::STYLE`, so a rule written against the wrong widget fails a test instead of becoming a bug report.
- Measured in a GTK4 harness loading `STYLE` straight out of `style.rs`, dark style, resting card painted over a traveller: overlap `rgb(50,50,54)` with `.reordering` versus `rgb(66,66,69)` without it, and `rgb(50,50,54)` for a card of either kind over the bare window — opaque, with no tone shift. The `.dragging` rule still wins over the new one (equal specificity, written after). `GtkCssProvider::parsing-error` reported nothing.
- The reorder animation was then driven end to end over a real `CardGrid` and checked by hand.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `dbus-run-session -- cargo test --workspace` (998 tests), `scripts/check-layering.sh`, `scripts/check-desktop-integration.sh` all pass.
