### PR TITLE
feat(debug): log every provider response verbatim behind a config switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ Antigravity can sign in through Tidemark, or reuse the login their own CLI alrea
 
 Removing a provider deletes its credentials and its card but keeps the quota history.
 
+## Reporting a wrong reading
+
+If a card shows a number the provider's own dashboard disagrees with, the useful evidence
+is the response Tidemark actually received. Put this in `~/.config/tidemark/config.toml`:
+
+```toml
+[debug]
+raw_responses = true
+```
+
+then `systemctl --user restart tidemarkd`. Every provider response is written verbatim,
+one JSON object per line, to `~/.local/share/tidemark/debug/responses.ndjson`:
+
+```bash
+jq 'select(.provider == "opencodego")' ~/.local/share/tidemark/debug/responses.ndjson
+```
+
+API keys are never written: request headers are left out entirely, URL query strings are
+redacted, and the sign-in endpoints are not logged at all. The file still describes your
+account's usage, so read it before attaching it to an issue. It rolls over at 16 MB and
+keeps one previous file. There is no switch in the interface — turning it off is the same
+edit, and a restart.
+
 ## Supported providers
 
 **Sign in with your account**

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -45,6 +45,14 @@ const UPDATES_TABLE: &str = "updates";
 const RELEASE_CHECK_KEY: &str = "check";
 const HISTORY_TABLE: &str = "history";
 const HISTORY_RETENTION_KEY: &str = "retention";
+/// Table the raw-response log lives under: `[debug] raw_responses = true`.
+///
+/// Deliberately not part of [`Preferences`]. That type is the D-Bus wire shape the
+/// interface and every other client read, and this is not a preference anyone is meant to
+/// find in a settings dialog: it is a switch a person flips in the file, on purpose, to
+/// collect evidence for a bug report.
+const DEBUG_TABLE: &str = "debug";
+const RAW_RESPONSES_KEY: &str = "raw_responses";
 const PROXY_TABLE: &str = "proxy";
 const PROXY_MODE_KEY: &str = "mode";
 const PROXY_HOST_KEY: &str = "host";
@@ -196,6 +204,17 @@ impl Config {
                 .to_owned(),
             proxy_port: self.preference_port(PROXY_TABLE, PROXY_PORT_KEY)?,
         })
+    }
+
+    /// Whether the daemon should write every provider response to the raw-response log.
+    ///
+    /// Read once, at startup: a switch that took effect mid-poll would leave a file whose
+    /// gaps mean nothing. There is no setter, because there is deliberately no control —
+    /// see [`DEBUG_TABLE`].
+    pub fn debug_raw_responses(&self) -> Result<bool, ConfigError> {
+        Ok(self
+            .preference_bool(DEBUG_TABLE, RAW_RESPONSES_KEY)?
+            .unwrap_or(false))
     }
 
     pub fn set_release_check(&mut self, enabled: bool) -> Result<(), ConfigError> {
@@ -752,6 +771,37 @@ mod tests {
         let config = Config::at(scratch("absent").with_file_name("nothing.toml"))
             .expect("a missing file is an empty document");
         assert_eq!(config.option("zai", "region"), None);
+    }
+
+    #[test]
+    fn the_raw_response_log_is_off_until_the_file_asks_for_it() {
+        let path = scratch("debug-absent");
+        let _ = std::fs::remove_file(&path);
+        let config = Config::at(path.clone()).expect("missing is valid");
+        assert!(!config.debug_raw_responses().expect("readable"));
+
+        std::fs::write(&path, "[debug]\nraw_responses = true\n").expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert!(config.debug_raw_responses().expect("readable"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_raw_response_switch_that_is_not_a_boolean_is_refused_rather_than_ignored() {
+        // Silently defaulting would leave someone collecting evidence for a bug report
+        // from a log that was never opened.
+        let path = scratch("debug-not-a-bool");
+        std::fs::write(&path, "[debug]\nraw_responses = \"yes\"\n").expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert!(matches!(
+            config.debug_raw_responses(),
+            Err(ConfigError::InvalidPreference {
+                table: DEBUG_TABLE,
+                key: RAW_RESPONSES_KEY,
+                ..
+            })
+        ));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/tidemark-core/src/debug.rs
+++ b/crates/tidemark-core/src/debug.rs
@@ -1,0 +1,494 @@
+//! The raw-response log: every provider exchange, written down verbatim, when the user
+//! asks for one.
+//!
+//! Off unless `[debug] raw_responses = true` in `config.toml`, and read only when the
+//! daemon starts. A reading that is wrong is wrong somewhere between the bytes on the
+//! wire and the number on the card, and by the time the card is wrong the bytes are gone:
+//! this is the only place they still exist. NDJSON, one line per request, so a body can
+//! go to `jq` or into a bug report exactly as it arrived — the body is stored as a
+//! *string*, never re-encoded, because a malformed response is the interesting case and
+//! re-encoding it would repair the evidence.
+//!
+//! # What is deliberately not written
+//!
+//! Request headers, ever: the credential rides in one. The query string of a URL, for the
+//! same reason — a few providers take the key there. And the OAuth token endpoints do not
+//! come through here at all, because their response body *is* the credential.
+//!
+//! # Why the sink is process-wide rather than a parameter
+//!
+//! For the reason [`crate::providers::http`] gives about the proxy, which this deliberately
+//! mirrors: whether this process writes a debug log is a property of the process, it is
+//! written once at startup, and forty-odd provider clients would otherwise forward the
+//! same value, unchanged, from the same source.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+/// Directory the log lives in, under the data directory.
+pub const DEBUG_DIR: &str = "debug";
+
+/// File name of the raw-response log.
+pub const RESPONSE_LOG: &str = "responses.ndjson";
+
+/// Size at which the log rolls over to `responses.ndjson.1`.
+///
+/// One previous file is kept, so the ceiling on disk is twice this. At forty accounts on
+/// a five-minute interval that is days of history, which is the horizon a "sometimes it
+/// reads 100%" report needs — long enough to catch the next occurrence, short enough that
+/// a switch left on does not quietly fill a home directory.
+const ROTATE_AT: u64 = 16 * 1024 * 1024;
+
+/// The open log, or `None` for "the user did not ask for one".
+static SINK: Mutex<Option<Sink>> = Mutex::new(None);
+
+/// What was sent. Headers are absent by construction — see the module docs.
+#[derive(Debug, Clone, Copy)]
+pub struct Sent<'a> {
+    /// HTTP method.
+    pub method: &'a str,
+    /// URL, whose query string this module strips before writing.
+    pub url: &'a str,
+    /// The request body, for the providers whose quota call is a POST. Without it the
+    /// JSON-RPC to `agy` is unreadable.
+    pub body: Option<&'a str>,
+}
+
+impl<'a> Sent<'a> {
+    /// A GET, which is what all but a handful of quota endpoints are.
+    pub const fn get(url: &'a str) -> Self {
+        Self {
+            method: "GET",
+            url,
+            body: None,
+        }
+    }
+}
+
+/// A built request's own description of itself, taken before the request is consumed so
+/// that the answer can be written down beside it.
+#[derive(Debug, Clone)]
+pub struct Recorded {
+    method: String,
+    url: String,
+    body: Option<String>,
+}
+
+impl Recorded {
+    /// Describes a request, or nothing at all when the log is off and no one would read
+    /// it — which is the state this costs anything in.
+    pub fn of(request: &reqwest::Request) -> Option<Self> {
+        if !enabled() {
+            return None;
+        }
+        Some(Self {
+            method: request.method().as_str().to_owned(),
+            url: request.url().as_str().to_owned(),
+            body: request
+                .body()
+                .and_then(reqwest::Body::as_bytes)
+                .map(|bytes| String::from_utf8_lossy(bytes).into_owned()),
+        })
+    }
+
+    /// What to hand [`Exchange`].
+    pub fn sent(&self) -> Sent<'_> {
+        Sent {
+            method: &self.method,
+            url: &self.url,
+            body: self.body.as_deref(),
+        }
+    }
+}
+
+/// What came back.
+#[derive(Debug, Clone, Copy)]
+pub enum Answer<'a> {
+    /// A response whose body was read, whatever that body turns out to mean.
+    Body {
+        /// The status that carried it.
+        status: u16,
+        /// The body, verbatim.
+        body: &'a str,
+    },
+    /// A response refused on its status before the body was read.
+    Refused {
+        /// The status that refused it.
+        status: u16,
+    },
+    /// No response at all: DNS, connection, TLS, timeout.
+    Failed {
+        /// The failure, already rendered — and already redacted, where the caller
+        /// redacts.
+        error: &'a str,
+    },
+}
+
+/// One provider request and whatever came back from it.
+#[derive(Debug, Clone, Copy)]
+pub struct Exchange<'a> {
+    /// Slug of the provider that made the request, so a line is greppable by the card it
+    /// belongs to rather than only by host.
+    pub provider: &'a str,
+    /// What was sent.
+    pub sent: Sent<'a>,
+    /// What came back.
+    pub answer: Answer<'a>,
+}
+
+/// Starts writing every exchange to `<data_dir>/debug/responses.ndjson`, and says where.
+///
+/// Appends to an existing file: the whole point is to still hold yesterday's evidence
+/// after a restart.
+pub fn enable(data_dir: &Path) -> std::io::Result<PathBuf> {
+    let path = data_dir.join(DEBUG_DIR).join(RESPONSE_LOG);
+    let sink = Sink::open(path.clone())?;
+    *lock() = Some(sink);
+    Ok(path)
+}
+
+/// Stops writing and closes the log.
+pub fn disable() {
+    *lock() = None;
+}
+
+/// Whether an exchange handed to [`record`] would be written.
+///
+/// For a caller deciding whether to pay for a string it would otherwise not build.
+pub fn enabled() -> bool {
+    lock().is_some()
+}
+
+/// Writes one exchange, or does nothing at all when the log is off.
+///
+/// A write that fails closes the log and says so once. The alternative — reporting per
+/// poll — turns a full disk into a second problem, and this is a debugging aid: it must
+/// never be able to take polling down with it.
+pub fn record(exchange: Exchange<'_>) {
+    let mut guard = lock();
+    let Some(sink) = guard.as_mut() else {
+        return;
+    };
+    if let Err(error) = sink.write(&line(&exchange)) {
+        *guard = None;
+        tracing::error!(%error, "the raw-response log could not be written; it is now off");
+    }
+}
+
+/// The open file and how much has gone into it.
+#[derive(Debug)]
+struct Sink {
+    path: PathBuf,
+    file: File,
+    written: u64,
+}
+
+impl Sink {
+    fn open(path: PathBuf) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let written = file.metadata()?.len();
+        Ok(Self {
+            path,
+            file,
+            written,
+        })
+    }
+
+    fn write(&mut self, line: &str) -> std::io::Result<()> {
+        self.file.write_all(line.as_bytes())?;
+        self.file.write_all(b"\n")?;
+        // Flushed by `File` on every write; nothing is buffered here on purpose, because
+        // the run this log exists to explain is the one that ends in a crash.
+        self.written = self
+            .written
+            .saturating_add(line.len() as u64)
+            .saturating_add(1);
+        if self.written >= ROTATE_AT {
+            *self = Self::rolled(&self.path)?;
+        }
+        Ok(())
+    }
+
+    /// The log renamed aside and a fresh one opened in its place.
+    fn rolled(path: &Path) -> std::io::Result<Self> {
+        std::fs::rename(path, previous(path))?;
+        Self::open(path.to_owned())
+    }
+}
+
+/// Where a rolled-over log goes: `responses.ndjson.1`, beside the live one.
+fn previous(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(".1");
+    PathBuf::from(name)
+}
+
+/// One NDJSON line. Pure, so the shape is testable without a file.
+fn line(exchange: &Exchange<'_>) -> String {
+    let mut entry = serde_json::Map::new();
+    entry.insert("at".to_owned(), now().into());
+    entry.insert("provider".to_owned(), exchange.provider.into());
+    entry.insert("method".to_owned(), exchange.sent.method.into());
+    entry.insert("url".to_owned(), redact(exchange.sent.url).into());
+    entry.insert(
+        "request_body".to_owned(),
+        match exchange.sent.body {
+            Some(body) => body.into(),
+            None => serde_json::Value::Null,
+        },
+    );
+    match exchange.answer {
+        Answer::Body { status, body } => {
+            entry.insert("status".to_owned(), status.into());
+            entry.insert("body".to_owned(), body.into());
+        }
+        Answer::Refused { status } => {
+            entry.insert("status".to_owned(), status.into());
+            entry.insert("body".to_owned(), serde_json::Value::Null);
+        }
+        Answer::Failed { error } => {
+            entry.insert("error".to_owned(), error.into());
+        }
+    }
+    serde_json::Value::Object(entry).to_string()
+}
+
+/// The URL without its query string, which is where a few providers carry the key.
+fn redact(url: &str) -> String {
+    match url.split_once('?') {
+        Some((base, _)) => format!("{base}?<redacted>"),
+        None => url.to_owned(),
+    }
+}
+
+fn now() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_default()
+}
+
+fn lock() -> MutexGuard<'static, Option<Sink>> {
+    SINK.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exchange<'a>(url: &'a str, answer: Answer<'a>) -> Exchange<'a> {
+        Exchange {
+            provider: "opencodego",
+            sent: Sent {
+                method: "GET",
+                url,
+                body: None,
+            },
+            answer,
+        }
+    }
+
+    fn parsed(line: &str) -> serde_json::Value {
+        serde_json::from_str(line).expect("every written line is one JSON object")
+    }
+
+    #[test]
+    fn a_body_is_written_as_a_string_rather_than_re_encoded() {
+        // The malformed response is the one worth having, and a re-encode would repair
+        // it on the way to disk.
+        let raw = "{\"used\": 100,}";
+        let entry = parsed(&line(&exchange(
+            "https://opencode.ai/api/usage",
+            Answer::Body {
+                status: 200,
+                body: raw,
+            },
+        )));
+        assert_eq!(entry["body"], serde_json::Value::String(raw.to_owned()));
+        assert_eq!(entry["status"], 200);
+        assert_eq!(entry["provider"], "opencodego");
+        assert_eq!(entry["request_body"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn a_key_carried_in_the_query_string_never_reaches_the_log() {
+        let entry = parsed(&line(&exchange(
+            "https://api.example/usage?api_key=sk-secret&x=1",
+            Answer::Body {
+                status: 200,
+                body: "{}",
+            },
+        )));
+        assert_eq!(entry["url"], "https://api.example/usage?<redacted>");
+        assert!(!entry.to_string().contains("sk-secret"), "{entry}");
+    }
+
+    #[test]
+    fn a_refusal_and_a_transport_failure_are_told_apart() {
+        let refused = parsed(&line(&exchange(
+            "https://api.example/usage",
+            Answer::Refused { status: 429 },
+        )));
+        assert_eq!(refused["status"], 429);
+        assert_eq!(refused["body"], serde_json::Value::Null);
+        assert_eq!(refused.get("error"), None);
+
+        let failed = parsed(&line(&exchange(
+            "https://api.example/usage",
+            Answer::Failed {
+                error: "connection refused",
+            },
+        )));
+        assert_eq!(failed["error"], "connection refused");
+        assert_eq!(failed.get("status"), None);
+    }
+
+    /// Answers exactly one request with one JSON body, then closes.
+    fn one_request_server(body: &'static str) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead, BufReader, Write as _};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("loopback listener");
+        let address = listener.local_addr().expect("listener address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("request accepted");
+            let mut reader = BufReader::new(&mut stream);
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("header read");
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+            }
+            drop(reader);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("response written");
+        });
+        (format!("http://{address}"), server)
+    }
+
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("a runtime")
+            .block_on(future)
+    }
+
+    /// A temporary directory that removes itself, named so two suites can run at once.
+    #[derive(Debug)]
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new() -> Self {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static SERIAL: AtomicU32 = AtomicU32::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "tidemark-debug-{}-{}",
+                std::process::id(),
+                SERIAL.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).expect("a temporary directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Exercises the file directly rather than through the process-wide sink: while the
+    /// sink is on, every other provider test in this binary writes to it too, so line
+    /// counts are only deterministic here.
+    #[test]
+    fn the_log_appends_a_line_at_a_time_and_rolls_over_at_the_cap() {
+        let dir = TestDir::new();
+        let path = dir.0.join(DEBUG_DIR).join(RESPONSE_LOG);
+        let mut sink = Sink::open(path.clone()).expect("a writable log");
+
+        for index in 0..3 {
+            sink.write(&format!("{{\"n\":{index}}}")).expect("written");
+        }
+        let written = std::fs::read_to_string(&path).expect("the log exists");
+        assert_eq!(written.lines().count(), 3, "{written}");
+        assert_eq!(written.lines().last(), Some("{\"n\":2}"));
+
+        // One oversized line takes the file past the cap, which must move it aside and
+        // start a fresh one rather than letting it grow without bound.
+        let huge = "x".repeat(usize::try_from(ROTATE_AT).expect("the cap fits a usize"));
+        sink.write(&huge).expect("written");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("a fresh log"),
+            "",
+            "the live log starts empty after a roll-over"
+        );
+        assert_eq!(
+            std::fs::read_to_string(previous(&path))
+                .expect("the rolled-aside log")
+                .lines()
+                .count(),
+            4
+        );
+
+        // Reopening appends rather than truncating: the evidence from before a restart is
+        // the reason this file exists.
+        let mut reopened = Sink::open(path.clone()).expect("reopened");
+        reopened.write("{\"after\":\"restart\"}").expect("written");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("the log exists"),
+            "{\"after\":\"restart\"}\n"
+        );
+    }
+
+    /// The sink reached the way a provider reaches it: through the transport every keyed
+    /// provider shares. Asserts only on its own line, because the sink is process-wide and
+    /// the rest of this binary's tests keep polling while it is on.
+    #[test]
+    fn an_exchange_reaches_the_log_through_the_transport_every_provider_shares() {
+        let dir = TestDir::new();
+        let served = "{\"limits\":[{\"used\":7}]}";
+        let (url, server) = one_request_server(served);
+
+        let path = enable(&dir.0).expect("a writable log");
+        assert!(enabled());
+        let fetched = block_on(async {
+            let client = reqwest::Client::new();
+            let request = client
+                .get(format!("{url}/usage"))
+                .query(&[("api_key", "sk-secret")])
+                .build()
+                .expect("a built request");
+            crate::providers::keyed::request("opencodego", &client, request).await
+        });
+        disable();
+        assert!(!enabled());
+
+        server.join().expect("the server thread finished");
+        assert_eq!(fetched.expect("the server answered"), served);
+
+        let written = std::fs::read_to_string(&path).expect("the log exists");
+        let entry = written
+            .lines()
+            .map(parsed)
+            .find(|entry| entry["provider"] == "opencodego")
+            .expect("the exchange this test made");
+        assert_eq!(entry["method"], "GET");
+        assert_eq!(entry["status"], 200);
+        assert_eq!(entry["body"], served);
+        assert_eq!(entry["url"], format!("{url}/usage?<redacted>"));
+        assert!(!written.contains("sk-secret"), "{written}");
+    }
+}

--- a/crates/tidemark-core/src/lib.rs
+++ b/crates/tidemark-core/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub mod config;
 
+pub mod debug;
+
 pub mod paths;
 
 pub mod oauth;

--- a/crates/tidemark-core/src/providers/antigravity/agy.rs
+++ b/crates/tidemark-core/src/providers/antigravity/agy.rs
@@ -146,19 +146,26 @@ impl Agy {
 
     /// Posts one RPC to a server already proven ready.
     pub async fn rpc(&self, port: u16, path: &str) -> Result<String, ProviderError> {
+        let url = endpoint(port, path);
         let response = self
             .client
-            .post(endpoint(port, path))
+            .post(&url)
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .header(reqwest::header::ACCEPT, "application/json")
             .body("{}")
             .send()
             .await
             .map_err(ProviderError::Transport)?;
-        let status = response.status();
-        let retry_after = http::retry_after_header(&response).map(str::to_owned);
-        http::check(status, retry_after.as_deref())?;
-        response.text().await.map_err(ProviderError::Transport)
+        crate::providers::read_body(
+            super::PROVIDER_ID,
+            crate::debug::Sent {
+                method: "POST",
+                url: &url,
+                body: Some("{}"),
+            },
+            response,
+        )
+        .await
     }
 
     /// Returns the port of a live server, starting one if there is none.

--- a/crates/tidemark-core/src/providers/antigravity/direct.rs
+++ b/crates/tidemark-core/src/providers/antigravity/direct.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use tidemark_types::{AccountId, ProviderId, Snapshot, Timestamp, Window, WindowKey, WindowLength};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-use crate::providers::{ProviderError, http, title_case};
+use crate::providers::{ProviderError, title_case};
 
 use super::PROVIDER_ID;
 
@@ -29,22 +29,30 @@ pub async fn fetch(
         "{}/v1internal:fetchAvailableModels",
         endpoint.trim_end_matches('/')
     );
+    let payload = match project_id {
+        Some(project_id) => serde_json::json!({ "project": project_id }),
+        // Not `{"project": ""}`: an account Google gave no Cloud AI Companion project
+        // asks about itself, and a blank one is a value the server would validate.
+        None => serde_json::json!({}),
+    };
     let response = client
-        .post(url)
+        .post(&url)
         .bearer_auth(access_token)
-        .json(&match project_id {
-            Some(project_id) => serde_json::json!({ "project": project_id }),
-            // Not `{"project": ""}`: an account Google gave no Cloud AI Companion project
-            // asks about itself, and a blank one is a value the server would validate.
-            None => serde_json::json!({}),
-        })
+        .json(&payload)
         .send()
         .await
         .map_err(ProviderError::Transport)?;
-    let status = response.status();
-    let retry_after = http::retry_after_header(&response).map(str::to_owned);
-    http::check(status, retry_after.as_deref())?;
-    let body = response.text().await.map_err(ProviderError::Transport)?;
+    let sent_body = payload.to_string();
+    let body = crate::providers::read_body(
+        PROVIDER_ID,
+        crate::debug::Sent {
+            method: "POST",
+            url: &url,
+            body: Some(&sent_body),
+        },
+        response,
+    )
+    .await?;
     parse(&body, Timestamp::now())
 }
 

--- a/crates/tidemark-core/src/providers/claude.rs
+++ b/crates/tidemark-core/src/providers/claude.rs
@@ -201,10 +201,12 @@ impl Claude {
             .send()
             .await
             .map_err(ProviderError::Transport)?;
-        let status = response.status();
-        let retry_after = http::retry_after_header(&response).map(str::to_owned);
-        http::check(status, retry_after.as_deref())?;
-        let body = response.text().await.map_err(ProviderError::Transport)?;
+        let body = super::read_body(
+            PROVIDER_ID,
+            crate::debug::Sent::get(&self.usage_url),
+            response,
+        )
+        .await?;
         let mut snapshot = parse(&body, Timestamp::now())?;
         // Asked after the reading, never before it: the plan is one line on the card and
         // the windows are the point of the poll, so nothing about the plan may delay or
@@ -253,10 +255,20 @@ impl Claude {
             .send()
             .await
             .ok()?;
-        if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.ok()?;
+        crate::debug::record(crate::debug::Exchange {
+            provider: PROVIDER_ID,
+            sent: crate::debug::Sent::get(&self.profile_url),
+            answer: crate::debug::Answer::Body {
+                status: status.as_u16(),
+                body: &body,
+            },
+        });
+        if !status.is_success() {
             return None;
         }
-        let plan = plan_from_profile(&response.text().await.ok()?)?;
+        let plan = plan_from_profile(&body)?;
         let _ = self.plan.set(plan.clone());
         Some(plan)
     }

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -215,13 +215,23 @@ impl Codex {
                 )
                 && credentials.refresh_token.is_some()
             {
+                crate::debug::record(crate::debug::Exchange {
+                    provider: PROVIDER_ID,
+                    sent: crate::debug::Sent::get(&self.usage_url),
+                    answer: crate::debug::Answer::Refused {
+                        status: status.as_u16(),
+                    },
+                });
                 refreshed = true;
                 credentials = self.force_refresh().await?;
                 continue;
             }
-            let retry_after = http::retry_after_header(&response).map(str::to_owned);
-            http::check(status, retry_after.as_deref())?;
-            let body = response.text().await.map_err(ProviderError::Transport)?;
+            let body = super::read_body(
+                PROVIDER_ID,
+                crate::debug::Sent::get(&self.usage_url),
+                response,
+            )
+            .await?;
             return parse(&body, Timestamp::now());
         }
     }

--- a/crates/tidemark-core/src/providers/keyed/aiand.rs
+++ b/crates/tidemark-core/src/providers/keyed/aiand.rs
@@ -135,6 +135,7 @@ impl AiAnd {
         let mut after_id: Option<String> = None;
         for _ in 0..MAX_PAGES {
             let body = super::request(
+                PROVIDER_ID,
                 &self.client,
                 self.logs_request(after.as_deref(), after_id.as_deref())?,
             )

--- a/crates/tidemark-core/src/providers/keyed/codebuff.rs
+++ b/crates/tidemark-core/src/providers/keyed/codebuff.rs
@@ -482,7 +482,9 @@ impl Codebuff {
     /// because the credits already in hand are the point of the poll.
     async fn subscription(&self) -> Option<Subscription> {
         let request = self.subscription_request().ok()?;
-        let body = super::request(&self.client, request).await.ok()?;
+        let body = super::request(PROVIDER_ID, &self.client, request)
+            .await
+            .ok()?;
         parse_subscription(&body).ok()
     }
 
@@ -490,7 +492,8 @@ impl Codebuff {
         if self.credential.is_blank() {
             return Err(ProviderError::Credential { status: 401 });
         }
-        let usage = parse_usage(&super::request(&self.client, self.usage_request()?).await?)?;
+        let usage =
+            parse_usage(&super::request(PROVIDER_ID, &self.client, self.usage_request()?).await?)?;
         let subscription = self.subscription().await;
         Ok(snapshot(&usage, subscription.as_ref(), Timestamp::now()))
     }

--- a/crates/tidemark-core/src/providers/keyed/deepgram.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepgram.rs
@@ -430,7 +430,7 @@ impl Deepgram {
     }
 
     async fn get(&self, url: &str) -> Result<String, ProviderError> {
-        super::request(&self.client, self.request(url)?).await
+        super::request(PROVIDER_ID, &self.client, self.request(url)?).await
     }
 
     async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {

--- a/crates/tidemark-core/src/providers/keyed/deepinfra.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepinfra.rs
@@ -112,8 +112,9 @@ impl DeepInfra {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let checklist_body = super::request(&self.client, self.checklist_request()?).await?;
-        let usage_body = super::request(&self.client, self.usage_request()?).await?;
+        let checklist_body =
+            super::request(PROVIDER_ID, &self.client, self.checklist_request()?).await?;
+        let usage_body = super::request(PROVIDER_ID, &self.client, self.usage_request()?).await?;
         combine(
             &parse_checklist(&checklist_body)?,
             &parse_usage(&usage_body)?,

--- a/crates/tidemark-core/src/providers/keyed/factory.rs
+++ b/crates/tidemark-core/src/providers/keyed/factory.rs
@@ -196,7 +196,7 @@ impl Factory {
     /// The soft second rung: any failure — the request, the status, the body — is no
     /// answer, and the ladder falls through to usage.
     async fn limits(&self) -> Option<BillingReading> {
-        let body = super::request(&self.client, self.limits_request().ok()?)
+        let body = super::request(PROVIDER_ID, &self.client, self.limits_request().ok()?)
             .await
             .ok()?;
         parse_limits(&body)
@@ -207,7 +207,7 @@ impl Factory {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let body = super::request(&self.client, self.auth_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.auth_request()?).await?;
         let auth = parse_auth(&body)?;
         // The source's own precedence: the profile's id, else the JWT inside the key.
         // The sniff is the last thing the key is used for besides the wire.
@@ -218,7 +218,12 @@ impl Factory {
         if let Some(reading) = self.limits().await {
             return Ok(rate_limits_snapshot(&auth, &reading, now));
         }
-        let body = super::request(&self.client, self.usage_request(user_id.as_deref())?).await?;
+        let body = super::request(
+            PROVIDER_ID,
+            &self.client,
+            self.usage_request(user_id.as_deref())?,
+        )
+        .await?;
         let usage = parse_usage(&body)?;
         Ok(classic_snapshot(&auth, &usage, now))
     }

--- a/crates/tidemark-core/src/providers/keyed/fireworks.rs
+++ b/crates/tidemark-core/src/providers/keyed/fireworks.rs
@@ -132,7 +132,7 @@ impl Fireworks {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let body = super::request(&self.client, self.summary_request(now)?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.summary_request(now)?).await?;
         Ok(snapshot(parse_summary(&body)?.as_ref(), now))
     }
 }

--- a/crates/tidemark-core/src/providers/keyed/groq.rs
+++ b/crates/tidemark-core/src/providers/keyed/groq.rs
@@ -138,7 +138,7 @@ impl Groq {
 
     /// Sends one query and reads its scalar answer.
     async fn scalar(&self, query: &str) -> Result<f64, ProviderError> {
-        let body = super::request(&self.client, self.query_request(query)?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.query_request(query)?).await?;
         parse_scalar(&body)
     }
 }

--- a/crates/tidemark-core/src/providers/keyed/ibmbob.rs
+++ b/crates/tidemark-core/src/providers/keyed/ibmbob.rs
@@ -162,7 +162,7 @@ impl IBMBob {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let body = super::request(&self.client, self.profile_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.profile_request()?).await?;
         let profile = parse_profile(&body)?;
         let mut teams = Vec::new();
         for instance in &profile.instances {
@@ -180,7 +180,7 @@ impl IBMBob {
                     continue;
                 }
                 let request = self.team_request(&host, &instance.instance_id, &team.id, user_id)?;
-                let body = super::request(&self.client, request).await?;
+                let body = super::request(PROVIDER_ID, &self.client, request).await?;
                 let budget = parse_team_budget(&body)?;
                 teams.push(TeamUsage::of(instance, team, &budget));
             }

--- a/crates/tidemark-core/src/providers/keyed/kilo.rs
+++ b/crates/tidemark-core/src/providers/keyed/kilo.rs
@@ -1084,7 +1084,9 @@ impl Kilo {
     /// card: the quota is the point of the poll.
     async fn profile(&self) -> Option<Profile> {
         let request = self.profile_request().ok()?;
-        let body = super::request(&self.client, request).await.ok()?;
+        let body = super::request(PROVIDER_ID, &self.client, request)
+            .await
+            .ok()?;
         parse_profile(&body).ok()
     }
 
@@ -1092,7 +1094,8 @@ impl Kilo {
         if self.credential.is_blank() {
             return Err(ProviderError::Credential { status: 401 });
         }
-        let reading = parse_batch(&super::request(&self.client, self.batch_request()?).await?)?;
+        let reading =
+            parse_batch(&super::request(PROVIDER_ID, &self.client, self.batch_request()?).await?)?;
         let profile = self.profile().await;
         Ok(snapshot(
             &reading,

--- a/crates/tidemark-core/src/providers/keyed/litellm.rs
+++ b/crates/tidemark-core/src/providers/keyed/litellm.rs
@@ -163,15 +163,17 @@ impl LiteLLM {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let body = super::request(&self.client, self.key_info_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.key_info_request()?).await?;
         let key = parse_key_info(&body)?;
         let reading = if key.user_id.is_some() {
             let id = key.user_id.as_deref().expect("checked above");
-            let body = super::request(&self.client, self.user_info_request(id)?).await?;
+            let body =
+                super::request(PROVIDER_ID, &self.client, self.user_info_request(id)?).await?;
             parse_user_info(&body, &key)?
         } else if key.team_id.is_some() {
             let id = key.team_id.as_deref().expect("checked above");
-            let body = super::request(&self.client, self.team_info_request(id)?).await?;
+            let body =
+                super::request(PROVIDER_ID, &self.client, self.team_info_request(id)?).await?;
             Reading::Team(parse_team_info(&body, &key)?)
         } else {
             // Unreachable — `parse_key_info` refuses a body naming neither — but the

--- a/crates/tidemark-core/src/providers/keyed/llmproxy.rs
+++ b/crates/tidemark-core/src/providers/keyed/llmproxy.rs
@@ -414,7 +414,7 @@ impl LLMProxy {
         if self.credential.is_blank() {
             return Err(ProviderError::Credential { status: 401 });
         }
-        let body = super::request(&self.client, self.quota_stats_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.quota_stats_request()?).await?;
         parse(&body, Timestamp::now())
     }
 }

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -72,6 +72,7 @@ pub mod zai;
 pub mod zenmux;
 
 use super::{BoxFuture, Credential, Provider, ProviderError, http};
+use crate::debug;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
@@ -269,7 +270,7 @@ impl Keyed {
         if self.credential.is_blank() {
             return Err(ProviderError::Credential { status: 401 });
         }
-        let body = request(&self.client, self.build_request()?).await?;
+        let body = request(self.spec.id, &self.client, self.build_request()?).await?;
         (self.spec.parse)(&body, Timestamp::now())
     }
 }
@@ -281,25 +282,67 @@ impl Keyed {
 /// OpenRouter makes two calls — keeps its own `impl Provider` and sends each of its
 /// requests through here, so the parts that are easy to forget travel with the function
 /// rather than with each provider: `Retry-After` is read before the body consumes the
-/// headers, a non-success status goes through `http::check`, and the query string is
-/// stripped off any `reqwest` error before it can be rendered.
+/// headers, a non-success status goes through `http::check`, the query string is
+/// stripped off any `reqwest` error before it can be rendered, and the exchange reaches
+/// [`crate::debug`] when the user has asked for a raw-response log.
+///
+/// The slug is the provider the request belongs to. It is a parameter rather than
+/// something inferred from the URL because a provider whose fetch is several requests to
+/// several hosts is exactly the one whose log is hard to read without it.
 pub async fn request(
+    provider: &str,
     client: &reqwest::Client,
     request: reqwest::Request,
 ) -> Result<String, ProviderError> {
-    let response = client
-        .execute(request)
-        .await
-        .map_err(|error| ProviderError::Transport(redact_query(error)))?;
+    let sent = debug::Recorded::of(&request);
+    let note = |answer| {
+        if let Some(sent) = &sent {
+            debug::record(debug::Exchange {
+                provider,
+                sent: sent.sent(),
+                answer,
+            });
+        }
+    };
+
+    let response = match client.execute(request).await {
+        Ok(response) => response,
+        Err(error) => {
+            let error = ProviderError::Transport(redact_query(error));
+            note(debug::Answer::Failed {
+                error: &error.to_string(),
+            });
+            return Err(error);
+        }
+    };
 
     let status = response.status();
     let retry_after = http::retry_after_header(&response).map(str::to_owned);
-    http::check(status, retry_after.as_deref())?;
+    if let Err(error) = http::check(status, retry_after.as_deref()) {
+        // Refused on its status: `reqwest` has not read the body and neither have we, so
+        // the line says what came back without pretending to a body it never held.
+        note(debug::Answer::Refused {
+            status: status.as_u16(),
+        });
+        return Err(error);
+    }
 
-    let body = response
-        .text()
-        .await
-        .map_err(|error| ProviderError::Transport(redact_query(error)))?;
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            let error = ProviderError::Transport(redact_query(error));
+            note(debug::Answer::Failed {
+                error: &error.to_string(),
+            });
+            return Err(error);
+        }
+    };
+    // Before the emptiness check, deliberately: "the provider answered nothing" is one of
+    // the things a person reads this log to confirm.
+    note(debug::Answer::Body {
+        status: status.as_u16(),
+        body: &body,
+    });
     if body.trim().is_empty() {
         // An empty body is its own error rather than serde's "EOF while parsing a value":
         // the one says the provider answered nothing, the other says we read it wrong.

--- a/crates/tidemark-core/src/providers/keyed/nanogpt.rs
+++ b/crates/tidemark-core/src/providers/keyed/nanogpt.rs
@@ -101,8 +101,8 @@ impl NanoGpt {
         let subscription_request = self.subscription_request()?;
         let balance_request = self.balance_request()?;
         let (subscription, balance) = tokio::join!(
-            super::request(&self.client, subscription_request),
-            super::request(&self.client, balance_request),
+            super::request(PROVIDER_ID, &self.client, subscription_request),
+            super::request(PROVIDER_ID, &self.client, balance_request),
         );
         parse(&subscription?, &balance?, Timestamp::now())
     }

--- a/crates/tidemark-core/src/providers/keyed/openai-api.rs
+++ b/crates/tidemark-core/src/providers/keyed/openai-api.rs
@@ -236,7 +236,7 @@ impl OpenAiApi {
     /// The legacy balance path, whose failure is a balance error for the precedence
     /// above to weigh — never a silent return to the usage error.
     async fn balance(&self, now: Timestamp) -> Result<Snapshot, ProviderError> {
-        let body = super::request(&self.client, self.credit_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.credit_request()?).await?;
         let grants = parse_credit_grants(&body, now)?;
         Ok(balance_snapshot(&grants, now))
     }
@@ -272,6 +272,7 @@ impl OpenAiApi {
             let mut walk = Walk::default();
             loop {
                 let body = super::request(
+                    PROVIDER_ID,
                     &self.client,
                     self.page_request(url, group_by, *range, walk.cursor())?,
                 )

--- a/crates/tidemark-core/src/providers/keyed/openrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/openrouter.rs
@@ -145,7 +145,9 @@ impl OpenRouter {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let credits = parse_credits(&super::request(&self.client, self.credits_request()?).await?)?;
+        let credits = parse_credits(
+            &super::request(PROVIDER_ID, &self.client, self.credits_request()?).await?,
+        )?;
         let key = self.key_state().await;
         Ok(snapshot(&credits, &key, now))
     }
@@ -158,7 +160,7 @@ impl OpenRouter {
         let Ok(request) = self.key_request() else {
             return KeyState::Degraded("request failed".to_owned());
         };
-        match super::request(&self.client, request).await {
+        match super::request(PROVIDER_ID, &self.client, request).await {
             Ok(body) => match parse_key(&body) {
                 Ok(Some(data)) => KeyState::Data(data),
                 Ok(None) => KeyState::Degraded("no key data in the response".to_owned()),

--- a/crates/tidemark-core/src/providers/keyed/poe.rs
+++ b/crates/tidemark-core/src/providers/keyed/poe.rs
@@ -117,7 +117,7 @@ impl Poe {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let body = super::request(&self.client, self.balance_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.balance_request()?).await?;
         let balance = parse_balance(&body)?;
         let history = self.history(now).await;
         Ok(snapshot(balance, &history, now))
@@ -154,7 +154,7 @@ impl Poe {
         entries: &mut Vec<HistoryEntry>,
     ) -> Result<Option<String>, ()> {
         let request = self.history_request(cursor).map_err(|_| ())?;
-        let body = super::request(&self.client, request)
+        let body = super::request(PROVIDER_ID, &self.client, request)
             .await
             .map_err(|_| ())?;
         let page = parse_history_page(&body).map_err(|_| ())?;

--- a/crates/tidemark-core/src/providers/keyed/sub2api.rs
+++ b/crates/tidemark-core/src/providers/keyed/sub2api.rs
@@ -560,7 +560,7 @@ impl Sub2Api {
         if self.credential.is_blank() {
             return Err(ProviderError::Credential { status: 401 });
         }
-        let body = super::request(&self.client, self.usage_request()?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.usage_request()?).await?;
         parse(&body, Timestamp::now())
     }
 }

--- a/crates/tidemark-core/src/providers/keyed/wayfinder.rs
+++ b/crates/tidemark-core/src/providers/keyed/wayfinder.rs
@@ -145,7 +145,7 @@ impl Wayfinder {
     }
 
     async fn get(&self, url: &str) -> Result<String, ProviderError> {
-        super::request(&self.client, self.request(url)?).await
+        super::request(PROVIDER_ID, &self.client, self.request(url)?).await
     }
 
     async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {

--- a/crates/tidemark-core/src/providers/keyed/xai.rs
+++ b/crates/tidemark-core/src/providers/keyed/xai.rs
@@ -147,7 +147,9 @@ impl Xai {
             return Err(ProviderError::Credential { status: 401 });
         }
         let now = Timestamp::now();
-        let balance = parse_balance(&super::request(&self.client, self.balance_request()?).await?)?;
+        let balance = parse_balance(
+            &super::request(PROVIDER_ID, &self.client, self.balance_request()?).await?,
+        )?;
         // The history is optional, as in the source: every failure but an
         // authentication one is swallowed into the unavailable row. A rejected
         // credential on this request is the same rejection as on the balance, and the
@@ -163,7 +165,7 @@ impl Xai {
     }
 
     async fn history(&self, now: Timestamp) -> Result<History, ProviderError> {
-        let body = super::request(&self.client, self.usage_request(now)?).await?;
+        let body = super::request(PROVIDER_ID, &self.client, self.usage_request(now)?).await?;
         parse_usage(&body).map(History::Present)
     }
 }

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -111,6 +111,55 @@ pub const OAUTH_SOURCE: &str = "oauth";
 /// The stored spelling of [`Source::Cli`].
 pub const CLI_SOURCE: &str = "cli";
 
+/// Checks a response's status and reads its body, writing the whole exchange to the
+/// raw-response log on the way through.
+///
+/// The providers that keep their own client — Claude, Codex, Antigravity — do these three
+/// steps identically, and each of them is a place the debug log would otherwise be
+/// forgotten. `keyed::request` is deliberately not this function: it redacts a query
+/// string out of its own errors, which these four have none of.
+pub(crate) async fn read_body(
+    provider: &str,
+    sent: crate::debug::Sent<'_>,
+    response: reqwest::Response,
+) -> Result<String, ProviderError> {
+    use crate::debug::{Answer, Exchange, record};
+
+    let status = response.status();
+    let retry_after = http::retry_after_header(&response).map(str::to_owned);
+    let note = |answer| {
+        record(Exchange {
+            provider,
+            sent,
+            answer,
+        });
+    };
+
+    if let Err(error) = http::check(status, retry_after.as_deref()) {
+        // Refused on its status: nothing has read the body, so the line says what came
+        // back rather than pretending to a body it never held.
+        note(Answer::Refused {
+            status: status.as_u16(),
+        });
+        return Err(error);
+    }
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            let error = ProviderError::Transport(error);
+            note(Answer::Failed {
+                error: &error.to_string(),
+            });
+            return Err(error);
+        }
+    };
+    note(Answer::Body {
+        status: status.as_u16(),
+        body: &body,
+    });
+    Ok(body)
+}
+
 /// What to call a window of this length, in the plainest terms that divide evenly.
 ///
 /// Shared because a window's span is the provider-neutral half of its title: every

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -24,6 +24,7 @@ use std::error::Error;
 use std::sync::Arc;
 
 use tidemark_core::config::Config;
+use tidemark_core::debug;
 use tidemark_core::paths;
 use tidemark_core::providers::http::{self, Proxy};
 use tidemark_core::secrets::Secrets;
@@ -129,6 +130,16 @@ async fn run() -> Result<(), Box<dyn Error>> {
     // key. Once running, a later bad edit is reported and the previous settings stand.
     let config = Config::at(config_path.clone())?;
     let preferences = config.preferences()?;
+    // Read here and only here: a switch that took effect mid-poll would leave a log whose
+    // gaps mean nothing, so turning it on is a restart. Before the first client is built,
+    // for the same reason the proxy is — the very first poll is often the interesting one.
+    if config.debug_raw_responses()? {
+        let log = debug::enable(&paths::data_dir()?)?;
+        tracing::warn!(
+            log = %log.display(),
+            "[debug] raw_responses is on: every provider response is being written to disk verbatim"
+        );
+    }
     // Before the first client is built, because `registry::accounts` builds several of
     // them: a `reqwest::Client` holds its proxy for life, and one built a line too early
     // would keep talking around the proxy until the daemon was restarted.


### PR DESCRIPTION
## Why

Some cards occasionally read wrong — OpenCode Go showing 100% used when it is not. The evidence needed to tell a bad parse from a bad response is the response itself, and nothing in the daemon keeps it.

## What

A config-only switch. In `~/.config/tidemark/config.toml`:

```toml
[debug]
raw_responses = true
```

then `systemctl --user restart tidemarkd`. Every provider exchange is appended to `~/.local/share/tidemark/debug/responses.ndjson`, one JSON object per line:

```json
{"at":"2026-08-25T12:00:00Z","provider":"opencodego","method":"GET",
 "url":"https://opencode.ai/api/usage","request_body":null,
 "status":200,"body":"{\"limits\":[…]}"}
```

The body is stored as a **string**, never re-parsed and re-encoded — a malformed response has to survive as the malformed thing it was, since that is the case worth catching. Refusals (`status`, no body) and transport failures (`error`) are distinguishable from answers.

## Design notes

- **Not in `Preferences`.** That is the D-Bus wire shape the UI and every other client read; this is not a setting anyone should find in a dialog. `Config::debug_raw_responses()` is its own reader.
- **Read once, at startup**, next to `http::set_proxy`. A switch that took effect mid-poll would leave a file whose gaps mean nothing.
- **The sink is process-wide**, mirroring the existing `http::ACTIVE` proxy pattern for the same reason: it is a property of the process, written once, read from forty-odd clients.
- **Nothing credential-bearing is written.** Request headers are omitted entirely; URL query strings are redacted (a few providers carry the key there); the four OAuth token endpoints are not routed through the logging path at all, because their response body *is* the credential.
- **Rolls over at 16 MB**, one previous file kept, so the ceiling on disk is 32 MB.

## Cost

`keyed::request` gained the provider slug as its first parameter — 31 mechanical, compiler-checked call sites. Without it a line is identifiable only by URL, which is worst exactly for the multi-request providers. The three providers that keep their own client (Claude, Codex, Antigravity) now share one `providers::read_body` helper for status-check → body-read → record.

## Verification

```
cargo fmt --all --check                                  ok
cargo clippy --workspace --all-targets -- -D warnings     ok
dbus-run-session -- cargo test --workspace                ok (all suites, 0 failed)
scripts/check-layering.sh                                 layering ok
```

New tests: config default and non-boolean refusal; three pure line-shape tests (verbatim body, query redaction, refusal vs failure); rollover and append-on-reopen against `Sink` directly; one end-to-end through `keyed::request` against a loopback server asserting the line lands and the key does not.

That end-to-end asserts only on its own line rather than on line counts — the sink is process-wide, so while it is on the rest of the test binary writes to it too. The first version of the test counted lines and failed against a concurrent `antigravity` write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)