### PR TITLE
Track Cursor through browser sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 .claude
 .codex
 .opencode
+.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ CI (`ubuntu-26.04`, `.github/workflows/ci.yml`) runs exactly:
 ```bash
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
-dbus-run-session -- cargo test --workspace
+cargo test --workspace
 scripts/check-layering.sh
 scripts/check-desktop-integration.sh
 scripts/test-restart-user-daemon.sh
@@ -198,7 +198,7 @@ human work. Tag push starts the release workflow, so the script runs no tests.
   them for process-global behaviour (proxy selection) and cross-seam flows.
 
 ```bash
-dbus-run-session -- cargo test --workspace          # exactly as CI runs it
+cargo test --workspace          # exactly as CI runs it
 cargo test -p tidemark-core
 cargo test -p tidemark-core providers::antigravity::direct::tests -- --nocapture
 cargo test -p tidemark chart::tests -- --nocapture  # passes without a display server
@@ -221,6 +221,3 @@ cargo test -p tidemark chart::tests -- --nocapture  # passes without a display s
   `matches!(..., Err(ProviderError::Malformed { .. }))` for malformed-provider contracts.
 - No coverage tooling or threshold is configured; "coverage" in the design docs means scenario
   coverage.
-- Gotchas: without a session bus the Secret Service tests silently skip, so prefer the
-  `dbus-run-session` form. `corpus_replay.rs` skips unless `TIDEMARK_CORPUS_DIR` or
-  `~/.config/codexbar/history` exists — never commit corpus data.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,6 +197,31 @@ entry of a kind we recognize but cannot parse fails the whole fetch. Only an ent
 *unrecognized* kind is skipped, because that is a quota type that did not exist when the
 parser was written rather than a failure to understand one that did.
 
+### Local authentication sources
+
+Some providers hold no key at all — their credential is a session this machine
+already has. Cursor is the first: it reads cursor.com through either the Cursor
+App's local state or one browser's cookie store. Which of them answers is a
+recorded choice, not a scan: the daemon discovers every candidate, proves each
+with a real request, and records the pick (`auth-source`, plus `auth-browser`
+and `auth-profile` where they apply) beside the account's other options — the
+same way an OAuth-or-CLI choice is stored. The window sees titles and readiness
+states over D-Bus, never cookie values, tokens, or database paths.
+
+Three boundaries make this acceptable where blanket cookie-scraping would not be:
+
+- **The daemon owns all of it.** Browser storage is touched by tidemarkd alone;
+  the GTK process renders published states and never learns how a credential is
+  stored.
+- **Snapshot reads.** A browser's cookie database is read through an owner-only
+  temporary copy; no browser directory is opened in place or written to.
+- **One recorded source, used exclusively.** A failing source fails the account,
+  and Tidemark reports the gap rather than quietly switching to another browser
+  or the App — quota on screen must belong to the account the user chose.
+
+Browser slugs and profile identifiers are stable config keys for the same reason
+provider slugs are — not renamable once shipped.
+
 ### API floor
 
 GTK **4.22** and libadwaita **1.9**, set as the `v4_22` and `v1_9` binding features.
@@ -599,7 +624,9 @@ transactions; it is run by hand rather than in CI.
 ## Non-goals
 
 - No web UI, no Electron, no embedded browser engine. See ADR 0002 and ADR 0003.
-- No browser-cookie scraping, and therefore no providers that require it.
+- No silent source selection. A local browser or app session is read only from
+  the source the user picked and the daemon validated; nothing scans or falls
+  back on its own.
 - No API Platform spend dashboards. Different metric, different product.
 - No forecast-driven notifications until there is history to calibrate them on.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,15 +2666,20 @@ dependencies = [
 name = "tidemark-core"
 version = "0.1.3"
 dependencies = [
+ "aes",
  "base64",
+ "cbc",
  "fs4",
+ "hmac",
  "libc",
  "oo7",
+ "pbkdf2",
  "reqwest",
  "rusqlite",
  "rustix",
  "serde",
  "serde_json",
+ "sha1",
  "sha2 0.11.0",
  "thiserror",
  "tidemark-types",

--- a/README.md
+++ b/README.md
@@ -98,15 +98,19 @@ DeepSeek · ElevenLabs · Factory · Fireworks · Groq · IBM Bob · Kilo · Kim
 LLM Proxy · MiniMax · Moonshot · NanoGPT · Neuralwatt · OpenAI · OpenCode Go · OpenRouter ·
 Poe · sub2api · Synthetic · Venice · Warp · xAI · Z.ai · ZenMux
 
-**No credential needed**
+**Local session**
 
-Cursor · Wayfinder
+Cursor
 
-Cursor uses the cursor.com session already signed in on this machine — it has no API key
-to paste. Its settings page asks you to choose one local source: the Cursor App, or one of
+Cursor uses a cursor.com session already signed in on this machine — Tidemark does not store
+an API key or session token. Its settings page asks you to choose one local source: the Cursor App, or one of
 your browsers (and one of its profiles, if it keeps more than one). That choice is kept and
 used alone; if the chosen source later signs out, Tidemark tells you instead of silently
 switching to another browser or the App.
+
+**No credential needed**
+
+Wayfinder
 
 Some providers need one extra setting alongside the key — a region, an account id, or the
 base URL of your own deployment. The provider's page asks for it.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,11 @@ Poe · sub2api · Synthetic · Venice · Warp · xAI · Z.ai · ZenMux
 
 Cursor · Wayfinder
 
-Cursor reads the session a browser on this machine already has on cursor.com — it has no
-API key to paste.
+Cursor uses the cursor.com session already signed in on this machine — it has no API key
+to paste. Its settings page asks you to choose one local source: the Cursor App, or one of
+your browsers (and one of its profiles, if it keeps more than one). That choice is kept and
+used alone; if the chosen source later signs out, Tidemark tells you instead of silently
+switching to another browser or the App.
 
 Some providers need one extra setting alongside the key — a region, an account id, or the
 base URL of your own deployment. The provider's page asks for it.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Poe · sub2api · Synthetic · Venice · Warp · xAI · Z.ai · ZenMux
 
 **No credential needed**
 
-Wayfinder
+Cursor · Wayfinder
+
+Cursor reads the session a browser on this machine already has on cursor.com — it has no
+API key to paste.
 
 Some providers need one extra setting alongside the key — a region, an account id, or the
 base URL of your own deployment. The provider's page asks for it.

--- a/crates/tidemark-core/Cargo.toml
+++ b/crates/tidemark-core/Cargo.toml
@@ -12,9 +12,16 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+# aes + cbc + pbkdf2 + hmac + sha1: decrypting Chromium's os_crypt cookie values (RustCrypto,
+# pure Rust — the workspace's no-OpenSSL rule holds).
+aes = "0.8.4"
 base64 = "0.22.1"
+cbc = { version = "0.1.2", features = ["block-padding"] }
 fs4 = "0.13.1"
+hmac = "0.12.1"
 libc = "0.2.180"
+pbkdf2 = { version = "0.12.2", default-features = false, features = ["hmac"] }
+sha1 = { version = "0.10.7", default-features = false }
 oo7 = { version = "0.6.0", default-features = false, features = ["native_crypto", "tokio"] }
 # `socks`: without it a `socks5://` proxy URL parses and then refuses every connection
 # made through it. `system-proxy`: what "no proxy configured here" falls back to.

--- a/crates/tidemark-core/src/browser/auth.rs
+++ b/crates/tidemark-core/src/browser/auth.rs
@@ -1,6 +1,6 @@
 //! Generic inspection of browser-cookie authentication sources.
 
-use super::{CookieError, Query, SafeStorage, Store, header};
+use super::{CookieError, Query, SafeStorage, Store, header_for};
 use std::future::Future;
 use tidemark_types::{AuthCandidate, AuthCandidateState};
 
@@ -73,6 +73,7 @@ impl CandidateCredential {
 pub async fn inspect<F, Fut>(
     stores: Vec<Store>,
     query: &Query,
+    request_url: &str,
     storage: &dyn SafeStorage,
     validate: F,
 ) -> Vec<AuthCandidate>
@@ -90,7 +91,8 @@ where
                     .into_iter()
                     .filter(|cookie| cookie.is_live(now))
                     .collect();
-                if live.is_empty() {
+                let header = header_for(&live, request_url);
+                if header.is_empty() {
                     AuthCandidateState::Missing
                 } else {
                     match validate(CandidateCredential {
@@ -98,7 +100,7 @@ where
                             browser: store.browser.slug.to_owned(),
                             profile: Some(store.profile.clone()),
                         },
-                        header: header(&live),
+                        header,
                     })
                     .await
                     {
@@ -241,6 +243,7 @@ mod tests {
         let report = runtime.block_on(inspect(
             stores_in(home.path()),
             &query,
+            "https://cursor.com/api/usage-summary",
             &NoKeyring,
             |credential| async move {
                 if credential.header().contains("rejected") {

--- a/crates/tidemark-core/src/browser/auth.rs
+++ b/crates/tidemark-core/src/browser/auth.rs
@@ -13,6 +13,16 @@ pub struct Selection {
     pub profile: Option<String>,
 }
 
+impl Selection {
+    /// The opaque stable path a client sends back to select this browser or profile.
+    pub fn candidate_id(&self) -> String {
+        match &self.profile {
+            Some(profile) => format!("{}/{}", self.browser, profile),
+            None => self.browser.clone(),
+        }
+    }
+}
+
 /// The outcome of a provider's proof request for a candidate cookie header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Validation {
@@ -102,7 +112,11 @@ where
             Err(_) => AuthCandidateState::Unreachable,
         };
         let child = AuthCandidate {
-            id: store.profile.clone(),
+            id: Selection {
+                browser: store.browser.slug.to_owned(),
+                profile: Some(store.profile.clone()),
+            }
+            .candidate_id(),
             title: store.profile,
             subtitle: None,
             state: state.as_wire().to_owned(),
@@ -249,8 +263,11 @@ mod tests {
                 .map(|candidate| (candidate.id.as_str(), candidate.state.as_str()))
                 .collect::<Vec<_>>(),
             [
-                ("aa.Working", AuthCandidateState::Ready.as_wire()),
-                ("zz.Rejected", AuthCandidateState::Rejected.as_wire()),
+                ("firefox/aa.Working", AuthCandidateState::Ready.as_wire()),
+                (
+                    "firefox/zz.Rejected",
+                    AuthCandidateState::Rejected.as_wire()
+                ),
             ]
         );
         assert_eq!(
@@ -264,8 +281,8 @@ mod tests {
                 .map(|candidate| (candidate.id.as_str(), candidate.state.as_str()))
                 .collect::<Vec<_>>(),
             [
-                ("aa.Expired", AuthCandidateState::Missing.as_wire()),
-                ("zz.AlsoWorking", AuthCandidateState::Ready.as_wire()),
+                ("zen/aa.Expired", AuthCandidateState::Missing.as_wire()),
+                ("zen/zz.AlsoWorking", AuthCandidateState::Ready.as_wire()),
             ]
         );
     }

--- a/crates/tidemark-core/src/browser/auth.rs
+++ b/crates/tidemark-core/src/browser/auth.rs
@@ -1,0 +1,290 @@
+//! Generic inspection of browser-cookie authentication sources.
+
+use super::{CookieError, Query, SafeStorage, Store, header};
+use std::future::Future;
+use tidemark_types::{AuthCandidate, AuthCandidateState};
+
+/// A browser source selected by its durable browser and optional profile identifiers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Selection {
+    /// Stable browser slug from [`super::Browser::slug`].
+    pub browser: String,
+    /// A profile directory name when the person chose one explicitly.
+    pub profile: Option<String>,
+}
+
+/// The outcome of a provider's proof request for a candidate cookie header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Validation {
+    /// The provider accepted the source.
+    Ready,
+    /// The provider rejected the source's credential.
+    Rejected,
+    /// The proof request could not say whether the source works.
+    Unreachable,
+}
+
+/// A selected store's cookie header, kept entirely inside core.
+///
+/// This deliberately has no derived `Debug`: an inspected header can carry a live session
+/// and must never reach a log while the provider validates it.
+pub struct CandidateCredential {
+    selection: Selection,
+    header: String,
+}
+
+impl std::fmt::Debug for CandidateCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CandidateCredential")
+            .field("selection", &self.selection)
+            .field("header", &"<redacted>")
+            .finish()
+    }
+}
+
+impl CandidateCredential {
+    /// The selected source this header was read from.
+    pub fn selection(&self) -> &Selection {
+        &self.selection
+    }
+
+    /// The header only a provider's in-core validator may send.
+    pub fn header(&self) -> &str {
+        &self.header
+    }
+}
+
+/// Inspects browser profiles in caller-provided scan order without exposing cookies.
+///
+/// A profile with no live matching cookie is missing. A locked Safe Storage keyring is
+/// deliberately distinct from a missing source. Every other local read error and an
+/// inconclusive proof request is temporarily unreachable, so the UI never paints a source
+/// invalid without Cursor (or a future provider) having actually rejected it.
+pub async fn inspect<F, Fut>(
+    stores: Vec<Store>,
+    query: &Query,
+    storage: &dyn SafeStorage,
+    validate: F,
+) -> Vec<AuthCandidate>
+where
+    F: Fn(CandidateCredential) -> Fut,
+    Fut: Future<Output = Validation>,
+{
+    let now = tidemark_types::Timestamp::now();
+    let mut browsers: Vec<(super::Browser, Vec<AuthCandidate>)> = Vec::new();
+
+    for store in stores {
+        let state = match store.cookies(query, storage).await {
+            Ok(cookies) => {
+                let live: Vec<_> = cookies
+                    .into_iter()
+                    .filter(|cookie| cookie.is_live(now))
+                    .collect();
+                if live.is_empty() {
+                    AuthCandidateState::Missing
+                } else {
+                    match validate(CandidateCredential {
+                        selection: Selection {
+                            browser: store.browser.slug.to_owned(),
+                            profile: Some(store.profile.clone()),
+                        },
+                        header: header(&live),
+                    })
+                    .await
+                    {
+                        Validation::Ready => AuthCandidateState::Ready,
+                        Validation::Rejected => AuthCandidateState::Rejected,
+                        Validation::Unreachable => AuthCandidateState::Unreachable,
+                    }
+                }
+            }
+            Err(CookieError::KeyringLocked) => AuthCandidateState::WaitingForKeyring,
+            Err(_) => AuthCandidateState::Unreachable,
+        };
+        let child = AuthCandidate {
+            id: store.profile.clone(),
+            title: store.profile,
+            subtitle: None,
+            state: state.as_wire().to_owned(),
+            children: Vec::new(),
+        };
+
+        match browsers.last_mut() {
+            Some((browser, children)) if browser.slug == store.browser.slug => {
+                children.push(child);
+            }
+            _ => browsers.push((store.browser, vec![child])),
+        }
+    }
+
+    browsers
+        .into_iter()
+        .map(|(browser, children)| AuthCandidate {
+            id: browser.slug.to_owned(),
+            title: browser.title.to_owned(),
+            subtitle: None,
+            state: aggregate_state(&children).as_wire().to_owned(),
+            children,
+        })
+        .collect()
+}
+
+fn aggregate_state(children: &[AuthCandidate]) -> AuthCandidateState {
+    let states = children.iter().filter_map(AuthCandidate::state);
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Ready)
+    {
+        return AuthCandidateState::Ready;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::WaitingForKeyring)
+    {
+        return AuthCandidateState::WaitingForKeyring;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Unreachable)
+    {
+        return AuthCandidateState::Unreachable;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Rejected)
+    {
+        return AuthCandidateState::Rejected;
+    }
+    AuthCandidateState::Missing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::{Query, SafeStorage, stores_in};
+    use crate::secrets::SecretError;
+    use rusqlite::Connection;
+    use tidemark_types::AuthCandidateState;
+
+    #[derive(Debug)]
+    struct NoKeyring;
+
+    impl SafeStorage for NoKeyring {
+        fn password(
+            &self,
+            _application: &str,
+        ) -> crate::providers::BoxFuture<'_, Result<Option<String>, SecretError>> {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    fn gecko_profile(
+        home: &crate::browser::tests::TestHome,
+        profile: &str,
+        value: &str,
+        expiry: i64,
+    ) {
+        let path = home.gecko(profile);
+        let connection = Connection::open(path).expect("opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE moz_cookies (
+                    id INTEGER PRIMARY KEY,
+                    baseDomain TEXT,
+                    originAttributes TEXT NOT NULL DEFAULT '',
+                    name TEXT, value TEXT, host TEXT, path TEXT,
+                    expiry INTEGER, lastAccessed INTEGER, creationTime INTEGER,
+                    isSecure INTEGER, isHttpOnly INTEGER
+                );",
+            )
+            .expect("creates the table");
+        connection
+            .execute(
+                "INSERT INTO moz_cookies (
+                    host, name, value, path, expiry, isSecure, lastAccessed,
+                    creationTime, isHttpOnly
+                ) VALUES ('.cursor.com', 'session', ?1, '/', ?2, 1, 0, 0, 0)",
+                (value, expiry),
+            )
+            .expect("inserts the session");
+    }
+
+    #[test]
+    fn the_browser_profiles_are_nested_in_scan_order_with_their_validation_states() {
+        // Replacing inspection with a first-match scan would lose the rejected and expired
+        // accounts the person must distinguish before selecting their exact browser source.
+        let home = crate::browser::tests::TestHome::new();
+        gecko_profile(&home, ".mozilla/firefox/aa.Working", "works", 0);
+        gecko_profile(&home, ".mozilla/firefox/zz.Rejected", "rejected", 0);
+        gecko_profile(&home, ".zen/aa.Expired", "expired", 1_785_000_000);
+        gecko_profile(&home, ".zen/zz.AlsoWorking", "also-works", 0);
+        let query = Query::new(["cursor.com"], ["session"]);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        let report = runtime.block_on(inspect(
+            stores_in(home.path()),
+            &query,
+            &NoKeyring,
+            |credential| async move {
+                if credential.header().contains("rejected") {
+                    Validation::Rejected
+                } else {
+                    Validation::Ready
+                }
+            },
+        ));
+
+        assert_eq!(report.len(), 2);
+        assert_eq!(
+            (report[0].id.as_str(), report[0].title.as_str()),
+            ("firefox", "Firefox")
+        );
+        assert_eq!(
+            report[0]
+                .children
+                .iter()
+                .map(|candidate| (candidate.id.as_str(), candidate.state.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                ("aa.Working", AuthCandidateState::Ready.as_wire()),
+                ("zz.Rejected", AuthCandidateState::Rejected.as_wire()),
+            ]
+        );
+        assert_eq!(
+            (report[1].id.as_str(), report[1].title.as_str()),
+            ("zen", "Zen")
+        );
+        assert_eq!(
+            report[1]
+                .children
+                .iter()
+                .map(|candidate| (candidate.id.as_str(), candidate.state.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                ("aa.Expired", AuthCandidateState::Missing.as_wire()),
+                ("zz.AlsoWorking", AuthCandidateState::Ready.as_wire()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_candidate_credential_never_prints_its_cookie_header() {
+        // A derived Debug would leak the live session while an adapter is being inspected.
+        let credential = CandidateCredential {
+            selection: Selection {
+                browser: "firefox".into(),
+                profile: Some("default-release".into()),
+            },
+            header: "session=do-not-print-this".into(),
+        };
+
+        let rendered = format!("{credential:?}");
+
+        assert!(rendered.contains("firefox"));
+        assert!(!rendered.contains("do-not-print-this"));
+        assert!(rendered.contains("redacted"));
+    }
+}

--- a/crates/tidemark-core/src/browser/chromium.rs
+++ b/crates/tidemark-core/src/browser/chromium.rs
@@ -1,0 +1,413 @@
+//! Reading cookies out of a Chromium-family `Cookies` database.
+//!
+//! # `os_crypt`, in the order Chromium built it
+//!
+//! Every cookie value in `cookies.encrypted_value` is sealed with AES-128-CBC and the IV
+//! is sixteen spaces. What changed over Chromium's life is where the key comes from, and
+//! the first three bytes of the blob say which:
+//!
+//! - `v10` — the key is derived from the fixed, well-known password `peanuts`, the
+//!   fallback Chromium itself uses when no keyring answers.
+//! - `v11` — the key is derived from the browser's "Safe Storage" password, a random
+//!   value Chromium stores in the Secret Service under its `application` attribute.
+//!
+//! Either way the derivation is PBKDF2-HMAC-SHA1, salt `saltysalt`, one iteration, sixteen
+//! bytes out.
+//!
+//! # Domain binding
+//!
+//! Since M130 Chromium prepends `SHA-256(host_key)` to the plaintext before sealing, so a
+//! cookie can only be read where it was set. We strip that prefix back off — and a
+//! decryptable cookie whose value is not text is treated as unreadable rather than as a
+//! value, because UTF-8 is how we tell a right key from a wrong one: a wrong key decrypts
+//! to noise, not to an error.
+
+use aes::Aes128;
+use cbc::Decryptor;
+use cbc::cipher::{BlockDecryptMut, KeyIvInit};
+use rusqlite::Connection;
+use std::path::Path;
+
+use super::{Cookie, CookieError, Query};
+
+/// The password `v10` values are sealed with, when no keyring exists.
+const BASIC_PASSWORD: &[u8] = b"peanuts";
+
+/// The salt and iteration count Chromium derives both key variants with.
+const SALT: &[u8] = b"saltysalt";
+const ITERATIONS: u32 = 1;
+
+/// The sixteen-space IV every os_crypt value is sealed with.
+const IV: [u8; 16] = [b' '; 16];
+
+/// The microseconds between Chromium's epoch (1601-01-01) and the Unix epoch.
+const WEBKIT_EPOCH_OFFSET_MICROS: i64 = 11_644_473_600_000_000;
+
+/// Reads every cookie the query asks for. `password` is the Safe Storage password from the
+/// Secret Service, or `None` when the browser never stored one — which is the world `v10`
+/// exists for, and also the shape of a machine that was never signed in anywhere.
+pub fn read(
+    database: &Path,
+    query: &Query,
+    password: Option<&str>,
+) -> Result<Vec<Cookie>, CookieError> {
+    let connection =
+        Connection::open_with_flags(database, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(
+            |source| CookieError::Database {
+                path: database.to_path_buf(),
+                source,
+            },
+        )?;
+    let mut statement = connection
+        .prepare(
+            "SELECT host_key, name, encrypted_value, value, path, is_secure, expires_utc \
+             FROM cookies",
+        )
+        .map_err(|source| CookieError::Database {
+            path: database.to_path_buf(),
+            source,
+        })?;
+
+    let key = password.map(|password| derive_key(password.as_bytes()));
+    let basic_key = derive_key(BASIC_PASSWORD);
+
+    let mut cookies = Vec::new();
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+            ))
+        })
+        .map_err(|source| CookieError::Database {
+            path: database.to_path_buf(),
+            source,
+        })?;
+    for row in rows {
+        let (host, name, encrypted, plain, path, secure, expires_utc) =
+            row.map_err(|source| CookieError::Database {
+                path: database.to_path_buf(),
+                source,
+            })?;
+        if !query.matches(&host, &name) {
+            continue;
+        }
+        let Some(value) = value(&encrypted, &plain, &host, key.as_ref(), &basic_key) else {
+            continue;
+        };
+        cookies.push(Cookie {
+            host,
+            name,
+            value,
+            path,
+            secure: secure != 0,
+            expires_at: expires(expires_utc),
+        });
+    }
+    Ok(cookies)
+}
+
+/// The cookie's value: the plain-text column when Chromium stored it there, otherwise the
+/// decryption of the sealed one. `None` for a value this build cannot read — the wrong
+/// keyring password, a sealing version Chromium invents next — rather than garbage on the
+/// wire.
+fn value(
+    encrypted: &[u8],
+    plain: &str,
+    host: &str,
+    key: Option<&[u8; 16]>,
+    basic_key: &[u8; 16],
+) -> Option<String> {
+    if encrypted.is_empty() {
+        return Some(plain.to_owned());
+    }
+    let key = match encrypted {
+        [b'v', b'1', b'0', ..] => Some(basic_key),
+        [b'v', b'1', b'1', ..] => key,
+        _ => None,
+    }?;
+    let mut body = encrypted[3..].to_vec();
+    let padded = Decryptor::<Aes128>::new(key.into(), &IV.into())
+        .decrypt_padded_mut::<cbc::cipher::block_padding::Pkcs7>(&mut body)
+        .ok()?;
+    // M130 and newer seal `SHA-256(host) || value`; the prefix is part of the plaintext,
+    // not of the value.
+    let digest = {
+        use sha2::Digest;
+        sha2::Sha256::digest(host.as_bytes())
+    };
+    let bytes = match padded.strip_prefix(digest.as_slice()) {
+        Some(value) => value,
+        None => padded,
+    };
+    String::from_utf8(bytes.to_vec()).ok()
+}
+
+/// Chromium's `expires_utc` is microseconds since 1601; zero means a session cookie.
+fn expires(webkit_micros: i64) -> Option<tidemark_types::Timestamp> {
+    if webkit_micros <= 0 {
+        return None;
+    }
+    let unix = (webkit_micros - WEBKIT_EPOCH_OFFSET_MICROS) / 1_000_000;
+    tidemark_types::Timestamp::from_unix(unix).ok()
+}
+
+/// The AES key for an os_crypt password.
+fn derive_key(password: &[u8]) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    pbkdf2::pbkdf2_hmac::<sha1::Sha1>(password, SALT, ITERATIONS, &mut key);
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::tests::TestHome;
+    use cbc::cipher::BlockEncryptMut;
+    use std::path::PathBuf;
+
+    /// The sealed form of a value, as Chromium would write it.
+    fn seal(password: &[u8], version: &[u8; 3], plaintext: &[u8]) -> Vec<u8> {
+        let key = derive_key(password);
+        let mut body = Vec::new();
+        body.extend_from_slice(version);
+        let length = plaintext.len() + (16 - plaintext.len() % 16);
+        let mut buffer = vec![0u8; length];
+        buffer[..plaintext.len()].copy_from_slice(plaintext);
+        let sealed = cbc::Encryptor::<Aes128>::new((&key).into(), &IV.into())
+            .encrypt_padded_mut::<cbc::cipher::block_padding::Pkcs7>(&mut buffer, plaintext.len())
+            .expect("seals")
+            .to_vec();
+        body.extend_from_slice(&sealed);
+        body
+    }
+
+    /// A Chromium cookie database holding exactly the cookies given.
+    fn database(home: &TestHome, cookies: &[(&str, &str, Vec<u8>, &str, i64)]) -> PathBuf {
+        let path = home.path().join("Cookies");
+        let connection = Connection::open(&path).expect("opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE cookies (
+                    creation_utc INTEGER NOT NULL,
+                    host_key TEXT NOT NULL,
+                    top_frame_site_key TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    value TEXT NOT NULL,
+                    encrypted_value BLOB NOT NULL,
+                    path TEXT NOT NULL,
+                    expires_utc INTEGER NOT NULL,
+                    is_secure INTEGER NOT NULL,
+                    is_httponly INTEGER NOT NULL,
+                    last_access_utc INTEGER NOT NULL,
+                    has_expires INTEGER NOT NULL,
+                    is_persistent INTEGER NOT NULL,
+                    priority INTEGER NOT NULL,
+                    samesite INTEGER NOT NULL,
+                    source_scheme INTEGER NOT NULL,
+                    source_port INTEGER NOT NULL,
+                    is_same_party INTEGER NOT NULL
+                );",
+            )
+            .expect("creates the table");
+        for (host, name, value, plain, expires_utc) in cookies {
+            connection
+                .execute(
+                    "INSERT INTO cookies (
+                        creation_utc, host_key, top_frame_site_key, name, value,
+                        encrypted_value, path, expires_utc, is_secure, is_httponly,
+                        last_access_utc, has_expires, is_persistent, priority, samesite,
+                        source_scheme, source_port, is_same_party
+                    ) VALUES (0, ?1, '', ?2, ?4, ?3, '/', ?5, 1, 0, 0, 1, 1, 1, 0, 1, 443, 0)",
+                    (host, name, value, plain, expires_utc),
+                )
+                .expect("inserts");
+        }
+        path
+    }
+
+    #[test]
+    fn a_v11_cookie_is_read_with_the_keyring_password() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[(
+                ".cursor.com",
+                "WorkosCursorSessionToken",
+                seal(b"a-real-password", b"v11", b"the-session"),
+                "",
+                0,
+            )],
+        );
+
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+        let cookies = read(&path, &query, Some("a-real-password")).expect("reads");
+
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].value, "the-session");
+        assert!(cookies[0].secure);
+        assert_eq!(cookies[0].expires_at, None);
+    }
+
+    #[test]
+    fn a_domain_bound_v11_cookie_is_unwrapped_back_to_its_value() {
+        use sha2::Digest;
+        let home = TestHome::new();
+        // What M130+ writes: the hash of the host before the value, inside the seal.
+        let mut plaintext = sha2::Sha256::digest(b".cursor.com").to_vec();
+        plaintext.extend_from_slice(b"the-session");
+        let path = database(
+            &home,
+            &[(
+                ".cursor.com",
+                "WorkosCursorSessionToken",
+                seal(b"a-real-password", b"v11", &plaintext),
+                "",
+                0,
+            )],
+        );
+
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+        let cookies = read(&path, &query, Some("a-real-password")).expect("reads");
+
+        assert_eq!(cookies[0].value, "the-session");
+    }
+
+    #[test]
+    fn a_v10_cookie_is_read_without_any_password() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[(
+                ".example.com",
+                "session",
+                seal(BASIC_PASSWORD, b"v10", b"legacy"),
+                "",
+                0,
+            )],
+        );
+
+        let query = Query::new(["example.com"], ["session"]);
+        let cookies = read(&path, &query, None).expect("reads");
+
+        assert_eq!(cookies[0].value, "legacy");
+    }
+
+    #[test]
+    fn a_plain_column_value_is_read_without_touching_the_sealed_one() {
+        let home = TestHome::new();
+        let path = database(&home, &[(".example.com", "consent", Vec::new(), "yes", 0)]);
+
+        let query = Query::new(["example.com"], ["consent"]);
+        let cookies = read(&path, &query, None).expect("reads");
+
+        assert_eq!(cookies[0].value, "yes");
+    }
+
+    #[test]
+    fn a_value_sealed_with_a_password_we_do_not_have_is_skipped_rather_than_faked() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[(
+                ".example.com",
+                "session",
+                seal(b"someone-elses-password", b"v11", b"not-for-us"),
+                "",
+                0,
+            )],
+        );
+
+        let query = Query::new(["example.com"], ["session"]);
+        // No password at all, and then the wrong password: both must answer nothing,
+        // never garbage.
+        assert!(read(&path, &query, None).expect("reads").is_empty());
+        assert!(
+            read(&path, &query, Some("wrong"))
+                .expect("reads")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_version_chromium_has_not_invented_yet_is_skipped() {
+        let home = TestHome::new();
+        let mut unknown = b"v99".to_vec();
+        unknown.extend_from_slice(&[0u8; 16]);
+        let path = database(&home, &[(".example.com", "session", unknown, "", 0)]);
+
+        let query = Query::new(["example.com"], ["session"]);
+        assert!(
+            read(&path, &query, Some("anything"))
+                .expect("reads")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn cookies_the_query_does_not_name_are_never_read() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[
+                (
+                    ".cursor.com",
+                    "WorkosCursorSessionToken",
+                    seal(b"a-real-password", b"v11", b"the-session"),
+                    "",
+                    0,
+                ),
+                (
+                    ".google.com",
+                    "NID",
+                    seal(b"a-real-password", b"v11", b"not-ours"),
+                    "",
+                    0,
+                ),
+                (
+                    ".cursor.com",
+                    "_ga",
+                    seal(b"a-real-password", b"v11", b"analytics"),
+                    "",
+                    0,
+                ),
+            ],
+        );
+
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+        let cookies = read(&path, &query, Some("a-real-password")).expect("reads");
+
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].name, "WorkosCursorSessionToken");
+    }
+
+    #[test]
+    fn an_expiry_in_chromium_time_becomes_a_unix_timestamp() {
+        let home = TestHome::new();
+        // 2026-08-25T00:00:00Z = 1787443200s since 1970 = 13431916800s since 1601.
+        let webkit = 13_431_916_800i64 * 1_000_000;
+        let path = database(
+            &home,
+            &[(
+                ".example.com",
+                "session",
+                seal(BASIC_PASSWORD, b"v10", b"legacy"),
+                "",
+                webkit,
+            )],
+        );
+
+        let query = Query::new(["example.com"], ["session"]);
+        let cookies = read(&path, &query, None).expect("reads");
+
+        assert_eq!(
+            cookies[0].expires_at.map(|at| at.as_unix()),
+            Some(1_787_443_200)
+        );
+    }
+}

--- a/crates/tidemark-core/src/browser/gecko.rs
+++ b/crates/tidemark-core/src/browser/gecko.rs
@@ -1,0 +1,182 @@
+//! Reading cookies out of a Gecko-family `cookies.sqlite` database.
+//!
+//! Firefox and its forks store cookies in plain text in the `moz_cookies` table — the
+//! whole of the work is the read itself. The expiry is Unix seconds, with zero meaning a
+//! session cookie.
+
+use rusqlite::Connection;
+use std::path::Path;
+
+use super::{Cookie, CookieError, Query};
+
+/// Reads every cookie the query asks for.
+pub fn read(database: &Path, query: &Query) -> Result<Vec<Cookie>, CookieError> {
+    let connection =
+        Connection::open_with_flags(database, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(
+            |source| CookieError::Database {
+                path: database.to_path_buf(),
+                source,
+            },
+        )?;
+    let mut statement = connection
+        .prepare("SELECT host, name, value, path, isSecure, expiry FROM moz_cookies")
+        .map_err(|source| CookieError::Database {
+            path: database.to_path_buf(),
+            source,
+        })?;
+
+    let mut cookies = Vec::new();
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
+        .map_err(|source| CookieError::Database {
+            path: database.to_path_buf(),
+            source,
+        })?;
+    for row in rows {
+        let (host, name, value, path, secure, expiry) =
+            row.map_err(|source| CookieError::Database {
+                path: database.to_path_buf(),
+                source,
+            })?;
+        if !query.matches(&host, &name) {
+            continue;
+        }
+        cookies.push(Cookie {
+            host,
+            name,
+            value,
+            path,
+            secure: secure != 0,
+            expires_at: expires(expiry),
+        });
+    }
+    Ok(cookies)
+}
+
+/// Gecko's `expiry` is Unix seconds; zero means a session cookie.
+fn expires(unix: i64) -> Option<tidemark_types::Timestamp> {
+    if unix <= 0 {
+        return None;
+    }
+    tidemark_types::Timestamp::from_unix(unix).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::tests::TestHome;
+    use std::path::PathBuf;
+
+    /// A Gecko cookie database holding exactly the cookies given.
+    fn database(home: &TestHome, cookies: &[(&str, &str, &str, i64, i64)]) -> PathBuf {
+        let path = home.path().join("cookies.sqlite");
+        let connection = Connection::open(&path).expect("opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE moz_cookies (
+                    id INTEGER PRIMARY KEY,
+                    baseDomain TEXT,
+                    originAttributes TEXT NOT NULL DEFAULT '',
+                    name TEXT,
+                    value TEXT,
+                    host TEXT,
+                    path TEXT,
+                    expiry INTEGER,
+                    lastAccessed INTEGER,
+                    creationTime INTEGER,
+                    isSecure INTEGER,
+                    isHttpOnly INTEGER,
+                    inBrowserElement INTEGER DEFAULT 0,
+                    sameSite INTEGER DEFAULT 0,
+                    rawSameSite INTEGER DEFAULT 0,
+                    schemeMap INTEGER DEFAULT 0
+                );",
+            )
+            .expect("creates the table");
+        for (host, name, value, expiry, secure) in cookies {
+            connection
+                .execute(
+                    "INSERT INTO moz_cookies (
+                        host, name, value, path, expiry, isSecure, lastAccessed,
+                        creationTime, isHttpOnly
+                    ) VALUES (?1, ?2, ?3, '/', ?4, ?5, 0, 0, 0)",
+                    (host, name, value, expiry, secure),
+                )
+                .expect("inserts");
+        }
+        path
+    }
+
+    #[test]
+    fn a_cookie_is_read_in_plain_text() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[(
+                ".cursor.com",
+                "WorkosCursorSessionToken",
+                "the-session",
+                0,
+                1,
+            )],
+        );
+
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+        let cookies = read(&path, &query).expect("reads");
+
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].value, "the-session");
+        assert!(cookies[0].secure);
+        assert_eq!(cookies[0].expires_at, None);
+    }
+
+    #[test]
+    fn an_expiry_in_unix_seconds_is_carried_through() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[(".example.com", "session", "abc", 1_787_443_200, 0)],
+        );
+
+        let query = Query::new(["example.com"], ["session"]);
+        let cookies = read(&path, &query).expect("reads");
+
+        assert_eq!(
+            cookies[0].expires_at.map(|at| at.as_unix()),
+            Some(1_787_443_200)
+        );
+    }
+
+    #[test]
+    fn cookies_the_query_does_not_name_are_never_read() {
+        let home = TestHome::new();
+        let path = database(
+            &home,
+            &[
+                (
+                    ".cursor.com",
+                    "WorkosCursorSessionToken",
+                    "the-session",
+                    0,
+                    1,
+                ),
+                (".google.com", "NID", "not-ours", 0, 1),
+            ],
+        );
+
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+        let cookies = read(&path, &query).expect("reads");
+
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].name, "WorkosCursorSessionToken");
+    }
+}

--- a/crates/tidemark-core/src/browser/mod.rs
+++ b/crates/tidemark-core/src/browser/mod.rs
@@ -1,0 +1,630 @@
+//! Reading a browser's cookies, for the providers whose only credential is a session.
+//!
+//! # Why this exists
+//!
+//! Some services publish usage to their own dashboard and nowhere else: there is no API
+//! key to paste, and the only thing that authenticates a request is the session cookie the
+//! user's browser already holds. Cursor is the first of them here. Asking a person to open
+//! the network panel, find a request and copy a header out of it is a credential ceremony
+//! nobody should have to repeat every time a session rolls over, so this module reads the
+//! cookie the same way the browser would.
+//!
+//! # The rules this module keeps
+//!
+//! - **Nothing is written into a browser's directory.** A live browser holds its cookie
+//!   database in WAL mode, and opening that database directly can create the `-shm` and
+//!   `-wal` sidecars — files in someone else's application directory that we have no
+//!   business creating. Every read is taken from a private copy ([`Snapshot`]), which is
+//!   also what makes the read immune to the browser writing underneath it.
+//! - **Only the asked-for cookies leave this module.** A query names its domains, so a
+//!   provider that wants a Cursor session never gets handed a bank's.
+//! - **A cookie value is a secret.** [`Cookie`] prints its value as redacted for the same
+//!   reason [`crate::providers::Credential`] does: the workspace warns on a missing
+//!   `Debug`, and a derived one would put a live session in the log.
+//! - **A locked keyring is a state, not a failure.** Chromium seals its cookie values with
+//!   a password kept in the Secret Service; if the collection is locked we say so and let
+//!   the caller wait, exactly as [`crate::secrets`] does.
+//!
+//! # What a browser stores
+//!
+//! Two families, and the difference is the whole of the work:
+//!
+//! - **Gecko** — Firefox, Zen, LibreWolf. `cookies.sqlite`, table `moz_cookies`, values in
+//!   plain text.
+//! - **Chromium** — Chrome, Chromium, Brave, Edge, Vivaldi, Opera. `Cookies`, table
+//!   `cookies`, values sealed with `os_crypt`. See [`chromium`] for that scheme.
+
+pub mod chromium;
+pub mod gecko;
+mod safe_storage;
+
+pub use safe_storage::{Keyring, SafeStorage};
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tidemark_types::Timestamp;
+
+/// How a browser stores its cookies, which is the only thing that differs between the
+/// browsers of one family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Family {
+    /// Firefox and its forks: a plain-text `moz_cookies` table.
+    Gecko,
+    /// Chrome and its forks: an `os_crypt`-sealed `cookies` table.
+    Chromium,
+}
+
+/// One browser this build knows how to read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Browser {
+    /// The stable spelling a setting stores. Never changes once shipped.
+    pub slug: &'static str,
+    /// What to call it in front of a person.
+    pub title: &'static str,
+    /// How it stores cookies.
+    pub family: Family,
+    /// Directories under `$HOME` that hold this browser's profiles, in the order they are
+    /// looked for. More than one because the same browser installs differently as a
+    /// distribution package, a Flatpak and a Snap.
+    roots: &'static [&'static str],
+    /// The `application` attribute this browser files its `os_crypt` password under in the
+    /// Secret Service. Empty for the Gecko family, which seals nothing.
+    application: &'static str,
+}
+
+/// Every browser this build can read, in the order profiles are scanned.
+///
+/// Chromium-family browsers come first only because their share of Linux desktops is
+/// larger; the scan does not stop at the first store, so the order decides which session
+/// wins a tie, not which is looked at.
+pub static BROWSERS: &[Browser] = &[
+    Browser {
+        slug: "chrome",
+        title: "Google Chrome",
+        family: Family::Chromium,
+        roots: &[
+            ".config/google-chrome",
+            ".config/google-chrome-beta",
+            ".config/google-chrome-unstable",
+            ".var/app/com.google.Chrome/config/google-chrome",
+        ],
+        application: "chrome",
+    },
+    Browser {
+        slug: "chromium",
+        title: "Chromium",
+        family: Family::Chromium,
+        roots: &[
+            ".config/chromium",
+            ".var/app/org.chromium.Chromium/config/chromium",
+            "snap/chromium/common/chromium",
+        ],
+        application: "chromium",
+    },
+    Browser {
+        slug: "brave",
+        title: "Brave",
+        family: Family::Chromium,
+        roots: &[
+            ".config/BraveSoftware/Brave-Browser",
+            ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
+        ],
+        application: "brave",
+    },
+    Browser {
+        slug: "edge",
+        title: "Microsoft Edge",
+        family: Family::Chromium,
+        roots: &[
+            ".config/microsoft-edge",
+            ".var/app/com.microsoft.Edge/config/microsoft-edge",
+        ],
+        application: "microsoft-edge",
+    },
+    Browser {
+        slug: "vivaldi",
+        title: "Vivaldi",
+        family: Family::Chromium,
+        roots: &[
+            ".config/vivaldi",
+            ".var/app/com.vivaldi.Vivaldi/config/vivaldi",
+        ],
+        application: "vivaldi",
+    },
+    Browser {
+        slug: "opera",
+        title: "Opera",
+        family: Family::Chromium,
+        roots: &[".config/opera", ".var/app/com.opera.Opera/config/opera"],
+        application: "opera",
+    },
+    Browser {
+        slug: "firefox",
+        title: "Firefox",
+        family: Family::Gecko,
+        roots: &[
+            ".config/mozilla/firefox",
+            ".mozilla/firefox",
+            ".var/app/org.mozilla.firefox/.mozilla/firefox",
+            "snap/firefox/common/.mozilla/firefox",
+        ],
+        application: "",
+    },
+    Browser {
+        slug: "zen",
+        title: "Zen",
+        family: Family::Gecko,
+        roots: &[".zen", ".var/app/app.zen_browser.zen/.zen"],
+        application: "",
+    },
+    Browser {
+        slug: "librewolf",
+        title: "LibreWolf",
+        family: Family::Gecko,
+        roots: &[
+            ".librewolf",
+            ".var/app/io.gitlab.librewolf-community/.librewolf",
+        ],
+        application: "",
+    },
+];
+
+/// One profile's cookie database: what a person means by "the session I am signed in with".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Store {
+    /// Which browser holds it.
+    pub browser: Browser,
+    /// The profile's directory name — `Default`, `Profile 2`, `k26qcf29.Default (release)`.
+    pub profile: String,
+    /// The database itself.
+    pub path: PathBuf,
+}
+
+/// Which cookies a caller wants: a provider names the domains its session lives on, and
+/// optionally the names it needs, so nothing else is ever read out of the database.
+#[derive(Debug, Clone, Default)]
+pub struct Query {
+    /// Domains, matched as suffixes: `cursor.com` matches `cursor.com`, `.cursor.com` and
+    /// `www.cursor.com`, and does not match `notcursor.com`. Empty matches every domain,
+    /// which no provider should ask for.
+    pub domains: Vec<String>,
+    /// Cookie names. Empty means every name on a matching domain.
+    pub names: Vec<String>,
+}
+
+impl Query {
+    /// A query for one provider's domains and the cookie names its session is carried in.
+    pub fn new<D, N>(domains: D, names: N) -> Self
+    where
+        D: IntoIterator,
+        D::Item: Into<String>,
+        N: IntoIterator,
+        N::Item: Into<String>,
+    {
+        Self {
+            domains: domains.into_iter().map(Into::into).collect(),
+            names: names.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Whether a stored cookie is one of the ones asked for.
+    pub(crate) fn matches(&self, host: &str, name: &str) -> bool {
+        let host = host.trim_start_matches('.').to_ascii_lowercase();
+        let domain_matches = self.domains.is_empty()
+            || self.domains.iter().any(|domain| {
+                let domain = domain.trim_start_matches('.').to_ascii_lowercase();
+                host == domain || host.ends_with(&format!(".{domain}"))
+            });
+        let name_matches = self.names.is_empty() || self.names.iter().any(|wanted| wanted == name);
+        domain_matches && name_matches
+    }
+}
+
+/// One cookie, as the browser holds it.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Cookie {
+    /// The domain it was set for, with any leading dot kept: `.cursor.com` is a domain
+    /// cookie and `cursor.com` a host-only one, and a caller may care which.
+    pub host: String,
+    /// The cookie's name.
+    pub name: String,
+    /// The cookie's value. A live session — never log it.
+    pub value: String,
+    /// The path it was set for.
+    pub path: String,
+    /// Whether the browser will only send it over HTTPS.
+    pub secure: bool,
+    /// When it expires, or `None` for a session cookie or an unreadable expiry.
+    pub expires_at: Option<Timestamp>,
+}
+
+impl Cookie {
+    /// Whether this cookie is still live at `now`. A session cookie — one with no stated
+    /// expiry — counts as live: the browser holding it is what keeps it alive.
+    pub fn is_live(&self, now: Timestamp) -> bool {
+        self.expires_at
+            .is_none_or(|expires_at| now.seconds_until(expires_at) > 0)
+    }
+}
+
+impl fmt::Debug for Cookie {
+    /// Written by hand: a derived impl would print a live session the first time anything
+    /// traced a cookie.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cookie")
+            .field("host", &self.host)
+            .field("name", &self.name)
+            .field(
+                "value",
+                &format_args!("<{} bytes redacted>", self.value.len()),
+            )
+            .field("secure", &self.secure)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The value of a `Cookie:` header carrying these cookies, in the order given.
+pub fn header(cookies: &[Cookie]) -> String {
+    cookies
+        .iter()
+        .map(|cookie| format!("{}={}", cookie.name, cookie.value))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Why cookies could not be read.
+#[derive(Debug, thiserror::Error)]
+pub enum CookieError {
+    /// The database could not be copied or opened.
+    #[error("{path} could not be read: {source}")]
+    Unreadable {
+        /// What was being read.
+        path: PathBuf,
+        /// Why it could not be.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The copy opened but is not the database this build expects — a schema change, or a
+    /// file that is not a cookie store at all.
+    #[error("{path} is not a readable cookie database: {source}")]
+    Database {
+        /// What was being read.
+        path: PathBuf,
+        /// Why it could not be read.
+        #[source]
+        source: rusqlite::Error,
+    },
+    /// The Secret Service holds the browser's key and the collection is locked. A state to
+    /// wait out, not a failure to report — see the module docs.
+    #[error("the keyring is locked")]
+    KeyringLocked,
+    /// Nothing answered on the bus, so the browser's key cannot be reached at all.
+    #[error("the keyring is unavailable: {0}")]
+    KeyringUnavailable(String),
+}
+
+impl Store {
+    /// The cookies in this store that the query asks for.
+    ///
+    /// Async only because a Chromium store's key lives in the Secret Service; a Gecko store
+    /// never touches `storage` and answers without a bus.
+    pub async fn cookies(
+        &self,
+        query: &Query,
+        storage: &dyn SafeStorage,
+    ) -> Result<Vec<Cookie>, CookieError> {
+        let snapshot = Snapshot::of(&self.path)?;
+        match self.browser.family {
+            Family::Gecko => gecko::read(&snapshot.database(), query),
+            Family::Chromium => {
+                let password = storage.password(self.browser.application).await.map_err(
+                    |error| match error {
+                        crate::secrets::SecretError::Locked => CookieError::KeyringLocked,
+                        other => CookieError::KeyringUnavailable(other.to_string()),
+                    },
+                )?;
+                chromium::read(&snapshot.database(), query, password.as_deref())
+            }
+        }
+    }
+}
+
+/// Every cookie database on this machine, in [`BROWSERS`] order.
+///
+/// Cheap: it stats directories and never opens a database, so a caller may call it on
+/// every poll rather than caching a list that a newly created profile would make stale.
+pub fn stores() -> Vec<Store> {
+    match std::env::var_os("HOME") {
+        Some(home) => stores_in(Path::new(&home)),
+        None => Vec::new(),
+    }
+}
+
+/// [`stores`], against a stated home directory, so the scan is testable against a fixture
+/// tree rather than against whatever browsers a developer happens to have installed.
+pub fn stores_in(home: &Path) -> Vec<Store> {
+    let mut stores = Vec::new();
+    for browser in BROWSERS {
+        for root in browser.roots {
+            let root = home.join(root);
+            let Ok(entries) = std::fs::read_dir(&root) else {
+                continue;
+            };
+            let mut profiles: Vec<_> = entries
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect();
+            // Read order from a directory is whatever the filesystem says; a stable scan
+            // order is what keeps "the first store that has the session" from meaning a
+            // different profile on every poll.
+            profiles.sort();
+            for profile in profiles {
+                let directory = root.join(&profile);
+                let Some(path) = database(browser.family, &directory) else {
+                    continue;
+                };
+                stores.push(Store {
+                    browser: *browser,
+                    profile,
+                    path,
+                });
+            }
+        }
+    }
+    stores
+}
+
+/// The cookie database inside one profile directory, if it holds one.
+fn database(family: Family, profile: &Path) -> Option<PathBuf> {
+    let candidates: &[&str] = match family {
+        // Chromium moved cookies under `Network/` in M96 and left the old location in
+        // place for profiles that predate it, so both are real.
+        Family::Chromium => &["Network/Cookies", "Cookies"],
+        Family::Gecko => &["cookies.sqlite"],
+    };
+    candidates
+        .iter()
+        .map(|name| profile.join(name))
+        .find(|path| path.is_file())
+}
+
+/// A private copy of a cookie database, deleted when it goes out of scope.
+///
+/// The copy exists so that nothing is written into the browser's own directory: opening a
+/// WAL database read-only still needs to create its `-shm` sidecar, and a browser that is
+/// running would find a file it did not put there. Copying the sidecars along with the
+/// main file is what makes the copy show the same cookies the browser itself would see.
+#[derive(Debug)]
+struct Snapshot {
+    directory: PathBuf,
+}
+
+impl Snapshot {
+    fn of(path: &Path) -> Result<Self, CookieError> {
+        use std::os::unix::fs::DirBuilderExt;
+
+        static SERIAL: AtomicU64 = AtomicU64::new(0);
+        let directory = std::env::temp_dir().join(format!(
+            "tidemark-cookies-{}-{}",
+            std::process::id(),
+            SERIAL.fetch_add(1, Ordering::Relaxed)
+        ));
+        let unreadable = |source| CookieError::Unreadable {
+            path: path.to_path_buf(),
+            source,
+        };
+        // Owner-only, because what lands in it is a set of live sessions.
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&directory)
+            .map_err(unreadable)?;
+        let snapshot = Self { directory };
+        std::fs::copy(path, snapshot.database()).map_err(unreadable)?;
+        for sidecar in ["-wal", "-shm"] {
+            let source = with_suffix(path, sidecar);
+            if source.is_file() {
+                std::fs::copy(&source, with_suffix(&snapshot.database(), sidecar))
+                    .map_err(unreadable)?;
+            }
+        }
+        Ok(snapshot)
+    }
+
+    fn database(&self) -> PathBuf {
+        self.directory.join("cookies")
+    }
+}
+
+impl Drop for Snapshot {
+    fn drop(&mut self) {
+        // Best effort: a copy left behind is owner-only and in the temp directory, and
+        // there is nothing useful to do with the failure of a cleanup.
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    fn cookie(host: &str, name: &str, value: &str) -> Cookie {
+        Cookie {
+            host: host.to_owned(),
+            name: name.to_owned(),
+            value: value.to_owned(),
+            path: "/".to_owned(),
+            secure: true,
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn a_domain_matches_its_own_host_and_its_subdomains_and_nothing_that_merely_ends_in_it() {
+        let query = Query::new(["cursor.com"], Vec::<String>::new());
+
+        assert!(query.matches("cursor.com", "anything"));
+        assert!(query.matches(".cursor.com", "anything"));
+        assert!(query.matches("www.cursor.com", "anything"));
+        assert!(!query.matches("notcursor.com", "anything"));
+        assert!(!query.matches("cursor.com.evil.test", "anything"));
+    }
+
+    #[test]
+    fn a_named_query_reads_only_the_names_it_asked_for() {
+        let query = Query::new(["cursor.com"], ["WorkosCursorSessionToken"]);
+
+        assert!(query.matches(".cursor.com", "WorkosCursorSessionToken"));
+        assert!(!query.matches(".cursor.com", "_ga"));
+    }
+
+    #[test]
+    fn a_cookie_never_prints_its_value() {
+        let rendered = format!(
+            "{:?}",
+            cookie(".cursor.com", "session", "do-not-print-this")
+        );
+
+        assert!(rendered.contains("session"));
+        assert!(!rendered.contains("do-not-print-this"));
+        assert!(rendered.contains("redacted"));
+    }
+
+    #[test]
+    fn a_header_is_the_cookies_in_the_order_they_were_given() {
+        let header = header(&[
+            cookie(".cursor.com", "WorkosCursorSessionToken", "abc"),
+            cookie(".cursor.com", "other", "1"),
+        ]);
+
+        assert_eq!(header, "WorkosCursorSessionToken=abc; other=1");
+    }
+
+    #[test]
+    fn a_session_cookie_is_live_and_a_past_expiry_is_not() {
+        let now = Timestamp::from_unix(1_787_000_000).expect("plausible");
+        let mut expired = cookie(".cursor.com", "session", "abc");
+        expired.expires_at = Some(now.saturating_add_seconds(-1));
+        let mut live = cookie(".cursor.com", "session", "abc");
+        live.expires_at = Some(now.saturating_add_seconds(60));
+
+        assert!(cookie(".cursor.com", "session", "abc").is_live(now));
+        assert!(live.is_live(now));
+        assert!(!expired.is_live(now));
+    }
+
+    #[test]
+    fn the_scan_finds_every_profile_of_every_installed_browser_and_nothing_else() {
+        let home = crate::browser::tests::TestHome::new();
+        home.profile("google-chrome/Default", "Cookies");
+        home.profile("google-chrome/Profile 1", "Network/Cookies");
+        home.profile("chromium/Default", "Cookies");
+        home.gecko(".zen/k26qcf29.Default (release)");
+        // A profile directory with no cookie database is not a store.
+        std::fs::create_dir_all(home.path().join(".config/google-chrome/System Profile"))
+            .expect("creates");
+
+        let stores = stores_in(home.path());
+
+        let found: Vec<(&str, &str)> = stores
+            .iter()
+            .map(|store| (store.browser.slug, store.profile.as_str()))
+            .collect();
+        assert_eq!(
+            found,
+            [
+                ("chrome", "Default"),
+                ("chrome", "Profile 1"),
+                ("chromium", "Default"),
+                ("zen", "k26qcf29.Default (release)"),
+            ]
+        );
+        assert!(stores[1].path.ends_with("Profile 1/Network/Cookies"));
+    }
+
+    #[test]
+    fn a_firefox_profile_in_the_config_directory_is_scanned() {
+        let home = TestHome::new();
+        let path = home
+            .path()
+            .join(".config/mozilla/firefox/j7aiac5u.default-release/cookies.sqlite");
+        std::fs::create_dir_all(path.parent().expect("has parent")).expect("creates");
+        std::fs::write(path, b"").expect("creates cookie database");
+
+        let stores = stores_in(home.path());
+
+        assert!(stores.iter().any(|store| {
+            store.browser.slug == "firefox" && store.profile == "j7aiac5u.default-release"
+        }));
+    }
+
+    #[test]
+    fn a_snapshot_copies_the_sidecars_and_takes_the_copy_with_it() {
+        let home = TestHome::new();
+        let path = home.profile("chromium/Default", "Cookies");
+        std::fs::write(with_suffix(&path, "-wal"), b"wal").expect("writes");
+
+        let directory;
+        {
+            let snapshot = Snapshot::of(&path).expect("copies");
+            directory = snapshot.directory.clone();
+            assert!(snapshot.database().is_file());
+            assert!(with_suffix(&snapshot.database(), "-wal").is_file());
+            assert!(!with_suffix(&snapshot.database(), "-shm").exists());
+        }
+        assert!(!directory.exists(), "the copy is a live session; it goes");
+    }
+
+    /// A throwaway home directory: browser profiles have to be *found*, and the finding is
+    /// the part worth testing, so the fixture is a real tree rather than a stubbed scan.
+    #[derive(Debug)]
+    pub(crate) struct TestHome {
+        path: PathBuf,
+    }
+
+    impl TestHome {
+        pub(crate) fn new() -> Self {
+            static SERIAL: AtomicU64 = AtomicU64::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "tidemark-browser-test-{}-{}",
+                std::process::id(),
+                SERIAL.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).expect("creates a test home");
+            Self { path }
+        }
+
+        pub(crate) fn path(&self) -> &Path {
+            &self.path
+        }
+
+        /// A Chromium profile holding an empty database at the stated relative name.
+        pub(crate) fn profile(&self, profile: &str, database: &str) -> PathBuf {
+            let path = self.path.join(".config").join(profile).join(database);
+            std::fs::create_dir_all(path.parent().expect("has a parent")).expect("creates");
+            std::fs::write(&path, b"").expect("writes");
+            path
+        }
+
+        /// A Gecko profile holding an empty `cookies.sqlite`.
+        pub(crate) fn gecko(&self, profile: &str) -> PathBuf {
+            let path = self.path.join(profile).join("cookies.sqlite");
+            std::fs::create_dir_all(path.parent().expect("has a parent")).expect("creates");
+            std::fs::write(&path, b"").expect("writes");
+            path
+        }
+    }
+
+    impl Drop for TestHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/crates/tidemark-core/src/browser/mod.rs
+++ b/crates/tidemark-core/src/browser/mod.rs
@@ -249,6 +249,56 @@ impl Cookie {
     }
 }
 
+#[cfg(test)]
+mod scope_tests {
+    use super::{Cookie, header_for};
+
+    #[test]
+    fn a_cookie_header_keeps_only_the_one_cursor_session_the_request_url_can_receive() {
+        // Sending either a www-only token or a path-scoped duplicate to cursor.com lets the
+        // server choose an account Tidemark did not validate.
+        let cookies = vec![
+            Cookie {
+                host: ".cursor.com".into(),
+                name: "WorkosCursorSessionToken".into(),
+                value: "selected".into(),
+                path: "/".into(),
+                secure: true,
+                expires_at: None,
+            },
+            Cookie {
+                host: "www.cursor.com".into(),
+                name: "WorkosCursorSessionToken".into(),
+                value: "wrong-host".into(),
+                path: "/".into(),
+                secure: true,
+                expires_at: None,
+            },
+            Cookie {
+                host: ".cursor.com".into(),
+                name: "WorkosCursorSessionToken".into(),
+                value: "wrong-path".into(),
+                path: "/settings".into(),
+                secure: true,
+                expires_at: None,
+            },
+            Cookie {
+                host: ".cursor.com".into(),
+                name: "analytics".into(),
+                value: "allowed".into(),
+                path: "/".into(),
+                secure: false,
+                expires_at: None,
+            },
+        ];
+
+        assert_eq!(
+            header_for(&cookies, "https://cursor.com/api/usage-summary"),
+            "WorkosCursorSessionToken=selected; analytics=allowed"
+        );
+    }
+}
+
 impl fmt::Debug for Cookie {
     /// Written by hand: a derived impl would print a live session the first time anything
     /// traced a cookie.
@@ -265,13 +315,56 @@ impl fmt::Debug for Cookie {
     }
 }
 
-/// The value of a `Cookie:` header carrying these cookies, in the order given.
-pub fn header(cookies: &[Cookie]) -> String {
+/// The `Cookie:` header a browser would send to one HTTPS request URL.
+///
+/// Browser stores can contain same-named cookies for several hosts and paths.  Sending all
+/// of them makes the remote server choose a session rather than the browser's own matching
+/// rules, so this keeps request host/path/secure scope and the first matching name only.
+pub fn header_for(cookies: &[Cookie], request_url: &str) -> String {
+    let Ok(url) = reqwest::Url::parse(request_url) else {
+        return String::new();
+    };
+    let Some(host) = url.host_str() else {
+        return String::new();
+    };
+    let path = url.path();
+    let secure = url.scheme() == "https";
+    let mut names = std::collections::BTreeSet::new();
+
     cookies
         .iter()
+        .filter(|cookie| {
+            (!cookie.secure || secure)
+                && cookie_host_matches(&cookie.host, host)
+                && cookie_path_matches(&cookie.path, path)
+                && names.insert(&cookie.name)
+        })
         .map(|cookie| format!("{}={}", cookie.name, cookie.value))
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+fn cookie_host_matches(cookie_host: &str, request_host: &str) -> bool {
+    let request_host = request_host.to_ascii_lowercase();
+    match cookie_host.strip_prefix('.') {
+        Some(domain) => {
+            let domain = domain.to_ascii_lowercase();
+            request_host == domain || request_host.ends_with(&format!(".{domain}"))
+        }
+        None => request_host == cookie_host.to_ascii_lowercase(),
+    }
+}
+
+fn cookie_path_matches(cookie_path: &str, request_path: &str) -> bool {
+    let cookie_path = if cookie_path.is_empty() {
+        "/"
+    } else {
+        cookie_path
+    };
+    request_path.starts_with(cookie_path)
+        && (cookie_path.ends_with('/')
+            || request_path.len() == cookie_path.len()
+            || request_path.as_bytes().get(cookie_path.len()) == Some(&b'/'))
 }
 
 /// Why cookies could not be read.
@@ -496,16 +589,6 @@ pub(crate) mod tests {
         assert!(rendered.contains("session"));
         assert!(!rendered.contains("do-not-print-this"));
         assert!(rendered.contains("redacted"));
-    }
-
-    #[test]
-    fn a_header_is_the_cookies_in_the_order_they_were_given() {
-        let header = header(&[
-            cookie(".cursor.com", "WorkosCursorSessionToken", "abc"),
-            cookie(".cursor.com", "other", "1"),
-        ]);
-
-        assert_eq!(header, "WorkosCursorSessionToken=abc; other=1");
     }
 
     #[test]

--- a/crates/tidemark-core/src/browser/mod.rs
+++ b/crates/tidemark-core/src/browser/mod.rs
@@ -34,6 +34,7 @@
 //! - **Chromium** — Chrome, Chromium, Brave, Edge, Vivaldi, Opera. `Cookies`, table
 //!   `cookies`, values sealed with `os_crypt`. See [`chromium`] for that scheme.
 
+pub mod auth;
 pub mod chromium;
 pub mod gecko;
 mod safe_storage;

--- a/crates/tidemark-core/src/browser/safe_storage.rs
+++ b/crates/tidemark-core/src/browser/safe_storage.rs
@@ -1,0 +1,60 @@
+//! Where a Chromium-family browser keeps the password its cookie values are sealed with.
+//!
+//! Chromium files a random "Safe Storage" password in the Secret Service under the
+//! `application` attribute (`chrome`, `chromium`, `brave`, …) and the
+//! `chrome_libsecret_os_crypt_password_v2` schema. That secret is not Tidemark's — it is
+//! the browser's own, which is why it is not read through [`crate::secrets::Store`]: the
+//! store is typed and attributed for the two schemas Tidemark files under, and a foreign
+//! item is a different question with a different answer shape. What it shares is the
+//! locked-collection rule: a locked keyring is a state the caller waits out, never a prompt
+//! triggered from a background process.
+//!
+//! The seam is the [`SafeStorage`] trait so the cryptography in [`super::chromium`] is
+//! testable against a fixed password rather than against whatever keyring a test machine
+//! happens to run.
+
+use oo7::dbus::Service;
+
+use crate::secrets::SecretError;
+
+/// The password a browser sealed its cookie values with, if it stored one.
+pub trait SafeStorage: std::fmt::Debug + Send + Sync {
+    /// The Safe Storage password for `application` — Chrome is `chrome`, Chromium is
+    /// `chromium`, Brave is `brave`. `Ok(None)` when the browser never stored one, which
+    /// is the world Chromium's `v10` fallback exists for.
+    fn password(
+        &self,
+        application: &str,
+    ) -> crate::providers::BoxFuture<'_, Result<Option<String>, SecretError>>;
+}
+
+/// The Secret Service this machine is running.
+#[derive(Debug, Default)]
+pub struct Keyring;
+
+impl SafeStorage for Keyring {
+    fn password(
+        &self,
+        application: &str,
+    ) -> crate::providers::BoxFuture<'_, Result<Option<String>, SecretError>> {
+        let application = application.to_owned();
+        Box::pin(async move {
+            let service = Service::new().await?;
+            // The default collection only: prompting for a non-default one is not a
+            // thing a background process may cause, and Chromium files its password here.
+            let collection = service.default_collection().await?;
+            if collection.is_locked().await? {
+                return Err(SecretError::Locked);
+            }
+            let items = collection
+                .search_items(&[("application", application.as_str())])
+                .await?;
+            let Some(item) = items.into_iter().next() else {
+                return Ok(None);
+            };
+            let secret = item.secret().await?;
+            let password = String::from_utf8(secret.to_vec()).map_err(|_| SecretError::NotUtf8)?;
+            Ok(Some(password))
+        })
+    }
+}

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -20,7 +20,7 @@
 
 use std::path::{Path, PathBuf};
 
-use tidemark_types::Preferences;
+use tidemark_types::{AuthSelection, Preferences};
 use toml_edit::{Array, DocumentMut, Item, Table, Value, value};
 
 use crate::paths;
@@ -28,6 +28,10 @@ use crate::paths;
 /// Table every provider's own settings live under: `[provider.zai]`.
 const PROVIDER_TABLE: &str = "provider";
 const PROVIDERS_KEY: &str = "providers";
+/// The shared storage keys used by browser-cookie authentication providers.
+const AUTH_SOURCE_KEY: &str = "auth-source";
+const AUTH_BROWSER_KEY: &str = "auth-browser";
+const AUTH_PROFILE_KEY: &str = "auth-profile";
 
 /// Table the notification opt-in lives under: `[notify.claude]`.
 ///
@@ -106,6 +110,18 @@ pub enum ConfigError {
         path: PathBuf,
         /// Whose list it is.
         provider: String,
+    },
+    /// A browser-auth selection cannot be represented by the shared local-source keys.
+    #[error(
+        "{path}: [{PROVIDER_TABLE}.{provider}] has an invalid authentication selection: {reason}"
+    )]
+    InvalidAuthSelection {
+        /// The file.
+        path: PathBuf,
+        /// The provider carrying the selection.
+        provider: String,
+        /// Why the selected opaque candidate cannot be stored.
+        reason: String,
     },
     /// An application preference has a wrong type or an unknown named value.
     #[error("{path}: [{table}] {key} {reason}")]
@@ -543,6 +559,90 @@ impl Config {
         self.write()
     }
 
+    /// Stores one daemon-validated browser-cookie source in one staged config write.
+    ///
+    /// Browser candidates travel over D-Bus as opaque `browser` or `browser/profile` paths.
+    /// The daemon resolves and validates that path before it reaches this method; config only
+    /// turns it into the stable fields a provider rebuild consumes. Keeping all three fields
+    /// in this transaction prevents an old profile from surviving a newly selected browser.
+    pub fn set_auth_selection(
+        &mut self,
+        provider: &str,
+        selection: &AuthSelection,
+    ) -> Result<(), ConfigError> {
+        let browser_profile = match (selection.mode.as_str(), selection.candidate.as_deref()) {
+            ("cursor-app", None) => None,
+            ("browser", Some(candidate)) => {
+                Some(parse_browser_candidate(candidate).ok_or_else(|| {
+                    ConfigError::InvalidAuthSelection {
+                        path: self.path.clone(),
+                        provider: provider.to_owned(),
+                        reason: "browser candidates must name a browser and optional profile"
+                            .into(),
+                    }
+                })?)
+            }
+            ("cursor-app", Some(_)) => {
+                return Err(ConfigError::InvalidAuthSelection {
+                    path: self.path.clone(),
+                    provider: provider.to_owned(),
+                    reason: "Cursor App does not take a browser candidate".into(),
+                });
+            }
+            ("browser", None) => {
+                return Err(ConfigError::InvalidAuthSelection {
+                    path: self.path.clone(),
+                    provider: provider.to_owned(),
+                    reason: "Browser needs a selected candidate".into(),
+                });
+            }
+            _ => {
+                return Err(ConfigError::InvalidAuthSelection {
+                    path: self.path.clone(),
+                    provider: provider.to_owned(),
+                    reason: "unknown authentication mode".into(),
+                });
+            }
+        };
+
+        self.normalize_providers(None)?;
+        let providers = self
+            .document
+            .entry(PROVIDER_TABLE)
+            .or_insert_with(|| Item::Table(implicit_table()));
+        let providers = providers
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: PROVIDER_TABLE.to_owned(),
+            })?;
+        let table = providers
+            .entry(provider)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let table = table
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: format!("{PROVIDER_TABLE}.{provider}"),
+            })?;
+        table.insert(AUTH_SOURCE_KEY, value(selection.mode.as_str()));
+        match browser_profile {
+            Some((browser, profile)) => {
+                table.insert(AUTH_BROWSER_KEY, value(browser));
+                if let Some(profile) = profile {
+                    table.insert(AUTH_PROFILE_KEY, value(profile));
+                } else {
+                    table.remove(AUTH_PROFILE_KEY);
+                }
+            }
+            None => {
+                table.remove(AUTH_BROWSER_KEY);
+                table.remove(AUTH_PROFILE_KEY);
+            }
+        }
+        self.write()
+    }
+
     /// Window keys of this provider whose notifications the user has switched on.
     ///
     /// Absent table, absent key and empty array all mean the same thing: this provider
@@ -713,6 +813,19 @@ fn remove_carrying_prefix(array: &mut Array, index: usize) {
     }
 }
 
+/// Splits the opaque browser candidate path used by browser-cookie source selection.
+///
+/// Browser slugs and profile directory names cannot contain `/`, so one separator retains
+/// both durable components while a bare browser path represents the common parent choice.
+fn parse_browser_candidate(candidate: &str) -> Option<(&str, Option<&str>)> {
+    let (browser, profile) = match candidate.split_once('/') {
+        Some((browser, profile)) => (browser, Some(profile)),
+        None => (candidate, None),
+    };
+    (!browser.is_empty() && profile.is_none_or(|profile| !profile.is_empty()))
+        .then_some((browser, profile))
+}
+
 /// Appends without moving the previous last element's inline comment onto the new value.
 fn push_provider(array: &mut Array, provider: &str) {
     let trailing = array.trailing().as_str().map(str::to_owned);
@@ -758,6 +871,7 @@ fn implicit_table() -> Table {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tidemark_types::AuthSelection;
 
     fn scratch(name: &str) -> PathBuf {
         let dir =
@@ -771,6 +885,60 @@ mod tests {
         let config = Config::at(scratch("absent").with_file_name("nothing.toml"))
             .expect("a missing file is an empty document");
         assert_eq!(config.option("zai", "region"), None);
+    }
+
+    #[test]
+    fn an_auth_selection_replaces_only_its_stale_browser_fields() {
+        // Replacing this with individual option writes could leave an old profile paired
+        // with a newly chosen browser if the daemon stopped between them.
+        let path = scratch("auth-selection");
+        std::fs::write(
+            &path,
+            "[provider.cursor]\n\
+             auth-source = \"browser\"\n\
+             auth-browser = \"firefox\"\n\
+             auth-profile = \"Default\"\n",
+        )
+        .expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        config
+            .set_auth_selection(
+                "cursor",
+                &AuthSelection {
+                    mode: "cursor-app".into(),
+                    candidate: None,
+                },
+            )
+            .expect("stores Cursor App");
+        assert_eq!(config.option("cursor", "auth-source"), Some("cursor-app"));
+        assert_eq!(config.option("cursor", "auth-browser"), None);
+        assert_eq!(config.option("cursor", "auth-profile"), None);
+
+        config
+            .set_auth_selection(
+                "cursor",
+                &AuthSelection {
+                    mode: "browser".into(),
+                    candidate: Some("zen".into()),
+                },
+            )
+            .expect("stores a browser parent");
+        assert_eq!(config.option("cursor", "auth-browser"), Some("zen"));
+        assert_eq!(config.option("cursor", "auth-profile"), None);
+
+        config
+            .set_auth_selection(
+                "cursor",
+                &AuthSelection {
+                    mode: "browser".into(),
+                    candidate: Some("firefox/work".into()),
+                },
+            )
+            .expect("stores a browser profile");
+        assert_eq!(config.option("cursor", "auth-browser"), Some("firefox"));
+        assert_eq!(config.option("cursor", "auth-profile"), Some("work"));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/tidemark-core/src/lib.rs
+++ b/crates/tidemark-core/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub mod config;
 
+pub mod browser;
+
 pub mod paths;
 
 pub mod oauth;

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -613,6 +613,10 @@ impl Provider for Cursor {
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
         Box::pin(self.fetch_inner())
     }
+
+    fn inspect_auth_sources(&self) -> BoxFuture<'_, Result<Vec<AuthCandidate>, ProviderError>> {
+        Box::pin(self.inspect_sources())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1025,7 +1029,7 @@ fn parse(
 #[cfg(test)]
 mod tests {
     use super::{Cursor, Options, SPEC, parse};
-    use crate::providers::{Credential, ProviderError};
+    use crate::providers::{Credential, Provider, ProviderError};
     use tidemark_types::{AuthCandidateState, CredentialKind, DetailSection, Timestamp};
 
     /// A live Pro account's `GET /api/usage-summary`, as CodexBar's own regression test
@@ -1803,7 +1807,7 @@ mod tests {
         assert_eq!(sources[1].children[0].id, "zen");
         assert_eq!(
             sources[1].children[0].children[0].id,
-            "k26qcf29.Default (release)"
+            "zen/k26qcf29.Default (release)"
         );
         assert!(!format!("{sources:?}").contains("browser-session"));
         assert!(
@@ -1811,6 +1815,35 @@ mod tests {
                 .iter()
                 .any(|request| request.contains("browser-session"))
         );
+    }
+
+    #[test]
+    fn the_provider_trait_exposes_cursor_auth_sources_without_credentials() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "browser-session",
+            0,
+        )]);
+        let (base, requests, server) = session_server(1);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let provider: &dyn Provider = &provider;
+        let sources = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.inspect_auth_sources())
+            .expect("inspects");
+        let _ = requests.recv().expect("the browser validation request");
+        server.join().expect("server stopped");
+
+        assert_eq!(sources[1].children[0].id, "zen");
+        assert_eq!(
+            sources[1].children[0].children[0].id,
+            "zen/k26qcf29.Default (release)"
+        );
+        assert!(!format!("{sources:?}").contains("browser-session"));
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -136,10 +136,10 @@ fn session_query() -> browser::Query {
 pub static SPEC: HandSpec = HandSpec {
     id: PROVIDER_ID,
     title: "Cursor",
-    // Nothing is asked of the user: the credential is the session a browser on this
-    // machine already holds, so the settings dialog draws no credential row at all.
-    credential: CredentialKind::None,
-    credential_hint: "",
+    // Cursor owns this session outside Tidemark. The daemon selects it without ever storing
+    // its token, unlike a local gateway that genuinely needs no credential.
+    credential: CredentialKind::External,
+    credential_hint: "Choose a local Cursor session.",
     options: &[
         OptionSchema {
             name: AUTH_SOURCE,
@@ -357,7 +357,10 @@ impl Cursor {
                 .iter()
                 .any(|cookie| SESSION_COOKIE_NAMES.contains(&cookie.name.as_str()))
             {
-                return Ok(Some(browser::header(&live)));
+                let header = browser::header_for(&live, USAGE_SUMMARY_URL);
+                if !header.is_empty() {
+                    return Ok(Some(header));
+                }
             }
         }
         if keyring_locked {
@@ -379,8 +382,8 @@ impl Cursor {
         let Ok(request) = self.get(&self.url(USAGE_SUMMARY_URL), cookie) else {
             return crate::browser::auth::Validation::Unreachable;
         };
-        match super::request(PROVIDER_ID, &self.client, request).await {
-            Ok(_) => crate::browser::auth::Validation::Ready,
+        match super::validate(&self.client, request).await {
+            Ok(()) => crate::browser::auth::Validation::Ready,
             Err(ProviderError::Credential { status: 401 | 403 }) => {
                 crate::browser::auth::Validation::Rejected
             }
@@ -401,6 +404,7 @@ impl Cursor {
                 .map(browser::stores_in)
                 .unwrap_or_default(),
             &session_query(),
+            USAGE_SUMMARY_URL,
             self.storage.as_ref(),
             |credential| async move { self.validate_header(credential.header()).await },
         )
@@ -1386,10 +1390,10 @@ mod tests {
     }
 
     #[test]
-    fn the_spec_builds_a_cursor_provider_that_needs_no_credential() {
+    fn the_spec_describes_cursor_as_an_external_local_credential() {
         assert_eq!(SPEC.id, "cursor");
         assert_eq!(SPEC.title, "Cursor");
-        assert_eq!(SPEC.credential, CredentialKind::None);
+        assert_eq!(SPEC.credential, CredentialKind::External);
         assert_eq!(
             SPEC.options
                 .iter()
@@ -1814,6 +1818,43 @@ mod tests {
             requests
                 .iter()
                 .any(|request| request.contains("browser-session"))
+        );
+    }
+
+    #[test]
+    fn source_validation_does_not_retain_a_response_body_in_the_raw_response_log() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "browser-session",
+            0,
+        )]);
+        let log = crate::debug::enable(home.path()).expect("enables raw response logging");
+        let (base, requests, server) = session_server(1);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let sources = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.inspect_sources())
+            .expect("inspects");
+        let _ = requests.recv().expect("the validation request");
+        server.join().expect("server stopped");
+        crate::debug::disable();
+
+        assert_eq!(sources[1].children[0].children[0].state, "ready");
+        // The raw log is process-global and parallel tests legitimately record their own
+        // exchanges into whatever sink is open, so emptiness cannot be asserted. What this
+        // inspection alone contributed would name this server's unique port — and none may.
+        let recorded = std::fs::read_to_string(log).expect("debug log reads");
+        let leaked: Vec<&str> = recorded
+            .lines()
+            .filter(|line| line.contains(&base))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "proof responses are credential-adjacent and must never join ordinary polling logs, got {leaked:?}"
         );
     }
 

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -2,18 +2,11 @@
 //!
 //! # Why the credential is a browser session
 //!
-//! Cursor publishes no usage API and issues no API key for one. Every reader of this data —
-//! the dashboard, and CodexBar, which this port follows — authenticates with the
-//! `WorkosCursorSessionToken` cookie a browser session holds. CodexBar on Linux makes the
-//! user copy that header out of the browser's network panel by hand; Tidemark instead reads
-//! the cookie itself, out of every browser on the machine, on every poll — which is also
-//! what keeps the reading alive when the session rolls over. The reading machinery is
-//! [`crate::browser`]; this module only names the domains and the cookie names.
-//!
-//! Which cookies count, and in what order they are tried, is CodexBar's ladder: a strict
-//! pass that requires one of the known session-cookie names to be present, then a fallback
-//! pass that takes any cookies on Cursor's domains at all, because the session name has
-//! changed before and the API is the arbiter of what still works.
+//! Cursor publishes no usage API and issues no API key for one. The dashboard authenticates
+//! with a local Cursor session, either the Cursor App's state database or a browser cookie.
+//! Tidemark reads exactly the source the person selected; it never substitutes another
+//! browser, profile, or Cursor App session after a failure. The browser reading machinery is
+//! [`crate::browser`]; this module names Cursor's domains and session-cookie names.
 //!
 //! # The four requests
 //!
@@ -60,7 +53,7 @@
 //! percentages come from the token-based pricing that plan is not on, so showing them
 //! beside a request quota would be showing a person two unrelated readings of one account.
 
-use super::{HandSpec, Options, ProviderError, redact_query};
+use super::{HandSpec, OptionSchema, Options, ProviderError, redact_query};
 use crate::browser::{self, Keyring, SafeStorage};
 use crate::providers::{BoxFuture, Credential, Provider, http, parse_rfc3339, title_case};
 use base64::Engine;
@@ -72,11 +65,22 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tidemark_types::{
-    AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
-    WindowKey, WindowLength,
+    AccountId, AuthCandidate, AuthCandidateState, CredentialKind, DetailRow, DetailSection,
+    ProviderId, Snapshot, Timestamp, Window, WindowKey, WindowLength,
 };
 
 pub const PROVIDER_ID: &str = "cursor";
+
+/// The local source mode selected for Cursor under `[provider.cursor]`.
+pub const AUTH_SOURCE: &str = "auth-source";
+/// The selected browser's stable slug, present for [`BROWSER_SOURCE`].
+pub const AUTH_BROWSER: &str = "auth-browser";
+/// The selected browser profile directory name, when a browser has multiple usable profiles.
+pub const AUTH_PROFILE: &str = "auth-profile";
+/// Cursor's standalone state database source.
+pub const CURSOR_APP_SOURCE: &str = "cursor-app";
+/// A browser-cookie source.
+pub const BROWSER_SOURCE: &str = "browser";
 
 const USAGE_SUMMARY_URL: &str = "https://cursor.com/api/usage-summary";
 const AUTH_ME_URL: &str = "https://cursor.com/api/auth/me";
@@ -121,6 +125,14 @@ fn cookie_query() -> browser::Query {
     browser::Query::new(COOKIE_DOMAINS.iter().copied(), Vec::<String>::new())
 }
 
+/// The narrower query used only to discover whether a profile has a Cursor session.
+fn session_query() -> browser::Query {
+    browser::Query::new(
+        COOKIE_DOMAINS.iter().copied(),
+        SESSION_COOKIE_NAMES.iter().copied(),
+    )
+}
+
 pub static SPEC: HandSpec = HandSpec {
     id: PROVIDER_ID,
     title: "Cursor",
@@ -128,28 +140,94 @@ pub static SPEC: HandSpec = HandSpec {
     // machine already holds, so the settings dialog draws no credential row at all.
     credential: CredentialKind::None,
     credential_hint: "",
-    options: &[],
+    options: &[
+        OptionSchema {
+            name: AUTH_SOURCE,
+            title: "Authentication source",
+            description: None,
+            default: "",
+            choices: &[
+                (CURSOR_APP_SOURCE, "Cursor App"),
+                (BROWSER_SOURCE, "Browser"),
+            ],
+            required: false,
+        },
+        OptionSchema {
+            name: AUTH_BROWSER,
+            title: "Browser",
+            description: None,
+            default: "",
+            choices: &[],
+            required: false,
+        },
+        OptionSchema {
+            name: AUTH_PROFILE,
+            title: "Browser profile",
+            description: None,
+            default: "",
+            choices: &[],
+            required: false,
+        },
+    ],
     build,
 };
 
-fn build(_credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Cursor::new()?))
+fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Cursor::new(options)?))
+}
+
+/// The one local Cursor session a provider instance may read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Source {
+    CursorApp,
+    Browser {
+        browser: String,
+        profile: Option<String>,
+    },
+}
+
+impl Source {
+    fn from_options(options: &Options) -> Option<Self> {
+        match options.get(AUTH_SOURCE).map(String::as_str) {
+            Some(CURSOR_APP_SOURCE) => Some(Self::CursorApp),
+            Some(BROWSER_SOURCE) => {
+                let browser = options
+                    .get(AUTH_BROWSER)
+                    .map(String::as_str)
+                    .map(str::trim)
+                    .filter(|browser| !browser.is_empty())?;
+                let profile = options
+                    .get(AUTH_PROFILE)
+                    .map(String::as_str)
+                    .map(str::trim)
+                    .filter(|profile| !profile.is_empty())
+                    .map(str::to_owned);
+                Some(Self::Browser {
+                    browser: browser.to_owned(),
+                    profile,
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 pub struct Cursor {
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
+    source: Option<Source>,
     #[cfg(test)]
     base_url: Option<String>,
 }
 
 impl Cursor {
-    pub fn new() -> Result<Self, ProviderError> {
+    pub fn new(options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
+            source: Source::from_options(options),
             #[cfg(test)]
             base_url: None,
         })
@@ -166,6 +244,7 @@ impl Cursor {
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
+            source: None,
             base_url: None,
         })
     }
@@ -173,6 +252,12 @@ impl Cursor {
     #[cfg(test)]
     fn with_test_base(mut self, base_url: &str) -> Self {
         self.base_url = Some(base_url.trim_end_matches('/').to_owned());
+        self
+    }
+
+    #[cfg(test)]
+    fn with_options(mut self, options: Options) -> Self {
+        self.source = Source::from_options(&options);
         self
     }
 
@@ -224,93 +309,120 @@ impl Cursor {
             .map_err(|error| ProviderError::Client(redact_query(error)))
     }
 
-    /// Every `Cookie:` header a browser on this machine could send to cursor.com.
-    ///
-    /// Two passes over every profile of every browser, CodexBar's order: first the stores
-    /// holding one of the known session-cookie names, then — because the name has changed
-    /// before — any store holding cookies on Cursor's domains at all. The headers remain in
-    /// that order, but are not trusted on the name alone: [`Self::fetch_inner`] gives each
-    /// one the required summary request, then only moves to the next after an HTTP
-    /// credential rejection.
-    ///
-    /// A locked keyring is not an empty answer: a Chromium store's cookies are sealed with
-    /// a Secret Service password, so nothing can be said about them until it unlocks, and
-    /// the caller gets [`ProviderError::KeyringLocked`] — the waiting state, not a failure.
-    async fn session_headers(&self) -> Result<Vec<String>, ProviderError> {
+    /// The header from exactly the selected source, if it still contains a session.
+    async fn session_header(&self) -> Result<Option<String>, ProviderError> {
+        let Some(source) = &self.source else {
+            return Ok(None);
+        };
+        match source {
+            Source::CursorApp => Ok(self.home.as_deref().and_then(standalone_session_header)),
+            Source::Browser { browser, profile } => {
+                self.browser_session_header(browser, profile).await
+            }
+        }
+    }
+
+    /// The header from one selected browser, and optionally one selected profile.
+    async fn browser_session_header(
+        &self,
+        browser: &str,
+        profile: &Option<String>,
+    ) -> Result<Option<String>, ProviderError> {
         let stores = match &self.home {
             Some(home) => browser::stores_in(home),
             None => Vec::new(),
         };
-        let standalone = self.home.as_deref().and_then(standalone_session_header);
         let now = Timestamp::now();
         let mut keyring_locked = false;
-        let mut headers = Vec::new();
-        for strict in [true, false] {
-            for store in &stores {
-                let cookies = match store.cookies(&cookie_query(), self.storage.as_ref()).await {
-                    Ok(cookies) => cookies,
-                    Err(browser::CookieError::KeyringLocked) => {
-                        keyring_locked = true;
-                        continue;
-                    }
-                    // A database that does not open is a browser we cannot ask, not a
-                    // session that is not there; the next store may still hold one.
-                    Err(_) => continue,
-                };
-                let live: Vec<_> = cookies
-                    .into_iter()
-                    .filter(|cookie| cookie.is_live(now))
-                    .collect();
-                if live.is_empty() {
+
+        for store in stores.into_iter().filter(|store| {
+            store.browser.slug == browser
+                && profile
+                    .as_ref()
+                    .is_none_or(|profile| profile == &store.profile)
+        }) {
+            let cookies = match store.cookies(&cookie_query(), self.storage.as_ref()).await {
+                Ok(cookies) => cookies,
+                Err(browser::CookieError::KeyringLocked) => {
+                    keyring_locked = true;
                     continue;
                 }
-                let has_session = live
-                    .iter()
-                    .any(|cookie| SESSION_COOKIE_NAMES.contains(&cookie.name.as_str()));
-                if strict && !has_session {
-                    continue;
-                }
-                let header = browser::header(&live);
-                if !headers.contains(&header) {
-                    headers.push(header);
-                }
+                Err(_) => continue,
+            };
+            let live: Vec<_> = cookies
+                .into_iter()
+                .filter(|cookie| cookie.is_live(now))
+                .collect();
+            if live
+                .iter()
+                .any(|cookie| SESSION_COOKIE_NAMES.contains(&cookie.name.as_str()))
+            {
+                return Ok(Some(browser::header(&live)));
             }
         }
-        if let Some(header) = standalone
-            && !headers.contains(&header)
-        {
-            headers.push(header);
-        }
-        if headers.is_empty() && keyring_locked {
+        if keyring_locked {
             return Err(ProviderError::KeyringLocked);
         }
-        Ok(headers)
-    }
-
-    #[cfg(test)]
-    async fn session_header(&self) -> Result<Option<String>, ProviderError> {
-        Ok(self.session_headers().await?.into_iter().next())
+        Ok(None)
     }
 
     async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {
-        let headers = self.session_headers().await?;
-        if headers.is_empty() {
-            return Err(ProviderError::NoCredential);
-        }
-        let mut rejected = None;
-        for cookie in headers {
-            match self.fetch_with_cookie(&cookie).await {
-                Err(error @ ProviderError::Credential { .. }) => rejected = Some(error),
-                outcome => return outcome,
+        let cookie = self
+            .session_header()
+            .await?
+            .ok_or(ProviderError::NoCredential)?;
+        self.fetch_with_cookie(&cookie).await
+    }
+
+    /// Validates one header without reading or publishing its body.
+    async fn validate_header(&self, cookie: &str) -> crate::browser::auth::Validation {
+        let Ok(request) = self.get(&self.url(USAGE_SUMMARY_URL), cookie) else {
+            return crate::browser::auth::Validation::Unreachable;
+        };
+        match super::request(PROVIDER_ID, &self.client, request).await {
+            Ok(_) => crate::browser::auth::Validation::Ready,
+            Err(ProviderError::Credential { status: 401 | 403 }) => {
+                crate::browser::auth::Validation::Rejected
             }
+            Err(_) => crate::browser::auth::Validation::Unreachable,
         }
-        // `headers` was non-empty; reaching here means each candidate was explicitly
-        // rejected by Cursor, not that no browser had a session. The `None` branch is
-        // defensive against a future non-rejection retry rule changing above.
-        match rejected {
-            Some(error) => Err(error),
-            None => Err(ProviderError::NoCredential),
-        }
+    }
+
+    /// Inspects the standalone Cursor App and browser sources without returning cookies.
+    pub async fn inspect_sources(&self) -> Result<Vec<AuthCandidate>, ProviderError> {
+        let standalone = self.home.as_deref().and_then(standalone_session_header);
+        let standalone_state = match standalone.as_deref() {
+            Some(header) => validation_state(self.validate_header(header).await),
+            None => AuthCandidateState::Missing,
+        };
+        let browsers = crate::browser::auth::inspect(
+            self.home
+                .as_deref()
+                .map(browser::stores_in)
+                .unwrap_or_default(),
+            &session_query(),
+            self.storage.as_ref(),
+            |credential| async move { self.validate_header(credential.header()).await },
+        )
+        .await;
+        let browser_state = candidate_state(&browsers);
+
+        Ok(vec![
+            AuthCandidate {
+                id: CURSOR_APP_SOURCE.into(),
+                title: "Cursor App".into(),
+                subtitle: Some("Cursor's local session database".into()),
+                state: standalone_state.as_wire().into(),
+                children: Vec::new(),
+            },
+            AuthCandidate {
+                id: BROWSER_SOURCE.into(),
+                title: "Browser".into(),
+                subtitle: None,
+                state: browser_state.as_wire().into(),
+                children: browsers,
+            },
+        ])
     }
 
     async fn fetch_with_cookie(&self, cookie: &str) -> Result<Snapshot, ProviderError> {
@@ -353,6 +465,43 @@ impl Cursor {
             Timestamp::now(),
         )
     }
+}
+
+fn validation_state(validation: crate::browser::auth::Validation) -> AuthCandidateState {
+    match validation {
+        crate::browser::auth::Validation::Ready => AuthCandidateState::Ready,
+        crate::browser::auth::Validation::Rejected => AuthCandidateState::Rejected,
+        crate::browser::auth::Validation::Unreachable => AuthCandidateState::Unreachable,
+    }
+}
+
+fn candidate_state(candidates: &[AuthCandidate]) -> AuthCandidateState {
+    let states = candidates.iter().filter_map(AuthCandidate::state);
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Ready)
+    {
+        return AuthCandidateState::Ready;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::WaitingForKeyring)
+    {
+        return AuthCandidateState::WaitingForKeyring;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Unreachable)
+    {
+        return AuthCandidateState::Unreachable;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Rejected)
+    {
+        return AuthCandidateState::Rejected;
+    }
+    AuthCandidateState::Missing
 }
 
 /// Reads Cursor standalone's session JWT and reconstructs the cookie its dashboard accepts.
@@ -877,7 +1026,7 @@ fn parse(
 mod tests {
     use super::{Cursor, Options, SPEC, parse};
     use crate::providers::{Credential, ProviderError};
-    use tidemark_types::{CredentialKind, DetailSection, Timestamp};
+    use tidemark_types::{AuthCandidateState, CredentialKind, DetailSection, Timestamp};
 
     /// A live Pro account's `GET /api/usage-summary`, as CodexBar's own regression test
     /// records it: fractional lane percentages that are percentages, not fractions.
@@ -1191,7 +1340,7 @@ mod tests {
 
     #[test]
     fn every_request_carries_the_session_and_the_dashboard_post_carries_its_origin() {
-        let provider = Cursor::new().expect("builds");
+        let provider = Cursor::new(&Options::new()).expect("builds");
         let cookie = "WorkosCursorSessionToken=abc";
 
         let summary = provider
@@ -1237,7 +1386,13 @@ mod tests {
         assert_eq!(SPEC.id, "cursor");
         assert_eq!(SPEC.title, "Cursor");
         assert_eq!(SPEC.credential, CredentialKind::None);
-        assert!(SPEC.options.is_empty());
+        assert_eq!(
+            SPEC.options
+                .iter()
+                .map(|option| option.name)
+                .collect::<Vec<_>>(),
+            ["auth-source", "auth-browser", "auth-profile"]
+        );
 
         let provider =
             (SPEC.build)(Credential::new(String::new()), &Options::new()).expect("builds");
@@ -1372,7 +1527,21 @@ mod tests {
             .expect("no keyring state")
     }
 
-    fn session_server() -> (
+    fn cursor_options(source: &str, browser: Option<&str>, profile: Option<&str>) -> Options {
+        let mut options = Options::new();
+        options.insert("auth-source".into(), source.into());
+        if let Some(browser) = browser {
+            options.insert("auth-browser".into(), browser.into());
+        }
+        if let Some(profile) = profile {
+            options.insert("auth-profile".into(), profile.into());
+        }
+        options
+    }
+
+    fn session_server(
+        request_count: usize,
+    ) -> (
         String,
         std::sync::mpsc::Receiver<String>,
         std::thread::JoinHandle<()>,
@@ -1384,7 +1553,7 @@ mod tests {
         let address = listener.local_addr().expect("listener address");
         let (request_tx, request_rx) = std::sync::mpsc::channel();
         let server = std::thread::spawn(move || {
-            for _ in 0..4 {
+            for _ in 0..request_count {
                 let (mut stream, _) = listener.accept().expect("request accepted");
                 let mut reader = BufReader::new(&mut stream);
                 let mut request = String::new();
@@ -1407,7 +1576,11 @@ mod tests {
                 drop(reader);
 
                 let (status, response) =
-                    if request.contains("WorkosCursorSessionToken=expired-session") {
+                    if request.contains("WorkosCursorSessionToken=payment-required-session") {
+                        ("402 Payment Required", "{}")
+                    } else if request.contains("WorkosCursorSessionToken=forbidden-session") {
+                        ("403 Forbidden", "{}")
+                    } else if request.contains("WorkosCursorSessionToken=expired-session") {
                         ("401 Unauthorized", "{}")
                     } else if request.starts_with("GET /api/usage-summary ") {
                         ("200 OK", PRO)
@@ -1427,7 +1600,7 @@ mod tests {
     }
 
     #[test]
-    fn a_later_browser_session_is_used_after_an_earlier_one_is_rejected() {
+    fn a_selected_browser_rejection_does_not_try_another_profile() {
         let home = gecko_home(&[(
             ".cursor.com",
             "WorkosCursorSessionToken",
@@ -1459,28 +1632,21 @@ mod tests {
                 )
                 .expect("creates the working session");
         }
-        let (base, requests, server) = session_server();
+        let (base, requests, server) = session_server(1);
         let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
             .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), None))
             .with_test_base(&base);
 
-        let snapshot = tokio::runtime::Runtime::new()
+        let error = tokio::runtime::Runtime::new()
             .expect("runtime")
             .block_on(provider.fetch_inner())
-            .expect("the working session wins");
-        assert_eq!(snapshot.provider.as_str(), "cursor");
+            .expect_err("the selected session was rejected");
+        assert!(matches!(error, ProviderError::Credential { status: 401 }));
 
-        let requests: Vec<_> = (0..4)
-            .map(|_| requests.recv().expect("request captured"))
-            .collect();
+        let request = requests.recv().expect("the selected summary request");
+        assert!(request.contains("WorkosCursorSessionToken=expired-session"));
         server.join().expect("server stopped");
-        let summaries: Vec<_> = requests
-            .iter()
-            .filter(|request| request.starts_with("GET /api/usage-summary "))
-            .collect();
-        assert_eq!(summaries.len(), 2);
-        assert!(summaries[0].contains("WorkosCursorSessionToken=expired-session"));
-        assert!(summaries[1].contains("WorkosCursorSessionToken=working-session"));
     }
 
     #[test]
@@ -1490,7 +1656,9 @@ mod tests {
             (".cursor.com", "_ga", "analytics", 0),
             (".google.com", "NID", "not-ours", 0),
         ]);
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), None));
 
         let header = header_of(&provider).expect("a session");
         // The whole domain's cookies go on the wire, not just the session one.
@@ -1503,21 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn a_signed_in_cursor_desktop_app_supplies_the_session_header() {
-        let home =
-            cursor_home("eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature");
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
-
-        assert_eq!(
-            header_of(&provider).as_deref(),
-            Some(
-                "WorkosCursorSessionToken=user_cursor%3A%3AeyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature"
-            )
-        );
-    }
-
-    #[test]
-    fn a_cursor_desktop_session_is_tried_after_browser_sessions_are_rejected() {
+    fn the_cursor_app_source_never_reads_a_browser_session() {
         let home = gecko_home(&[(
             ".cursor.com",
             "WorkosCursorSessionToken",
@@ -1528,30 +1682,211 @@ mod tests {
             &home,
             "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature",
         );
-        let (base, requests, server) = session_server();
+        let (base, requests, server) = session_server(3);
         let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
             .expect("builds")
+            .with_options(cursor_options("cursor-app", None, None))
             .with_test_base(&base);
 
         let snapshot = tokio::runtime::Runtime::new()
             .expect("runtime")
             .block_on(provider.fetch_inner())
-            .expect("the standalone session wins after browser rejection");
+            .expect("the Cursor App session works");
         assert_eq!(snapshot.provider.as_str(), "cursor");
 
-        let requests: Vec<_> = (0..4)
+        let requests: Vec<_> = (0..3)
             .map(|_| requests.recv().expect("request captured"))
             .collect();
         server.join().expect("server stopped");
-        let summaries: Vec<_> = requests
-            .iter()
-            .filter(|request| request.starts_with("GET /api/usage-summary "))
+        assert!(
+            requests
+                .iter()
+                .all(|request| !request.contains("expired-session"))
+        );
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.contains("user_cursor%3A%3A"))
+        );
+    }
+
+    #[test]
+    fn a_selected_browser_profile_does_not_read_another_profile() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "expired-session",
+            0,
+        )]);
+        let other = home.gecko(".zen/zz99.Working");
+        {
+            use rusqlite::Connection;
+
+            let connection = Connection::open(other).expect("opens");
+            connection
+                .execute_batch(
+                    "CREATE TABLE moz_cookies (
+                        id INTEGER PRIMARY KEY,
+                        baseDomain TEXT,
+                        originAttributes TEXT NOT NULL DEFAULT '',
+                        name TEXT, value TEXT, host TEXT, path TEXT,
+                        expiry INTEGER, lastAccessed INTEGER, creationTime INTEGER,
+                        isSecure INTEGER, isHttpOnly INTEGER
+                    );
+                    INSERT INTO moz_cookies (
+                        host, name, value, path, expiry, isSecure, lastAccessed,
+                        creationTime, isHttpOnly
+                    ) VALUES (
+                        '.cursor.com', 'WorkosCursorSessionToken', 'working-session', '/', 0,
+                        1, 0, 0, 0
+                    );",
+                )
+                .expect("creates the working session");
+        }
+        let (base, requests, server) = session_server(3);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), Some("zz99.Working")))
+            .with_test_base(&base);
+
+        let snapshot = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect("the selected profile works");
+        assert_eq!(snapshot.provider.as_str(), "cursor");
+
+        let requests: Vec<_> = (0..3)
+            .map(|_| requests.recv().expect("request captured"))
             .collect();
-        assert_eq!(summaries.len(), 2);
-        assert!(summaries[0].contains("WorkosCursorSessionToken=expired-session"));
-        assert!(summaries[1].contains(
-            "WorkosCursorSessionToken=user_cursor%3A%3AeyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature"
-        ));
+        server.join().expect("server stopped");
+        assert!(
+            requests
+                .iter()
+                .all(|request| !request.contains("expired-session"))
+        );
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.contains("working-session"))
+        );
+    }
+
+    #[test]
+    fn the_source_inspection_reports_only_source_metadata() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "browser-session",
+            0,
+        )]);
+        cursor_state(
+            &home,
+            "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature",
+        );
+        let (base, requests, server) = session_server(2);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let sources = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.inspect_sources())
+            .expect("inspects");
+        let requests: Vec<_> = (0..2)
+            .map(|_| requests.recv().expect("request captured"))
+            .collect();
+        server.join().expect("server stopped");
+
+        assert_eq!(sources[0].id, "cursor-app");
+        assert_eq!(sources[0].state, "ready");
+        assert_eq!(sources[1].id, "browser");
+        assert_eq!(sources[1].children[0].id, "zen");
+        assert_eq!(
+            sources[1].children[0].children[0].id,
+            "k26qcf29.Default (release)"
+        );
+        assert!(!format!("{sources:?}").contains("browser-session"));
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.contains("browser-session"))
+        );
+    }
+
+    #[test]
+    fn a_payment_required_source_is_unreachable_during_inspection() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "payment-required-session",
+            0,
+        )]);
+        let (base, requests, server) = session_server(1);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let sources = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.inspect_sources())
+            .expect("inspects");
+        let _ = requests.recv().expect("the browser validation request");
+        server.join().expect("server stopped");
+
+        assert_eq!(
+            sources[1].children[0].children[0].state,
+            AuthCandidateState::Unreachable.as_wire()
+        );
+    }
+
+    #[test]
+    fn a_forbidden_source_is_rejected_during_inspection() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "forbidden-session",
+            0,
+        )]);
+        let (base, requests, server) = session_server(1);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let sources = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.inspect_sources())
+            .expect("inspects");
+        let _ = requests.recv().expect("the browser validation request");
+        server.join().expect("server stopped");
+
+        assert_eq!(
+            sources[1].children[0].children[0].state,
+            AuthCandidateState::Rejected.as_wire()
+        );
+    }
+
+    #[test]
+    fn a_signed_in_cursor_desktop_app_supplies_the_session_header() {
+        let home =
+            cursor_home("eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("cursor-app", None, None));
+
+        assert_eq!(
+            header_of(&provider).as_deref(),
+            Some(
+                "WorkosCursorSessionToken=user_cursor%3A%3AeyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature"
+            )
+        );
+    }
+
+    #[test]
+    fn an_unselected_provider_does_not_read_a_browser_session() {
+        let home = gecko_home(&[(".cursor.com", "WorkosCursorSessionToken", "the-session", 0)]);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert_eq!(header_of(&provider), None);
     }
 
     #[test]
@@ -1561,14 +1896,16 @@ mod tests {
             &home,
             "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature",
         );
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("cursor-app", None, None));
 
         assert!(header_of(&provider).is_some());
         drop(writer);
     }
 
     #[test]
-    fn a_known_session_name_wins_over_a_store_that_only_has_domain_cookies() {
+    fn a_selected_browser_skips_profiles_without_a_cursor_session() {
         let home = gecko_home(&[(".cursor.com", "_ga", "analytics", 0)]);
         // A second profile, later in the scan order, that holds the named session.
         let other = home.gecko(".zen/zz99.Other");
@@ -1597,22 +1934,26 @@ mod tests {
                 )
                 .expect("inserts");
         }
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), None));
 
         let header = header_of(&provider).expect("a session");
         assert!(header.contains("WorkosCursorSessionToken=the-session"));
         assert!(
             !header.contains("analytics"),
-            "the strict pass runs over every store before the fallback pass"
+            "analytics cookies do not become a Cursor session"
         );
     }
 
     #[test]
-    fn a_store_without_a_known_name_is_still_tried_in_the_fallback_pass() {
+    fn a_browser_cookie_without_a_known_session_name_is_not_a_credential() {
         let home = gecko_home(&[(".cursor.com", "_ga", "analytics", 0)]);
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), None));
 
-        assert_eq!(header_of(&provider).as_deref(), Some("_ga=analytics"));
+        assert_eq!(header_of(&provider), None);
     }
 
     #[test]
@@ -1623,7 +1964,9 @@ mod tests {
             "expired-session",
             1_600_000_000, // 2020
         )]);
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("zen"), None));
 
         assert_eq!(header_of(&provider), None);
     }
@@ -1631,7 +1974,9 @@ mod tests {
     #[test]
     fn a_machine_with_no_cursor_session_is_a_missing_credential_not_an_error() {
         let home = crate::browser::tests::TestHome::new();
-        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_options(cursor_options("cursor-app", None, None));
 
         assert_eq!(header_of(&provider), None);
     }
@@ -1641,7 +1986,9 @@ mod tests {
         let home = crate::browser::tests::TestHome::new();
         // A Chromium profile's cookies are sealed with the password this keyring holds.
         home.profile("chromium/Default", "Cookies");
-        let provider = Cursor::for_test(home.path(), Arc::new(LockedKeyring)).expect("builds");
+        let provider = Cursor::for_test(home.path(), Arc::new(LockedKeyring))
+            .expect("builds")
+            .with_options(cursor_options("browser", Some("chromium"), None));
 
         let result = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -63,10 +63,14 @@
 use super::{HandSpec, Options, ProviderError, redact_query};
 use crate::browser::{self, Keyring, SafeStorage};
 use crate::providers::{BoxFuture, Credential, Provider, http, parse_rfc3339, title_case};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL;
+use rusqlite::OptionalExtension;
 use serde::Deserialize;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tidemark_types::{
     AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
     WindowKey, WindowLength,
@@ -78,6 +82,12 @@ const USAGE_SUMMARY_URL: &str = "https://cursor.com/api/usage-summary";
 const AUTH_ME_URL: &str = "https://cursor.com/api/auth/me";
 const REQUEST_USAGE_URL: &str = "https://cursor.com/api/usage";
 const SAND_USAGE_URL: &str = "https://cursor.com/api/dashboard/get-sand-usage-status";
+
+/// Cursor's standalone desktop app keeps its sign-in token in this VS Code-style state store.
+const STATE_DATABASE: &str = ".config/Cursor/User/globalStorage/state.vscdb";
+
+/// The key Cursor uses for the raw JWT in [`STATE_DATABASE`].
+const ACCESS_TOKEN_KEY: &str = "cursorAuth/accessToken";
 
 /// What the dashboard POST must be sent from. Cursor refuses the Bot endpoint without it.
 const ORIGIN: &str = "https://cursor.com";
@@ -231,6 +241,7 @@ impl Cursor {
             Some(home) => browser::stores_in(home),
             None => Vec::new(),
         };
+        let standalone = self.home.as_deref().and_then(standalone_session_header);
         let now = Timestamp::now();
         let mut keyring_locked = false;
         let mut headers = Vec::new();
@@ -264,6 +275,11 @@ impl Cursor {
                     headers.push(header);
                 }
             }
+        }
+        if let Some(header) = standalone
+            && !headers.contains(&header)
+        {
+            headers.push(header);
         }
         if headers.is_empty() && keyring_locked {
             return Err(ProviderError::KeyringLocked);
@@ -337,6 +353,95 @@ impl Cursor {
             Timestamp::now(),
         )
     }
+}
+
+/// Reads Cursor standalone's session JWT and reconstructs the cookie its dashboard accepts.
+///
+/// The desktop app owns the database and may be writing it in WAL mode, so its files are
+/// copied into an owner-only temporary directory before SQLite opens them. A missing or changed
+/// store is just an unavailable credential source; browser sessions remain candidates.
+fn standalone_session_header(home: &Path) -> Option<String> {
+    let state = StateSnapshot::of(&home.join(STATE_DATABASE)).ok()?;
+    let connection = rusqlite::Connection::open_with_flags(
+        state.database(),
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .ok()?;
+    let token: String = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1",
+            [ACCESS_TOKEN_KEY],
+            |row| row.get(0),
+        )
+        .optional()
+        .ok()??;
+    standalone_cookie(&token)
+}
+
+/// Rebuilds the WorkOS session value Cursor's web dashboard derives from its access token.
+fn standalone_cookie(token: &str) -> Option<String> {
+    let claims = token.split('.').nth(1)?;
+    let claims = BASE64_URL.decode(claims).ok()?;
+    let subject = serde_json::from_slice::<StandaloneClaims>(&claims)
+        .ok()?
+        .sub;
+    let user = subject.split_once('|')?.1;
+    if user.trim().is_empty() {
+        return None;
+    }
+    Some(format!("WorkosCursorSessionToken={user}%3A%3A{token}"))
+}
+
+/// The only JWT claim needed to reconstruct the dashboard cookie.
+#[derive(Deserialize)]
+struct StandaloneClaims {
+    sub: String,
+}
+
+/// An owner-only temporary copy of Cursor standalone's SQLite database.
+#[derive(Debug)]
+struct StateSnapshot {
+    directory: PathBuf,
+}
+
+impl StateSnapshot {
+    fn of(path: &Path) -> std::io::Result<Self> {
+        use std::os::unix::fs::DirBuilderExt;
+
+        static SERIAL: AtomicU64 = AtomicU64::new(0);
+        let directory = std::env::temp_dir().join(format!(
+            "tidemark-cursor-state-{}-{}",
+            std::process::id(),
+            SERIAL.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::DirBuilder::new().mode(0o700).create(&directory)?;
+        let snapshot = Self { directory };
+        std::fs::copy(path, snapshot.database())?;
+        for sidecar in ["-wal", "-shm"] {
+            let source = with_suffix(path, sidecar);
+            if source.is_file() {
+                std::fs::copy(source, with_suffix(&snapshot.database(), sidecar))?;
+            }
+        }
+        Ok(snapshot)
+    }
+
+    fn database(&self) -> PathBuf {
+        self.directory.join("state.vscdb")
+    }
+}
+
+impl Drop for StateSnapshot {
+    fn drop(&mut self) {
+        // Best effort: the private copy has mode 0700, and a failed cleanup cannot be fixed.
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
 }
 
 impl fmt::Debug for Cursor {
@@ -1205,6 +1310,59 @@ mod tests {
         home
     }
 
+    /// A throwaway Cursor standalone state store holding its access token.
+    fn cursor_home(access_token: &str) -> crate::browser::tests::TestHome {
+        let home = crate::browser::tests::TestHome::new();
+        cursor_state(&home, access_token);
+        home
+    }
+
+    fn cursor_state(home: &crate::browser::tests::TestHome, access_token: &str) {
+        use rusqlite::Connection;
+
+        let path = home
+            .path()
+            .join(".config/Cursor/User/globalStorage/state.vscdb");
+        std::fs::create_dir_all(path.parent().expect("has parent")).expect("creates");
+        let connection = Connection::open(path).expect("opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+            )
+            .expect("creates the table");
+        connection
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('cursorAuth/accessToken', ?1)",
+                [access_token],
+            )
+            .expect("inserts the access token");
+    }
+
+    fn cursor_state_in_wal(
+        home: &crate::browser::tests::TestHome,
+        access_token: &str,
+    ) -> rusqlite::Connection {
+        let path = home
+            .path()
+            .join(".config/Cursor/User/globalStorage/state.vscdb");
+        std::fs::create_dir_all(path.parent().expect("has parent")).expect("creates");
+        let connection = rusqlite::Connection::open(path).expect("opens");
+        connection
+            .execute_batch(
+                "PRAGMA journal_mode = WAL;
+                 PRAGMA wal_autocheckpoint = 0;
+                 CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+            )
+            .expect("sets WAL mode and creates the table");
+        connection
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('cursorAuth/accessToken', ?1)",
+                [access_token],
+            )
+            .expect("inserts the access token");
+        connection
+    }
+
     fn header_of(provider: &Cursor) -> Option<String> {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1342,6 +1500,71 @@ mod tests {
             !header.contains("NID"),
             "other sites' cookies are never read"
         );
+    }
+
+    #[test]
+    fn a_signed_in_cursor_desktop_app_supplies_the_session_header() {
+        let home =
+            cursor_home("eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature");
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert_eq!(
+            header_of(&provider).as_deref(),
+            Some(
+                "WorkosCursorSessionToken=user_cursor%3A%3AeyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature"
+            )
+        );
+    }
+
+    #[test]
+    fn a_cursor_desktop_session_is_tried_after_browser_sessions_are_rejected() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "expired-session",
+            0,
+        )]);
+        cursor_state(
+            &home,
+            "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature",
+        );
+        let (base, requests, server) = session_server();
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let snapshot = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect("the standalone session wins after browser rejection");
+        assert_eq!(snapshot.provider.as_str(), "cursor");
+
+        let requests: Vec<_> = (0..4)
+            .map(|_| requests.recv().expect("request captured"))
+            .collect();
+        server.join().expect("server stopped");
+        let summaries: Vec<_> = requests
+            .iter()
+            .filter(|request| request.starts_with("GET /api/usage-summary "))
+            .collect();
+        assert_eq!(summaries.len(), 2);
+        assert!(summaries[0].contains("WorkosCursorSessionToken=expired-session"));
+        assert!(summaries[1].contains(
+            "WorkosCursorSessionToken=user_cursor%3A%3AeyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature"
+        ));
+    }
+
+    #[test]
+    fn a_cursor_desktop_session_committed_only_to_wal_is_found() {
+        let home = crate::browser::tests::TestHome::new();
+        let writer = cursor_state_in_wal(
+            &home,
+            "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhdXRoMHx1c2VyX2N1cnNvciJ9.signature",
+        );
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert!(header_of(&provider).is_some());
+        drop(writer);
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -1,0 +1,1428 @@
+//! Cursor plan usage, read from cursor.com with the session cookie a browser holds.
+//!
+//! # Why the credential is a browser session
+//!
+//! Cursor publishes no usage API and issues no API key for one. Every reader of this data —
+//! the dashboard, and CodexBar, which this port follows — authenticates with the
+//! `WorkosCursorSessionToken` cookie a browser session holds. CodexBar on Linux makes the
+//! user copy that header out of the browser's network panel by hand; Tidemark instead reads
+//! the cookie itself, out of every browser on the machine, on every poll — which is also
+//! what keeps the reading alive when the session rolls over. The reading machinery is
+//! [`crate::browser`]; this module only names the domains and the cookie names.
+//!
+//! Which cookies count, and in what order they are tried, is CodexBar's ladder: a strict
+//! pass that requires one of the known session-cookie names to be present, then a fallback
+//! pass that takes any cookies on Cursor's domains at all, because the session name has
+//! changed before and the API is the arbiter of what still works.
+//!
+//! # The four requests
+//!
+//! Only the first is the reading:
+//!
+//! - `GET /api/usage-summary` — the plan window and its lanes. **Required.**
+//! - `GET /api/auth/me` — email, name, and the `sub` the legacy endpoint is keyed by.
+//! - `GET /api/usage?user=<sub>` — the request quota of a legacy, request-based plan.
+//! - `POST /api/dashboard/get-sand-usage-status` — the weekly Grok Bot allowance. Cursor
+//!   calls the feature "sand" internally; the dashboard calls it Grok Bot. It is a
+//!   cross-site POST, so it needs `Origin: https://cursor.com` or Cursor rejects it.
+//!
+//! The three supplementary requests are asked of accounts that have nothing to answer with
+//! — an account on a modern plan has no request quota, one without a Bot allowance has no
+//! Bot window — so a request that *fails* leaves its section absent rather than failing the
+//! poll. A supplementary request that *answers* and cannot be read is a different thing:
+//! `/api/usage` and the Bot endpoint each describe a window, and a window we cannot read is
+//! the malformed case this workspace fails on rather than silently drops. Identity answers
+//! no window, so an unreadable one costs only the detail rows.
+//!
+//! # What the numbers mean
+//!
+//! Every `used`/`limit`/`remaining` in the summary is **cents**: `7384` is $73.84. Every
+//! `*PercentUsed` is already a percentage even when it is below 1.0 — `0.36` means 0.36% of
+//! the plan, which the dashboard rounds to 0% — so nothing here multiplies a percent by a
+//! hundred.
+//!
+//! The headline percentage takes the first of these Cursor reports, which is the ladder
+//! CodexBar arrived at against live Pro, Team and Enterprise accounts: `plan.totalPercentUsed`,
+//! then the mean of the two lane percentages, then either lane alone, then `plan`'s own
+//! cents ratio, then `individualUsage.overall` (the personal cap an Enterprise seat gets
+//! instead of a `plan` block), then `teamUsage.pooled` (the shared pool, when the account
+//! reports no individual usage at all). An account that reports none of them is at 0%,
+//! which is what Cursor's own dashboard shows it as.
+//!
+//! # Windows
+//!
+//! A billing cycle is a month, and a month is not a fixed number of seconds, so the keys
+//! here name their pool rather than deriving from a length that would change between a
+//! 30-day and a 31-day cycle and split the history in two. The length is still published
+//! when Cursor states both ends of the cycle, because that is what draws the pace mark.
+//!
+//! A legacy request-based plan replaces the lane bars rather than joining them: its
+//! percentages come from the token-based pricing that plan is not on, so showing them
+//! beside a request quota would be showing a person two unrelated readings of one account.
+
+use super::{HandSpec, Options, ProviderError, redact_query};
+use crate::browser::{self, Keyring, SafeStorage};
+use crate::providers::{BoxFuture, Credential, Provider, http, parse_rfc3339, title_case};
+use serde::Deserialize;
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tidemark_types::{
+    AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
+    WindowKey, WindowLength,
+};
+
+pub const PROVIDER_ID: &str = "cursor";
+
+const USAGE_SUMMARY_URL: &str = "https://cursor.com/api/usage-summary";
+const AUTH_ME_URL: &str = "https://cursor.com/api/auth/me";
+const REQUEST_USAGE_URL: &str = "https://cursor.com/api/usage";
+const SAND_USAGE_URL: &str = "https://cursor.com/api/dashboard/get-sand-usage-status";
+
+/// What the dashboard POST must be sent from. Cursor refuses the Bot endpoint without it.
+const ORIGIN: &str = "https://cursor.com";
+
+/// The cookie names Cursor has carried its session in, newest scheme first. WorkOS is the
+/// current one; the Auth.js (`next-auth`/`authjs`) names are what older sessions were filed
+/// under. Presence of any one of them is what makes a browser's cookies worth trying.
+const SESSION_COOKIE_NAMES: &[&str] = &[
+    "WorkosCursorSessionToken",
+    "__Secure-next-auth.session-token",
+    "next-auth.session-token",
+    "wos-session",
+    "__Secure-wos-session",
+    "authjs.session-token",
+    "__Secure-authjs.session-token",
+];
+
+/// The hosts a Cursor session can live on, including the authenticator the sign-in flow
+/// goes through.
+const COOKIE_DOMAINS: &[&str] = &[
+    "cursor.com",
+    "www.cursor.com",
+    "cursor.sh",
+    "authenticator.cursor.sh",
+];
+
+/// The query every store is read with: everything on Cursor's domains, no name filter —
+/// the session names are a gate on the result, not the query, because the header that goes
+/// on the wire carries the domain's other cookies too.
+fn cookie_query() -> browser::Query {
+    browser::Query::new(COOKIE_DOMAINS.iter().copied(), Vec::<String>::new())
+}
+
+pub static SPEC: HandSpec = HandSpec {
+    id: PROVIDER_ID,
+    title: "Cursor",
+    // Nothing is asked of the user: the credential is the session a browser on this
+    // machine already holds, so the settings dialog draws no credential row at all.
+    credential: CredentialKind::None,
+    credential_hint: "",
+    options: &[],
+    build,
+};
+
+fn build(_credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Cursor::new()?))
+}
+
+pub struct Cursor {
+    client: reqwest::Client,
+    home: Option<PathBuf>,
+    storage: Arc<dyn SafeStorage>,
+    #[cfg(test)]
+    base_url: Option<String>,
+}
+
+impl Cursor {
+    pub fn new() -> Result<Self, ProviderError> {
+        Ok(Self {
+            client: http::client()?,
+            home: std::env::var_os("HOME").map(PathBuf::from),
+            storage: Arc::new(Keyring),
+            #[cfg(test)]
+            base_url: None,
+        })
+    }
+
+    /// A client reading browsers under a stated home directory with a stated keyring — the
+    /// seam the tests pull on, so no test ever touches the real browser it runs beside.
+    #[cfg(test)]
+    fn for_test(
+        home: &std::path::Path,
+        storage: Arc<dyn SafeStorage>,
+    ) -> Result<Self, ProviderError> {
+        Ok(Self {
+            client: http::client()?,
+            home: Some(home.to_path_buf()),
+            storage,
+            base_url: None,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_test_base(mut self, base_url: &str) -> Self {
+        self.base_url = Some(base_url.trim_end_matches('/').to_owned());
+        self
+    }
+
+    fn url(&self, production: &'static str) -> String {
+        #[cfg(test)]
+        if let Some(base_url) = &self.base_url {
+            let path = production
+                .strip_prefix("https://cursor.com")
+                .expect("Cursor endpoints share the Cursor origin");
+            return format!("{base_url}{path}");
+        }
+        production.to_owned()
+    }
+
+    fn get(&self, url: &str, cookie: &str) -> Result<reqwest::Request, ProviderError> {
+        self.client
+            .get(url)
+            .header(reqwest::header::COOKIE, cookie)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .build()
+            .map_err(|error| ProviderError::Client(redact_query(error)))
+    }
+
+    /// The legacy request-quota call. The account id rides the query string because that is
+    /// where Cursor takes it; [`redact_query`] keeps it out of any error we render.
+    fn request_usage_request(
+        &self,
+        user: &str,
+        cookie: &str,
+    ) -> Result<reqwest::Request, ProviderError> {
+        self.client
+            .get(self.url(REQUEST_USAGE_URL))
+            .query(&[("user", user)])
+            .header(reqwest::header::COOKIE, cookie)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .build()
+            .map_err(|error| ProviderError::Client(redact_query(error)))
+    }
+
+    fn sand_usage_request(&self, cookie: &str) -> Result<reqwest::Request, ProviderError> {
+        self.client
+            .post(self.url(SAND_USAGE_URL))
+            .header(reqwest::header::COOKIE, cookie)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(reqwest::header::ORIGIN, ORIGIN)
+            .body("{}")
+            .build()
+            .map_err(|error| ProviderError::Client(redact_query(error)))
+    }
+
+    /// Every `Cookie:` header a browser on this machine could send to cursor.com.
+    ///
+    /// Two passes over every profile of every browser, CodexBar's order: first the stores
+    /// holding one of the known session-cookie names, then — because the name has changed
+    /// before — any store holding cookies on Cursor's domains at all. The headers remain in
+    /// that order, but are not trusted on the name alone: [`Self::fetch_inner`] gives each
+    /// one the required summary request, then only moves to the next after an HTTP
+    /// credential rejection.
+    ///
+    /// A locked keyring is not an empty answer: a Chromium store's cookies are sealed with
+    /// a Secret Service password, so nothing can be said about them until it unlocks, and
+    /// the caller gets [`ProviderError::KeyringLocked`] — the waiting state, not a failure.
+    async fn session_headers(&self) -> Result<Vec<String>, ProviderError> {
+        let stores = match &self.home {
+            Some(home) => browser::stores_in(home),
+            None => Vec::new(),
+        };
+        let now = Timestamp::now();
+        let mut keyring_locked = false;
+        let mut headers = Vec::new();
+        for strict in [true, false] {
+            for store in &stores {
+                let cookies = match store.cookies(&cookie_query(), self.storage.as_ref()).await {
+                    Ok(cookies) => cookies,
+                    Err(browser::CookieError::KeyringLocked) => {
+                        keyring_locked = true;
+                        continue;
+                    }
+                    // A database that does not open is a browser we cannot ask, not a
+                    // session that is not there; the next store may still hold one.
+                    Err(_) => continue,
+                };
+                let live: Vec<_> = cookies
+                    .into_iter()
+                    .filter(|cookie| cookie.is_live(now))
+                    .collect();
+                if live.is_empty() {
+                    continue;
+                }
+                let has_session = live
+                    .iter()
+                    .any(|cookie| SESSION_COOKIE_NAMES.contains(&cookie.name.as_str()));
+                if strict && !has_session {
+                    continue;
+                }
+                let header = browser::header(&live);
+                if !headers.contains(&header) {
+                    headers.push(header);
+                }
+            }
+        }
+        if headers.is_empty() && keyring_locked {
+            return Err(ProviderError::KeyringLocked);
+        }
+        Ok(headers)
+    }
+
+    #[cfg(test)]
+    async fn session_header(&self) -> Result<Option<String>, ProviderError> {
+        Ok(self.session_headers().await?.into_iter().next())
+    }
+
+    async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {
+        let headers = self.session_headers().await?;
+        if headers.is_empty() {
+            return Err(ProviderError::NoCredential);
+        }
+        let mut rejected = None;
+        for cookie in headers {
+            match self.fetch_with_cookie(&cookie).await {
+                Err(error @ ProviderError::Credential { .. }) => rejected = Some(error),
+                outcome => return outcome,
+            }
+        }
+        // `headers` was non-empty; reaching here means each candidate was explicitly
+        // rejected by Cursor, not that no browser had a session. The `None` branch is
+        // defensive against a future non-rejection retry rule changing above.
+        match rejected {
+            Some(error) => Err(error),
+            None => Err(ProviderError::NoCredential),
+        }
+    }
+
+    async fn fetch_with_cookie(&self, cookie: &str) -> Result<Snapshot, ProviderError> {
+        let summary_request = self.get(&self.url(USAGE_SUMMARY_URL), cookie)?;
+        let summary = super::request(&self.client, summary_request).await?;
+        let identity_request = self.get(&self.url(AUTH_ME_URL), cookie)?;
+        let sand_request = self.sand_usage_request(cookie)?;
+        let (identity, sand) = tokio::join!(
+            super::request(&self.client, identity_request),
+            super::request(&self.client, sand_request),
+        );
+        // Both are supplementary: a failure here is an account with nothing to say, not a
+        // poll that went wrong. See the module note.
+        let identity = identity.ok();
+        let sand = sand.ok();
+
+        // The legacy quota is keyed by the account id, so it can only be asked for after
+        // identity answered. Parsed here as well as in `parse` so that `parse` stays a pure
+        // function of the bodies.
+        let subject = identity
+            .as_deref()
+            .and_then(|body| serde_json::from_str::<UserInfo>(body).ok())
+            .and_then(|user| user.sub)
+            .filter(|sub| !sub.trim().is_empty());
+        let legacy = match subject {
+            Some(subject) => {
+                let request = self.request_usage_request(&subject, cookie)?;
+                super::request(&self.client, request).await.ok()
+            }
+            None => None,
+        };
+
+        parse(
+            &summary,
+            identity.as_deref(),
+            legacy.as_deref(),
+            sand.as_deref(),
+            Timestamp::now(),
+        )
+    }
+}
+
+impl fmt::Debug for Cursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cursor")
+            .field("id", &PROVIDER_ID)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Provider for Cursor {
+    fn id(&self) -> ProviderId {
+        ProviderId::new(PROVIDER_ID)
+    }
+
+    fn account(&self) -> AccountId {
+        AccountId::default()
+    }
+
+    fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+        Box::pin(self.fetch_inner())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Summary {
+    billing_cycle_start: Option<String>,
+    billing_cycle_end: Option<String>,
+    membership_type: Option<String>,
+    individual_usage: Option<IndividualUsage>,
+    team_usage: Option<TeamUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IndividualUsage {
+    plan: Option<PlanUsage>,
+    on_demand: Option<Amounts>,
+    /// The personal cap an Enterprise or Team seat gets *instead of* a `plan` block.
+    overall: Option<Amounts>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TeamUsage {
+    on_demand: Option<Amounts>,
+    /// The shared pool a whole team draws on.
+    pooled: Option<Amounts>,
+}
+
+/// Cents used against cents allowed. `limit` absent means the budget is uncapped.
+#[derive(Debug, Deserialize)]
+struct Amounts {
+    used: Option<f64>,
+    limit: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PlanUsage {
+    used: Option<f64>,
+    limit: Option<f64>,
+    /// Cursor's own models, the lane the dashboard calls "Cursor". Already a percentage.
+    auto_percent_used: Option<f64>,
+    /// Named third-party models. Already a percentage.
+    api_percent_used: Option<f64>,
+    /// The headline. Already a percentage.
+    total_percent_used: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserInfo {
+    email: Option<String>,
+    name: Option<String>,
+    /// The account id `/api/usage` is keyed by, in its `auth0|…` spelling.
+    sub: Option<String>,
+}
+
+/// `GET /api/usage?user=…`: the request counter of a legacy, request-based plan.
+#[derive(Debug, Deserialize)]
+struct RequestUsage {
+    /// Every legacy plan reports its counter under the model that plan was sold with.
+    #[serde(rename = "gpt-4")]
+    gpt4: Option<ModelUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ModelUsage {
+    num_requests: Option<f64>,
+    num_requests_total: Option<f64>,
+    /// Present only on a request-based plan. Its presence is what identifies one.
+    max_request_usage: Option<f64>,
+}
+
+/// `POST /api/dashboard/get-sand-usage-status`: the weekly Grok Bot allowance.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SandUsage {
+    current_period_start: Option<String>,
+    next_reset_timestamp_utc: Option<String>,
+    usage_percent: Option<f64>,
+    /// False for an account with no included Bot allowance, which therefore has no window.
+    has_non_zero_included_limit: Option<bool>,
+}
+
+/// A percentage Cursor states, refused when it is not a number and clamped to the range a
+/// bar can be drawn in.
+fn percent(value: Option<f64>, field: &str) -> Result<Option<f64>, ProviderError> {
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_finite() => Ok(Some(value.clamp(0.0, 100.0))),
+        Some(_) => Err(ProviderError::malformed(format!(
+            "{field} is not a finite number"
+        ))),
+    }
+}
+
+/// A quantity Cursor states — cents, or a request count — refused when it is not a number.
+fn number(value: Option<f64>, field: &str) -> Result<Option<f64>, ProviderError> {
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_finite() => Ok(Some(value)),
+        Some(_) => Err(ProviderError::malformed(format!(
+            "{field} is not a finite number"
+        ))),
+    }
+}
+
+/// The percentage a used/allowed pair states, or `None` when there is no allowance to
+/// divide by — a limit of zero is Cursor saying "no cap here", not "everything is spent".
+fn ratio(used: Option<f64>, limit: Option<f64>) -> Option<f64> {
+    let limit = limit.filter(|limit| *limit > 0.0)?;
+    Some((used.unwrap_or(0.0) / limit * 100.0).clamp(0.0, 100.0))
+}
+
+/// An instant Cursor states, refused when it is stated and unreadable: a reset time this
+/// build cannot parse is not a reset time it may quietly drop.
+fn instant(raw: Option<&str>, field: &str) -> Result<Option<Timestamp>, ProviderError> {
+    match raw.map(str::trim).filter(|raw| !raw.is_empty()) {
+        None => Ok(None),
+        Some(raw) => parse_rfc3339(raw).map(Some).ok_or_else(|| {
+            ProviderError::malformed(format!("{field} is not a readable timestamp"))
+        }),
+    }
+}
+
+/// How long a period lasts, from the two ends of it Cursor names.
+fn length_between(start: Option<Timestamp>, end: Option<Timestamp>) -> Option<WindowLength> {
+    let (start, end) = (start?, end?);
+    u64::try_from(start.seconds_until(end))
+        .ok()
+        .and_then(WindowLength::from_secs)
+}
+
+/// Cursor's own word for a plan, in the spelling it puts in front of a person: `pro_plus`
+/// is Pro+, `express` is Start. A level this build has not seen keeps Cursor's own word,
+/// re-cased.
+fn membership(raw: &str) -> String {
+    let named = match raw.trim().to_lowercase().as_str() {
+        "enterprise" => "Enterprise".to_owned(),
+        "express" => "Start".to_owned(),
+        "free" => "Free".to_owned(),
+        "free_trial" => "Pro Trial".to_owned(),
+        "hobby" => "Hobby".to_owned(),
+        "pro" | "pro_student" => "Pro".to_owned(),
+        "pro_plus" => "Pro+".to_owned(),
+        "team" => "Team".to_owned(),
+        "ultra" => "Ultra".to_owned(),
+        _ => title_case(raw),
+    };
+    format!("Cursor {named}")
+}
+
+/// A budget in the dollars Cursor holds it in cents: `$4.50 / $10.00`, or the spend alone
+/// when the budget is uncapped, which is what an absent limit means.
+fn money(used: f64, limit: Option<f64>) -> String {
+    match limit.filter(|limit| *limit > 0.0) {
+        Some(limit) => format!("${:.2} / ${:.2}", used / 100.0, limit / 100.0),
+        None => format!("${:.2}", used / 100.0),
+    }
+}
+
+fn parse(
+    summary_body: &str,
+    identity_body: Option<&str>,
+    legacy_body: Option<&str>,
+    sand_body: Option<&str>,
+    captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    let summary: Summary = serde_json::from_str(summary_body)
+        .map_err(|e| ProviderError::malformed(format!("unreadable usage summary: {e}")))?;
+    // Identity describes no window, so an unreadable one costs detail rows and nothing else.
+    let identity = identity_body.and_then(|body| serde_json::from_str::<UserInfo>(body).ok());
+    let legacy = legacy_body
+        .map(|body| {
+            serde_json::from_str::<RequestUsage>(body)
+                .map_err(|e| ProviderError::malformed(format!("unreadable request usage: {e}")))
+        })
+        .transpose()?;
+    let sand = sand_body
+        .map(|body| {
+            serde_json::from_str::<SandUsage>(body)
+                .map_err(|e| ProviderError::malformed(format!("unreadable Grok Bot usage: {e}")))
+        })
+        .transpose()?;
+
+    let cycle_start = instant(summary.billing_cycle_start.as_deref(), "billingCycleStart")?;
+    let cycle_end = instant(summary.billing_cycle_end.as_deref(), "billingCycleEnd")?;
+    let cycle_length = length_between(cycle_start, cycle_end);
+
+    let individual = summary.individual_usage.as_ref();
+    let plan = individual.and_then(|usage| usage.plan.as_ref());
+    let overall = individual.and_then(|usage| usage.overall.as_ref());
+    let pooled = summary
+        .team_usage
+        .as_ref()
+        .and_then(|usage| usage.pooled.as_ref());
+
+    let auto = percent(
+        plan.and_then(|plan| plan.auto_percent_used),
+        "autoPercentUsed",
+    )?;
+    let api = percent(
+        plan.and_then(|plan| plan.api_percent_used),
+        "apiPercentUsed",
+    )?;
+    let total = percent(
+        plan.and_then(|plan| plan.total_percent_used),
+        "totalPercentUsed",
+    )?;
+
+    let plan_used = number(plan.and_then(|plan| plan.used), "plan.used")?;
+    let plan_limit = number(plan.and_then(|plan| plan.limit), "plan.limit")?;
+    let overall_used = number(overall.and_then(|overall| overall.used), "overall.used")?;
+    let overall_limit = number(overall.and_then(|overall| overall.limit), "overall.limit")?;
+    let pooled_used = number(pooled.and_then(|pooled| pooled.used), "pooled.used")?;
+    let pooled_limit = number(pooled.and_then(|pooled| pooled.limit), "pooled.limit")?;
+
+    // The ladder in the module note, in order.
+    let headline = total
+        .or_else(|| match (auto, api) {
+            (Some(auto), Some(api)) => Some(((auto + api) / 2.0).clamp(0.0, 100.0)),
+            _ => None,
+        })
+        .or(api)
+        .or(auto)
+        .or_else(|| ratio(plan_used, plan_limit))
+        .or_else(|| match (overall_used, overall_limit) {
+            (Some(used), limit) => ratio(Some(used), limit),
+            _ => None,
+        })
+        .or_else(|| match (pooled_used, pooled_limit) {
+            (Some(used), limit) => ratio(Some(used), limit),
+            _ => None,
+        })
+        .unwrap_or(0.0);
+
+    // The absolutes under the headline bar come from whichever block the account is
+    // actually metered against, so they never contradict the percentage above them.
+    let (usd_used, usd_limit) = if plan_used.unwrap_or(0.0) > 0.0 || plan_limit.unwrap_or(0.0) > 0.0
+    {
+        (plan_used.unwrap_or(0.0), plan_limit)
+    } else if let (Some(used), Some(limit)) = (overall_used, overall_limit) {
+        (used, Some(limit))
+    } else if let (Some(used), Some(limit)) = (pooled_used, pooled_limit) {
+        (used, Some(limit))
+    } else {
+        (0.0, None)
+    };
+
+    // A request-based plan is identified by the presence of a request ceiling, and reads
+    // only when the counter beside it is there too.
+    let requests = match legacy.and_then(|legacy| legacy.gpt4) {
+        Some(model) => {
+            let limit = number(model.max_request_usage, "maxRequestUsage")?;
+            let used = number(
+                model.num_requests_total.or(model.num_requests),
+                "numRequests",
+            )?;
+            match (used, limit.filter(|limit| *limit > 0.0)) {
+                (Some(used), Some(limit)) => Some((used, limit)),
+                _ => None,
+            }
+        }
+        None => None,
+    };
+
+    let mut windows = Vec::new();
+    if let Some((used, limit)) = requests {
+        // A legacy plan meters requests, not dollars, so this is a different pool from the
+        // one the lanes below describe and carries a key of its own. Named rather than
+        // keyed by length: the billing month it resets with is not a fixed span.
+        windows.push(Window {
+            key: WindowKey::named("requests"),
+            title: "Requests".to_owned(),
+            subtitle: Some(format!("{used:.0} / {limit:.0} requests")),
+            used_percent: (used / limit * 100.0).clamp(0.0, 100.0),
+            resets_at: cycle_end,
+            length: cycle_length,
+        });
+    } else {
+        windows.push(Window {
+            // Named for the same reason as above: one plan pool, on a month that is not a
+            // fixed number of seconds.
+            key: WindowKey::named("plan"),
+            title: "Total".to_owned(),
+            subtitle: usd_limit
+                .filter(|limit| *limit > 0.0)
+                .map(|limit| money(usd_used, Some(limit))),
+            used_percent: headline,
+            resets_at: cycle_end,
+            length: cycle_length,
+        });
+        // The two lanes the headline is composed of. Cursor states them as percentages
+        // only, so there is nothing to print under the bars.
+        for (key, title, value) in [("auto", "Cursor", auto), ("api", "Third Party", api)] {
+            if let Some(used_percent) = value {
+                windows.push(Window {
+                    key: WindowKey::named(key),
+                    title: title.to_owned(),
+                    subtitle: None,
+                    used_percent,
+                    resets_at: cycle_end,
+                    length: cycle_length,
+                });
+            }
+        }
+        // The Bot allowance is weekly and separate from the billing cycle. Its own pool,
+        // its own period, and absent entirely for an account with no included limit.
+        if let Some(sand) = sand.filter(|sand| sand.has_non_zero_included_limit == Some(true))
+            && let Some(used_percent) = percent(sand.usage_percent, "usagePercent")?
+        {
+            let start = instant(sand.current_period_start.as_deref(), "currentPeriodStart")?;
+            let resets_at = instant(
+                sand.next_reset_timestamp_utc.as_deref(),
+                "nextResetTimestampUtc",
+            )?;
+            windows.push(Window {
+                key: WindowKey::named("grok-bot"),
+                title: "Grok Bot".to_owned(),
+                subtitle: None,
+                used_percent,
+                resets_at,
+                length: length_between(start, resets_at),
+            });
+        }
+    }
+
+    let mut details = Vec::new();
+    if let Some(level) = summary
+        .membership_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|level| !level.is_empty())
+    {
+        details.push(DetailSection {
+            title: DetailSection::PLAN.to_owned(),
+            rows: vec![DetailRow {
+                label: "Plan".to_owned(),
+                value: membership(level),
+            }],
+        });
+    }
+
+    // On-demand spend is money past the plan, not a quota that drains: it belongs beside
+    // the account rather than under a bar.
+    let mut usage = Vec::new();
+    if let Some(on_demand) = individual.and_then(|usage| usage.on_demand.as_ref()) {
+        let used = number(on_demand.used, "onDemand.used")?.unwrap_or(0.0);
+        let limit = number(on_demand.limit, "onDemand.limit")?;
+        if used > 0.0 || limit.is_some_and(|limit| limit > 0.0) {
+            usage.push(DetailRow {
+                label: "On-demand".to_owned(),
+                value: money(used, limit),
+            });
+        }
+    }
+    if let Some(on_demand) = summary
+        .team_usage
+        .as_ref()
+        .and_then(|usage| usage.on_demand.as_ref())
+    {
+        let used = number(on_demand.used, "teamUsage.onDemand.used")?.unwrap_or(0.0);
+        let limit = number(on_demand.limit, "teamUsage.onDemand.limit")?;
+        if used > 0.0 || limit.is_some_and(|limit| limit > 0.0) {
+            usage.push(DetailRow {
+                label: "Team on-demand".to_owned(),
+                value: money(used, limit),
+            });
+        }
+    }
+    if !usage.is_empty() {
+        details.push(DetailSection {
+            title: "Usage".to_owned(),
+            rows: usage,
+        });
+    }
+
+    let mut account = Vec::new();
+    if let Some(identity) = identity.as_ref() {
+        for (label, value) in [("Email", &identity.email), ("Name", &identity.name)] {
+            if let Some(value) = value
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                account.push(DetailRow {
+                    label: label.to_owned(),
+                    value: value.to_owned(),
+                });
+            }
+        }
+    }
+    if !account.is_empty() {
+        details.push(DetailSection {
+            title: "Account".to_owned(),
+            rows: account,
+        });
+    }
+
+    Ok(Snapshot {
+        provider: ProviderId::new(PROVIDER_ID),
+        account: AccountId::default(),
+        captured_at,
+        windows,
+        details,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cursor, Options, SPEC, parse};
+    use crate::providers::{Credential, ProviderError};
+    use tidemark_types::{CredentialKind, DetailSection, Timestamp};
+
+    /// A live Pro account's `GET /api/usage-summary`, as CodexBar's own regression test
+    /// records it: fractional lane percentages that are percentages, not fractions.
+    const PRO: &str = r#"{
+      "billingCycleStart": "2026-03-18T20:45:42.000Z",
+      "billingCycleEnd": "2026-04-18T20:45:42.000Z",
+      "membershipType": "pro",
+      "limitType": "user",
+      "isUnlimited": false,
+      "autoModelSelectedDisplayMessage": "You've used 1% of your included total usage",
+      "namedModelSelectedDisplayMessage": "You've used 1% of your included API usage",
+      "individualUsage": {
+        "plan": {
+          "enabled": true,
+          "used": 86,
+          "limit": 2000,
+          "remaining": 1914,
+          "breakdown": { "included": 86, "bonus": 0, "total": 86 },
+          "autoPercentUsed": 0.36,
+          "apiPercentUsed": 0.7111111111111111,
+          "totalPercentUsed": 0.441025641025641
+        },
+        "onDemand": { "enabled": false, "used": 0, "limit": null, "remaining": null }
+      },
+      "teamUsage": { "onDemand": null }
+    }"#;
+
+    /// A live Enterprise account, sanitized: no `plan` block at all, a personal cap under
+    /// `individualUsage.overall`, and the shared pool beside it.
+    const ENTERPRISE: &str = r#"{
+      "billingCycleStart": "2026-04-01T00:00:00.000Z",
+      "billingCycleEnd": "2026-05-01T00:00:00.000Z",
+      "membershipType": "enterprise",
+      "limitType": "team",
+      "isUnlimited": false,
+      "individualUsage": {
+        "overall": { "enabled": true, "used": 7384, "limit": 10000, "remaining": 2616 }
+      },
+      "teamUsage": {
+        "onDemand": { "enabled": true, "used": 0, "limit": null, "remaining": null },
+        "pooled": {
+          "enabled": true,
+          "used": 12725135,
+          "limit": 28122000,
+          "remaining": 15396865
+        }
+      }
+    }"#;
+
+    /// A Pro account with both on-demand budgets reported.
+    const BUDGETS: &str = r#"{
+      "billingCycleStart": "2025-01-01T00:00:00.000Z",
+      "billingCycleEnd": "2025-02-01T00:00:00.000Z",
+      "membershipType": "pro",
+      "individualUsage": {
+        "plan": {
+          "enabled": true,
+          "used": 1500,
+          "limit": 5000,
+          "remaining": 3500,
+          "totalPercentUsed": 30.0
+        },
+        "onDemand": { "enabled": true, "used": 500, "limit": 10000, "remaining": 9500 }
+      },
+      "teamUsage": {
+        "onDemand": { "enabled": true, "used": 2000, "limit": 50000, "remaining": 48000 }
+      }
+    }"#;
+
+    const IDENTITY: &str = r#"{"email":"user@example.com","email_verified":true,"name":"Test User","sub":"auth0|user_test"}"#;
+
+    /// `GET /api/usage?user=…` for a legacy request-based plan.
+    const LEGACY: &str =
+        r#"{"gpt-4":{"numRequests":200,"numRequestsTotal":240,"maxRequestUsage":500}}"#;
+
+    /// `POST /api/dashboard/get-sand-usage-status` for an account with a Bot allowance.
+    const SAND: &str = r#"{
+      "currentPeriodStart": "2026-08-17T07:57:50.647Z",
+      "nextResetTimestampUtc": "2026-08-24T07:57:50.647Z",
+      "usagePercent": 100,
+      "hasAvailableUsage": true,
+      "hasNonZeroIncludedLimit": true
+    }"#;
+
+    fn at(unix: i64) -> Timestamp {
+        Timestamp::from_unix(unix).expect("plausible")
+    }
+
+    #[test]
+    fn a_pro_account_reads_as_a_total_and_the_two_lanes_it_is_made_of() {
+        let snapshot = parse(PRO, Some(IDENTITY), None, None, at(1_774_000_000)).expect("parses");
+
+        assert_eq!(snapshot.provider.as_str(), "cursor");
+        assert_eq!(snapshot.windows.len(), 3);
+
+        let total = &snapshot.windows[0];
+        assert_eq!(total.key.as_str(), "plan");
+        assert_eq!(total.title, "Total");
+        assert_eq!(total.used_percent, 0.441_025_641_025_641);
+        assert_eq!(total.subtitle.as_deref(), Some("$0.86 / $20.00"));
+        // 2026-03-18T20:45:42Z .. 2026-04-18T20:45:42Z is thirty-one days.
+        assert_eq!(total.length.expect("both ends stated").as_secs(), 2_678_400);
+        assert_eq!(total.resets_at.expect("stated").as_unix(), 1_776_545_142);
+
+        let auto = &snapshot.windows[1];
+        assert_eq!(auto.key.as_str(), "auto");
+        assert_eq!(auto.title, "Cursor");
+        assert_eq!(
+            auto.used_percent, 0.36,
+            "a fractional percent is a percent, not a fraction"
+        );
+        assert_eq!(auto.subtitle, None);
+
+        let api = &snapshot.windows[2];
+        assert_eq!(api.key.as_str(), "api");
+        assert_eq!(api.title, "Third Party");
+        assert_eq!(api.used_percent, 0.711_111_111_111_111_1);
+
+        let plan = &snapshot.details[0];
+        assert_eq!(plan.title, DetailSection::PLAN);
+        assert_eq!(plan.rows[0].label, "Plan");
+        assert_eq!(plan.rows[0].value, "Cursor Pro");
+
+        // On-demand is off and unspent, so there is no usage section to show.
+        let account = snapshot
+            .details
+            .iter()
+            .find(|section| section.title == "Account")
+            .expect("identity answered");
+        assert_eq!(account.rows[0].value, "user@example.com");
+        assert_eq!(account.rows[1].value, "Test User");
+        assert!(
+            !snapshot
+                .details
+                .iter()
+                .any(|section| section.title == "Usage")
+        );
+    }
+
+    #[test]
+    fn an_enterprise_seat_is_metered_by_its_personal_cap_not_the_team_pool() {
+        let snapshot = parse(ENTERPRISE, None, None, None, at(1_775_000_000)).expect("parses");
+
+        // $73.84 of $100.00, which is what Cursor's own dashboard shows the seat as.
+        let total = &snapshot.windows[0];
+        assert!((total.used_percent - 73.84).abs() < 1e-9);
+        assert_eq!(total.subtitle.as_deref(), Some("$73.84 / $100.00"));
+        assert_eq!(
+            snapshot.windows.len(),
+            1,
+            "an account with no plan block states no lane percentages"
+        );
+        assert_eq!(snapshot.details[0].rows[0].value, "Cursor Enterprise");
+    }
+
+    #[test]
+    fn a_seat_with_no_individual_usage_falls_back_to_the_shared_pool() {
+        let pooled_only = ENTERPRISE.replacen(
+            r#""overall": { "enabled": true, "used": 7384, "limit": 10000, "remaining": 2616 }"#,
+            "",
+            1,
+        );
+
+        let snapshot = parse(&pooled_only, None, None, None, at(1_775_000_000)).expect("parses");
+
+        let total = &snapshot.windows[0];
+        // 12,725,135 of 28,122,000 cents.
+        assert!((total.used_percent - 45.249_751_084_560_13).abs() < 1e-9);
+        assert_eq!(total.subtitle.as_deref(), Some("$127251.35 / $281220.00"));
+    }
+
+    #[test]
+    fn a_legacy_plan_shows_its_request_quota_instead_of_lanes_it_is_not_metered_by() {
+        let snapshot = parse(
+            PRO,
+            Some(IDENTITY),
+            Some(LEGACY),
+            Some(SAND),
+            at(1_774_000_000),
+        )
+        .expect("parses");
+
+        assert_eq!(
+            snapshot.windows.len(),
+            1,
+            "the token-based lanes and the Bot allowance do not belong beside a request quota"
+        );
+        let requests = &snapshot.windows[0];
+        assert_eq!(requests.key.as_str(), "requests");
+        assert_eq!(requests.title, "Requests");
+        assert_eq!(requests.subtitle.as_deref(), Some("240 / 500 requests"));
+        assert_eq!(requests.used_percent, 48.0);
+        assert_eq!(requests.resets_at.expect("stated").as_unix(), 1_776_545_142);
+    }
+
+    #[test]
+    fn a_modern_plan_answering_the_legacy_endpoint_keeps_its_lanes() {
+        // Cursor answers `/api/usage` for every account; only a request-based plan states a
+        // ceiling in it.
+        let no_ceiling = r#"{"gpt-4":{"numRequests":0},"startOfMonth":"2026-03-18"}"#;
+
+        let snapshot = parse(PRO, None, Some(no_ceiling), None, at(1_774_000_000)).expect("parses");
+
+        assert_eq!(snapshot.windows.len(), 3);
+        assert_eq!(snapshot.windows[0].key.as_str(), "plan");
+    }
+
+    #[test]
+    fn the_bot_allowance_is_a_weekly_window_of_its_own() {
+        let snapshot = parse(PRO, None, None, Some(SAND), at(1_787_000_000)).expect("parses");
+
+        let bot = snapshot.windows.last().expect("a fourth window");
+        assert_eq!(bot.key.as_str(), "grok-bot");
+        assert_eq!(bot.title, "Grok Bot");
+        assert_eq!(bot.used_percent, 100.0);
+        assert_eq!(bot.length.expect("both ends stated").as_secs(), 604_800);
+        assert_eq!(bot.resets_at.expect("stated").as_unix(), 1_787_558_270);
+    }
+
+    #[test]
+    fn an_account_without_an_included_bot_allowance_has_no_bot_window() {
+        let none = SAND.replacen(
+            r#""hasNonZeroIncludedLimit": true"#,
+            r#""hasNonZeroIncludedLimit": false"#,
+            1,
+        );
+
+        let snapshot = parse(PRO, None, None, Some(&none), at(1_787_000_000)).expect("parses");
+
+        assert_eq!(snapshot.windows.len(), 3);
+    }
+
+    #[test]
+    fn both_on_demand_budgets_are_reported_in_the_dollars_they_are_held_in() {
+        let snapshot = parse(BUDGETS, None, None, None, at(1_736_000_000)).expect("parses");
+
+        assert_eq!(snapshot.windows[0].used_percent, 30.0);
+        let usage = snapshot
+            .details
+            .iter()
+            .find(|section| section.title == "Usage")
+            .expect("both budgets are reported");
+        assert_eq!(usage.rows[0].label, "On-demand");
+        assert_eq!(usage.rows[0].value, "$5.00 / $100.00");
+        assert_eq!(usage.rows[1].label, "Team on-demand");
+        assert_eq!(usage.rows[1].value, "$20.00 / $500.00");
+    }
+
+    #[test]
+    fn an_account_cursor_reports_no_usage_for_reads_as_untouched_rather_than_failing() {
+        let snapshot = parse(
+            r#"{"membershipType":"hobby","individualUsage":{}}"#,
+            None,
+            None,
+            None,
+            at(1_774_000_000),
+        )
+        .expect("parses");
+
+        assert_eq!(snapshot.windows.len(), 1);
+        assert_eq!(snapshot.windows[0].used_percent, 0.0);
+        assert_eq!(snapshot.windows[0].subtitle, None);
+        assert_eq!(snapshot.windows[0].length, None);
+        assert_eq!(snapshot.details[0].rows[0].value, "Cursor Hobby");
+    }
+
+    #[test]
+    fn a_window_source_that_answers_something_unreadable_fails_the_whole_fetch() {
+        let malformed_bot = SAND.replacen(r#""usagePercent": 100"#, r#""usagePercent": "all""#, 1);
+        assert!(matches!(
+            parse(PRO, None, None, Some(&malformed_bot), at(1_787_000_000)),
+            Err(ProviderError::Malformed { .. })
+        ));
+
+        let malformed_requests =
+            LEGACY.replacen(r#""maxRequestUsage":500"#, r#""maxRequestUsage":"lots""#, 1);
+        assert!(matches!(
+            parse(
+                PRO,
+                None,
+                Some(&malformed_requests),
+                None,
+                at(1_774_000_000)
+            ),
+            Err(ProviderError::Malformed { .. })
+        ));
+
+        let malformed_reset = PRO.replacen(
+            r#""billingCycleEnd": "2026-04-18T20:45:42.000Z""#,
+            r#""billingCycleEnd": "in a month""#,
+            1,
+        );
+        assert!(matches!(
+            parse(&malformed_reset, None, None, None, at(1_774_000_000)),
+            Err(ProviderError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn an_unreadable_identity_costs_the_account_rows_and_nothing_else() {
+        let snapshot = parse(PRO, Some("not json"), None, None, at(1_774_000_000)).expect("parses");
+
+        assert_eq!(snapshot.windows.len(), 3);
+        assert!(
+            !snapshot
+                .details
+                .iter()
+                .any(|section| section.title == "Account")
+        );
+    }
+
+    #[test]
+    fn every_request_carries_the_session_and_the_dashboard_post_carries_its_origin() {
+        let provider = Cursor::new().expect("builds");
+        let cookie = "WorkosCursorSessionToken=abc";
+
+        let summary = provider
+            .get(super::USAGE_SUMMARY_URL, cookie)
+            .expect("builds");
+        assert_eq!(summary.method(), reqwest::Method::GET);
+        assert_eq!(
+            summary.url().as_str(),
+            "https://cursor.com/api/usage-summary"
+        );
+
+        let legacy = provider
+            .request_usage_request("auth0|user_test", cookie)
+            .expect("builds");
+        assert_eq!(
+            legacy.url().as_str(),
+            "https://cursor.com/api/usage?user=auth0%7Cuser_test"
+        );
+
+        let sand = provider.sand_usage_request(cookie).expect("builds");
+        assert_eq!(sand.method(), reqwest::Method::POST);
+        assert_eq!(
+            sand.url().as_str(),
+            "https://cursor.com/api/dashboard/get-sand-usage-status"
+        );
+        assert_eq!(
+            sand.headers().get("origin").expect("present"),
+            "https://cursor.com"
+        );
+        assert_eq!(
+            sand.body().and_then(reqwest::Body::as_bytes),
+            Some(b"{}".as_slice()),
+            "the dashboard endpoint takes an empty JSON object"
+        );
+
+        for request in [summary, legacy, sand] {
+            assert_eq!(request.headers().get("cookie").expect("present"), cookie);
+        }
+    }
+
+    #[test]
+    fn the_spec_builds_a_cursor_provider_that_needs_no_credential() {
+        assert_eq!(SPEC.id, "cursor");
+        assert_eq!(SPEC.title, "Cursor");
+        assert_eq!(SPEC.credential, CredentialKind::None);
+        assert!(SPEC.options.is_empty());
+
+        let provider =
+            (SPEC.build)(Credential::new(String::new()), &Options::new()).expect("builds");
+        assert_eq!(provider.id().as_str(), "cursor");
+    }
+
+    // The session-resolution tests below run against a fixture home directory and never
+    // touch a real browser. The fixture database is Gecko (plain text) so the test needs
+    // no keyring at all; the Chromium decryption path has its own tests in `browser`.
+
+    use crate::browser::SafeStorage;
+    use crate::secrets::SecretError;
+    use std::sync::Arc;
+
+    /// A keyring that answers nothing — enough for Gecko stores, which never ask.
+    #[derive(Debug)]
+    struct NoKeyring;
+
+    impl SafeStorage for NoKeyring {
+        fn password(
+            &self,
+            _application: &str,
+        ) -> crate::providers::BoxFuture<'_, Result<Option<String>, SecretError>> {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    /// A keyring that is locked, for the waiting-state test.
+    #[derive(Debug)]
+    struct LockedKeyring;
+
+    impl SafeStorage for LockedKeyring {
+        fn password(
+            &self,
+            _application: &str,
+        ) -> crate::providers::BoxFuture<'_, Result<Option<String>, SecretError>> {
+            Box::pin(async { Err(SecretError::Locked) })
+        }
+    }
+
+    /// A throwaway home with one Gecko profile holding the given cookies.
+    fn gecko_home(cookies: &[(&str, &str, &str, i64)]) -> crate::browser::tests::TestHome {
+        use rusqlite::Connection;
+        let home = crate::browser::tests::TestHome::new();
+        let path = home.gecko(".zen/k26qcf29.Default (release)");
+        let connection = Connection::open(&path).expect("opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE moz_cookies (
+                    id INTEGER PRIMARY KEY,
+                    baseDomain TEXT,
+                    originAttributes TEXT NOT NULL DEFAULT '',
+                    name TEXT, value TEXT, host TEXT, path TEXT,
+                    expiry INTEGER, lastAccessed INTEGER, creationTime INTEGER,
+                    isSecure INTEGER, isHttpOnly INTEGER
+                );",
+            )
+            .expect("creates the table");
+        for (host, name, value, expiry) in cookies {
+            connection
+                .execute(
+                    "INSERT INTO moz_cookies (
+                        host, name, value, path, expiry, isSecure, lastAccessed,
+                        creationTime, isHttpOnly
+                    ) VALUES (?1, ?2, ?3, '/', ?4, 1, 0, 0, 0)",
+                    (host, name, value, expiry),
+                )
+                .expect("inserts");
+        }
+        home
+    }
+
+    fn header_of(provider: &Cursor) -> Option<String> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(provider.session_header())
+            .expect("no keyring state")
+    }
+
+    fn session_server() -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        std::thread::JoinHandle<()>,
+    ) {
+        use std::io::{BufRead, BufReader, Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("loopback listener");
+        let address = listener.local_addr().expect("listener address");
+        let (request_tx, request_rx) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            for _ in 0..4 {
+                let (mut stream, _) = listener.accept().expect("request accepted");
+                let mut reader = BufReader::new(&mut stream);
+                let mut request = String::new();
+                let mut content_length = 0;
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).expect("header read");
+                    if line == "\r\n" {
+                        request.push_str(&line);
+                        break;
+                    }
+                    if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        content_length = value.trim().parse().expect("content length");
+                    }
+                    request.push_str(&line);
+                }
+                let mut body = vec![0; content_length];
+                reader.read_exact(&mut body).expect("body read");
+                request.push_str(&String::from_utf8(body).expect("request body is text"));
+                drop(reader);
+
+                let (status, response) =
+                    if request.contains("WorkosCursorSessionToken=expired-session") {
+                        ("401 Unauthorized", "{}")
+                    } else if request.starts_with("GET /api/usage-summary ") {
+                        ("200 OK", PRO)
+                    } else {
+                        ("200 OK", "{}")
+                    };
+                request_tx.send(request).expect("request captured");
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response}",
+                    response.len()
+                )
+                .expect("response written");
+            }
+        });
+        (format!("http://{address}"), request_rx, server)
+    }
+
+    #[test]
+    fn a_later_browser_session_is_used_after_an_earlier_one_is_rejected() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "expired-session",
+            0,
+        )]);
+        let other = home.gecko(".zen/zz99.Working");
+        {
+            use rusqlite::Connection;
+
+            let connection = Connection::open(&other).expect("opens");
+            connection
+                .execute_batch(
+                    "CREATE TABLE moz_cookies (
+                        id INTEGER PRIMARY KEY,
+                        baseDomain TEXT,
+                        originAttributes TEXT NOT NULL DEFAULT '',
+                        name TEXT, value TEXT, host TEXT, path TEXT,
+                        expiry INTEGER, lastAccessed INTEGER, creationTime INTEGER,
+                        isSecure INTEGER, isHttpOnly INTEGER
+                    );
+                    INSERT INTO moz_cookies (
+                        host, name, value, path, expiry, isSecure, lastAccessed,
+                        creationTime, isHttpOnly
+                    ) VALUES (
+                        '.cursor.com', 'WorkosCursorSessionToken', 'working-session', '/', 0,
+                        1, 0, 0, 0
+                    );",
+                )
+                .expect("creates the working session");
+        }
+        let (base, requests, server) = session_server();
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))
+            .expect("builds")
+            .with_test_base(&base);
+
+        let snapshot = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(provider.fetch_inner())
+            .expect("the working session wins");
+        assert_eq!(snapshot.provider.as_str(), "cursor");
+
+        let requests: Vec<_> = (0..4)
+            .map(|_| requests.recv().expect("request captured"))
+            .collect();
+        server.join().expect("server stopped");
+        let summaries: Vec<_> = requests
+            .iter()
+            .filter(|request| request.starts_with("GET /api/usage-summary "))
+            .collect();
+        assert_eq!(summaries.len(), 2);
+        assert!(summaries[0].contains("WorkosCursorSessionToken=expired-session"));
+        assert!(summaries[1].contains("WorkosCursorSessionToken=working-session"));
+    }
+
+    #[test]
+    fn a_signed_in_browser_supplies_the_session_header() {
+        let home = gecko_home(&[
+            (".cursor.com", "WorkosCursorSessionToken", "the-session", 0),
+            (".cursor.com", "_ga", "analytics", 0),
+            (".google.com", "NID", "not-ours", 0),
+        ]);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        let header = header_of(&provider).expect("a session");
+        // The whole domain's cookies go on the wire, not just the session one.
+        assert!(header.contains("WorkosCursorSessionToken=the-session"));
+        assert!(header.contains("_ga=analytics"));
+        assert!(
+            !header.contains("NID"),
+            "other sites' cookies are never read"
+        );
+    }
+
+    #[test]
+    fn a_known_session_name_wins_over_a_store_that_only_has_domain_cookies() {
+        let home = gecko_home(&[(".cursor.com", "_ga", "analytics", 0)]);
+        // A second profile, later in the scan order, that holds the named session.
+        let other = home.gecko(".zen/zz99.Other");
+        {
+            use rusqlite::Connection;
+            let connection = Connection::open(&other).expect("opens");
+            connection
+                .execute_batch(
+                    "CREATE TABLE moz_cookies (
+                        id INTEGER PRIMARY KEY,
+                        baseDomain TEXT,
+                        originAttributes TEXT NOT NULL DEFAULT '',
+                        name TEXT, value TEXT, host TEXT, path TEXT,
+                        expiry INTEGER, lastAccessed INTEGER, creationTime INTEGER,
+                        isSecure INTEGER, isHttpOnly INTEGER
+                    );",
+                )
+                .expect("creates the table");
+            connection
+                .execute(
+                    "INSERT INTO moz_cookies (
+                        host, name, value, path, expiry, isSecure, lastAccessed,
+                        creationTime, isHttpOnly
+                    ) VALUES ('.cursor.com', 'WorkosCursorSessionToken', 'the-session', '/', 0, 1, 0, 0, 0)",
+                    [],
+                )
+                .expect("inserts");
+        }
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        let header = header_of(&provider).expect("a session");
+        assert!(header.contains("WorkosCursorSessionToken=the-session"));
+        assert!(
+            !header.contains("analytics"),
+            "the strict pass runs over every store before the fallback pass"
+        );
+    }
+
+    #[test]
+    fn a_store_without_a_known_name_is_still_tried_in_the_fallback_pass() {
+        let home = gecko_home(&[(".cursor.com", "_ga", "analytics", 0)]);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert_eq!(header_of(&provider).as_deref(), Some("_ga=analytics"));
+    }
+
+    #[test]
+    fn a_dead_session_cookie_is_not_a_session() {
+        let home = gecko_home(&[(
+            ".cursor.com",
+            "WorkosCursorSessionToken",
+            "expired-session",
+            1_600_000_000, // 2020
+        )]);
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert_eq!(header_of(&provider), None);
+    }
+
+    #[test]
+    fn a_machine_with_no_cursor_session_is_a_missing_credential_not_an_error() {
+        let home = crate::browser::tests::TestHome::new();
+        let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring)).expect("builds");
+
+        assert_eq!(header_of(&provider), None);
+    }
+
+    #[test]
+    fn a_locked_keyring_is_a_state_to_wait_out_not_a_missing_session() {
+        let home = crate::browser::tests::TestHome::new();
+        // A Chromium profile's cookies are sealed with the password this keyring holds.
+        home.profile("chromium/Default", "Cookies");
+        let provider = Cursor::for_test(home.path(), Arc::new(LockedKeyring)).expect("builds");
+
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(provider.session_header());
+        assert!(matches!(result, Err(ProviderError::KeyringLocked)));
+    }
+}

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -299,12 +299,12 @@ impl Cursor {
 
     async fn fetch_with_cookie(&self, cookie: &str) -> Result<Snapshot, ProviderError> {
         let summary_request = self.get(&self.url(USAGE_SUMMARY_URL), cookie)?;
-        let summary = super::request(&self.client, summary_request).await?;
+        let summary = super::request(PROVIDER_ID, &self.client, summary_request).await?;
         let identity_request = self.get(&self.url(AUTH_ME_URL), cookie)?;
         let sand_request = self.sand_usage_request(cookie)?;
         let (identity, sand) = tokio::join!(
-            super::request(&self.client, identity_request),
-            super::request(&self.client, sand_request),
+            super::request(PROVIDER_ID, &self.client, identity_request),
+            super::request(PROVIDER_ID, &self.client, sand_request),
         );
         // Both are supplementary: a failure here is an account with nothing to say, not a
         // poll that went wrong. See the module note.
@@ -322,7 +322,9 @@ impl Cursor {
         let legacy = match subject {
             Some(subject) => {
                 let request = self.request_usage_request(&subject, cookie)?;
-                super::request(&self.client, request).await.ok()
+                super::request(PROVIDER_ID, &self.client, request)
+                    .await
+                    .ok()
             }
             None => None,
         };

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -356,6 +356,22 @@ pub async fn request(
     Ok(body)
 }
 
+/// Sends a credential proof request without reading or recording its response body.
+///
+/// Source inspection proves only that a local session is accepted. Its body is not a quota
+/// reading and can contain account data, so it must not enter the optional raw-response log.
+pub async fn validate(
+    client: &reqwest::Client,
+    request: reqwest::Request,
+) -> Result<(), ProviderError> {
+    let response = client
+        .execute(request)
+        .await
+        .map_err(|error| ProviderError::Transport(redact_query(error)))?;
+    let retry_after = http::retry_after_header(&response).map(str::to_owned);
+    http::check(response.status(), retry_after.as_deref())
+}
+
 /// Reads a required option, refusing the build with the setting's name when it is unset
 /// or blank — the check [`Keyed::new`] makes generically, factored out for the
 /// hand-written providers whose builds are their own.

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -39,6 +39,7 @@ pub mod clawrouter;
 pub mod clinepass;
 pub mod codebuff;
 pub mod crof;
+pub mod cursor;
 pub mod deepgram;
 pub mod deepinfra;
 pub mod deepseek;
@@ -182,8 +183,10 @@ pub struct HandSpec {
     /// What to call it in front of a person.
     pub title: &'static str,
     /// How the account is authenticated, and therefore what the credentials dialog offers.
-    /// [`CredentialKind::Key`] for all but the local gateways, which answer without a
-    /// credential and declare [`CredentialKind::None`]; the registry publishes this rather
+    /// [`CredentialKind::Key`] for the providers the user pastes a key for;
+    /// [`CredentialKind::None`] for the ones that need nothing — the local gateways, which
+    /// answer without a credential, and the browser-session providers, which read the
+    /// session a browser on this machine already holds. The registry publishes this rather
     /// than assuming a key, and builds the account to match.
     pub credential: CredentialKind,
     /// One sentence saying which page the key is on. Empty for a provider that needs no

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -35,7 +35,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
-use tidemark_types::{AccountId, ProviderId, Snapshot, Timestamp, WindowLength};
+use tidemark_types::{AccountId, AuthCandidate, ProviderId, Snapshot, Timestamp, WindowLength};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 /// A future returned from a trait method.
@@ -57,6 +57,14 @@ pub trait Provider: fmt::Debug + Send + Sync {
 
     /// Fetch current quota.
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>>;
+
+    /// Inspects selectable local authentication sources without exposing their credentials.
+    ///
+    /// Most providers have no such choice. Browser-cookie providers override this so the
+    /// daemon can discover and validate candidates through the same trait object it polls.
+    fn inspect_auth_sources(&self) -> BoxFuture<'_, Result<Vec<AuthCandidate>, ProviderError>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
 }
 
 /// Which of two credentials an account uses.

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -19,8 +19,9 @@ pub use snapshot::{AccountId, DetailRow, DetailSection, ProviderId, Snapshot, pr
 pub use time::{AbsurdTimestamp, Timestamp};
 pub use window::{DANGER_AT, WARNING_AT, Window, WindowKey, WindowLength};
 pub use wire::{
-    CredentialKind, DataInfo, ExternalLogin, HistoryPoint, OptionChoice, Preferences,
-    ProviderDefinition, ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus,
+    AuthCandidate, AuthCandidateState, AuthMode, AuthSelection, AuthSelector, CredentialKind,
+    DataInfo, ExternalLogin, HistoryPoint, OptionChoice, Preferences, ProviderDefinition,
+    ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus,
 };
 
 /// Identity constants. Changing any of these is a breaking change for installed units,

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -235,6 +235,117 @@ pub struct ExternalLogin {
     pub writes_back: bool,
 }
 
+/// One top-level local authentication method a provider can offer.
+///
+/// Values are stable configuration values. A client draws `title`, but sends `value` back
+/// to the daemon unchanged so that it never needs to know provider-specific source names.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct AuthMode {
+    /// Stable value stored in the provider configuration.
+    pub value: String,
+    /// What to call this method on screen.
+    pub title: String,
+}
+
+/// Metadata for a provider's local authentication source selector.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct AuthSelector {
+    /// The provider option that records the selected top-level mode.
+    pub option: String,
+    /// Top-level methods the client presents as authentication tabs.
+    pub modes: Vec<AuthMode>,
+}
+
+/// The daemon's most recent verdict on a local authentication candidate.
+///
+/// The state travels as a string on [`AuthCandidate`] so a newer daemon can add a verdict
+/// without changing its D-Bus signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthCandidateState {
+    /// The daemon proved that this source authenticates successfully.
+    Ready,
+    /// The source does not contain a usable matching credential.
+    Missing,
+    /// The provider rejected the source's credential.
+    Rejected,
+    /// A locked keyring prevented the daemon from reading the source.
+    WaitingForKeyring,
+    /// The daemon could not reach the provider to determine whether the source works.
+    Unreachable,
+}
+
+impl AuthCandidateState {
+    /// The stable string this state travels as.
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Missing => "missing",
+            Self::Rejected => "rejected",
+            Self::WaitingForKeyring => "waiting-for-keyring",
+            Self::Unreachable => "unreachable",
+        }
+    }
+
+    /// Parses a daemon verdict. Unknown values remain unknown rather than being shown as a
+    /// usable source by an older client.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        [
+            Self::Ready,
+            Self::Missing,
+            Self::Rejected,
+            Self::WaitingForKeyring,
+            Self::Unreachable,
+        ]
+        .into_iter()
+        .find(|candidate| candidate.as_wire() == value)
+    }
+}
+
+impl std::fmt::Display for AuthCandidateState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
+/// One local source the daemon inspected, without its credential.
+///
+/// `id` is opaque to clients and stable enough to record a selected browser or profile.
+/// Children represent the rare case where a source needs a second explicit choice, such as
+/// multiple usable profiles inside a browser.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct AuthCandidate {
+    /// Stable opaque source identifier.
+    pub id: String,
+    /// Human-readable source name.
+    pub title: String,
+    /// Optional human-readable context, never a filesystem path or credential.
+    pub subtitle: Option<String>,
+    /// An [`AuthCandidateState`] string.
+    pub state: String,
+    /// Nested choices within this source.
+    pub children: Vec<AuthCandidate>,
+}
+
+impl AuthCandidate {
+    /// The verdict this build recognizes, if any.
+    pub fn state(&self) -> Option<AuthCandidateState> {
+        AuthCandidateState::from_wire(&self.state)
+    }
+}
+
+/// The explicit local authentication source an account uses.
+#[derive(Debug, Clone, PartialEq, Eq, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct AuthSelection {
+    /// The selected [`AuthMode::value`].
+    pub mode: String,
+    /// The selected candidate, or none for a mode that has no candidate choice.
+    pub candidate: Option<String>,
+}
+
 /// Presentation metadata for one provider in the daemon's catalog.
 #[derive(Debug, Clone, PartialEq, SerializeDict, DeserializeDict, Type)]
 #[zvariant(signature = "a{sv}")]
@@ -245,6 +356,9 @@ pub struct ProviderDefinition {
     pub credential_hint: String,
     /// The other credential this provider can read, for the providers that have one.
     pub external: Option<ExternalLogin>,
+    /// An explicit local browser or application authentication selector, when the provider
+    /// supports one. Its dynamic candidates are fetched separately from the daemon.
+    pub browser_auth: Option<AuthSelector>,
     pub options: Vec<ProviderOption>,
 }
 
@@ -475,6 +589,9 @@ pub struct ProviderStatus {
     /// login wins over the file their CLI owns. A client that guessed would have to be
     /// taught each of those rules, and would go stale the first time one changed.
     pub auth_source: Option<String>,
+    /// The daemon-resolved local source selected for browser-cookie authentication.
+    /// Absent on providers without this capability and when speaking to an older daemon.
+    pub auth_selection: Option<AuthSelection>,
     /// The provider's own settings, with their current values and alternatives.
     pub options: Vec<ProviderOption>,
     /// Keys of the windows whose notifications the user has switched on.
@@ -502,6 +619,7 @@ impl ProviderStatus {
             credential_hint: None,
             external_present: None,
             auth_source: None,
+            auth_selection: None,
             options: Vec::new(),
             notify: Vec::new(),
         }
@@ -630,6 +748,7 @@ mod tests {
                 command: "agy".into(),
                 writes_back: false,
             }),
+            browser_auth: None,
             options: Vec::new(),
         };
         let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
@@ -637,6 +756,74 @@ mod tests {
         assert_eq!(decoded, original);
         assert_eq!(decoded.credential_kind(), Some(CredentialKind::OAuth));
         assert_eq!(decoded.auth_option(), Some("source"));
+    }
+
+    #[test]
+    fn a_browser_auth_definition_and_nested_candidate_survive_the_bus() {
+        // Removing the selector or flattening a browser's two profiles would leave the GTK
+        // client unable to offer the explicit source the daemon validated.
+        let selector = AuthSelector {
+            option: "auth-source".into(),
+            modes: vec![
+                AuthMode {
+                    value: "cursor-app".into(),
+                    title: "Cursor App".into(),
+                },
+                AuthMode {
+                    value: "browser".into(),
+                    title: "Browser".into(),
+                },
+            ],
+        };
+        let definition = ProviderDefinition {
+            provider: "cursor".into(),
+            title: "Cursor".into(),
+            credential: CredentialKind::None.as_wire().into(),
+            credential_hint: "Choose a local Cursor session.".into(),
+            external: None,
+            browser_auth: Some(selector.clone()),
+            options: Vec::new(),
+        };
+        let candidate = AuthCandidate {
+            id: "firefox".into(),
+            title: "Firefox".into(),
+            subtitle: None,
+            state: AuthCandidateState::Ready.as_wire().into(),
+            children: vec![AuthCandidate {
+                id: "default-release".into(),
+                title: "Default Release".into(),
+                subtitle: Some("Cursor session".into()),
+                state: AuthCandidateState::Ready.as_wire().into(),
+                children: Vec::new(),
+            }],
+        };
+
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &definition).expect("encodes");
+        let (decoded, _): (ProviderDefinition, _) = encoded.deserialize().expect("decodes");
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &candidate).expect("encodes");
+        let (decoded_candidate, _): (AuthCandidate, _) = encoded.deserialize().expect("decodes");
+        let mut status = ProviderStatus::pending(&ProviderId::new("cursor"), &AccountId::default());
+        status.auth_selection = Some(AuthSelection {
+            mode: "browser".into(),
+            candidate: Some("firefox/default-release".into()),
+        });
+        let (decoded_status, _): (ProviderStatus, _) =
+            encode(&status).deserialize().expect("decodes");
+
+        assert_eq!(decoded.browser_auth.as_ref(), Some(&selector));
+        assert_eq!(decoded_candidate, candidate);
+        assert_eq!(decoded_status.auth_selection, status.auth_selection);
+    }
+
+    #[test]
+    fn an_older_status_dictionary_without_browser_auth_fields_still_decodes() {
+        // A daemon that predates source selection omits this key entirely; the GUI must not
+        // mistake that absence for a selected source.
+        let original = ProviderStatus::pending(&ProviderId::new("cursor"), &AccountId::default());
+        let encoded = encode(&original);
+        let (decoded, _): (ProviderStatus, _) = encoded.deserialize().expect("decodes");
+
+        assert_eq!(decoded.auth_selection, None);
     }
 
     #[test]
@@ -649,6 +836,7 @@ mod tests {
             credential: CredentialKind::Key.as_wire().into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         };
         assert_eq!(definition.auth_option(), None);

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -69,6 +69,7 @@ impl MockDaemon {
                     credential_hint: "Paste a key.".to_owned(),
                     options: external.iter().map(source_option).collect(),
                     external,
+                    browser_auth: None,
                 }
             })
             .collect()

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -25,7 +25,9 @@ use std::future::poll_fn;
 use std::pin::pin;
 use std::task::Poll;
 
-use tidemark_types::{DataInfo, Preferences, ProviderDefinition, ProviderStatus, ids};
+use tidemark_types::{
+    AuthCandidate, AuthSelection, DataInfo, Preferences, ProviderDefinition, ProviderStatus, ids,
+};
 use zbus::export::futures_core::Stream;
 
 /// How long to wait before trying the session bus again after a failure. Only reached when
@@ -92,6 +94,17 @@ pub trait Daemon {
         account: &str,
         name: &str,
         value: &str,
+    ) -> zbus::Result<()>;
+
+    /// Inspects secret-free local authentication candidates for one account.
+    fn get_auth_sources(&self, provider: &str, account: &str) -> zbus::Result<Vec<AuthCandidate>>;
+
+    /// Revalidates and stores one local authentication selection.
+    fn select_auth_source(
+        &self,
+        provider: &str,
+        account: &str,
+        selection: AuthSelection,
     ) -> zbus::Result<()>;
 
     /// Switches notifications for one of an account's windows on or off.
@@ -393,7 +406,9 @@ mod tests {
     use std::cell::RefCell;
     use std::process;
 
-    use tidemark_types::{Preferences, ProviderDefinition, ProviderStatus, ids};
+    use tidemark_types::{
+        AuthCandidate, AuthSelection, Preferences, ProviderDefinition, ProviderStatus, ids,
+    };
 
     use super::{DaemonProxy, Update, load};
     use zbus::fdo;
@@ -420,6 +435,26 @@ mod tests {
 
         fn get_status(&self) -> Vec<ProviderStatus> {
             Vec::new()
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct BrowserAuthService(std::sync::Arc<std::sync::Mutex<Option<AuthSelection>>>);
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl BrowserAuthService {
+        fn get_auth_sources(&self, _provider: &str, _account: &str) -> Vec<AuthCandidate> {
+            vec![AuthCandidate {
+                id: "cursor-app".into(),
+                title: "Cursor App".into(),
+                subtitle: None,
+                state: "ready".into(),
+                children: Vec::new(),
+            }]
+        }
+
+        fn select_auth_source(&self, _provider: &str, _account: &str, selection: AuthSelection) {
+            *self.0.lock().expect("no test panics holding this") = Some(selection);
         }
     }
     /// A daemon that implements `GetPreferences` but cannot read its own storage.
@@ -449,6 +484,58 @@ mod tests {
         assert_eq!(ids::DAEMON_INTERFACE, "io.github.zbndev.Tidemark.Daemon1");
         assert_eq!(ids::DAEMON_BUS_NAME, "io.github.zbndev.Tidemark.Daemon");
         assert_eq!(ids::OBJECT_PATH, "/io/github/zbndev/Tidemark");
+    }
+
+    #[test]
+    fn the_proxy_round_trips_secret_free_browser_auth_calls() {
+        zbus::block_on(async {
+            let Ok(client_connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus reachable");
+                return;
+            };
+            let name = format!(
+                "io.github.zbndev.Tidemark.BrowserAuthTest.p{}",
+                process::id()
+            );
+            let service = BrowserAuthService::default();
+            let selected = std::sync::Arc::clone(&service.0);
+            let _server = zbus::connection::Builder::session()
+                .expect("session bus address")
+                .name(name.as_str())
+                .expect("valid test bus name")
+                .serve_at(ids::OBJECT_PATH, service)
+                .expect("valid test object")
+                .build()
+                .await
+                .expect("test service starts");
+            let proxy = DaemonProxy::builder(&client_connection)
+                .destination(name.as_str())
+                .expect("valid destination")
+                .path(ids::OBJECT_PATH)
+                .expect("valid path")
+                .build()
+                .await
+                .expect("proxy builds");
+
+            let sources = proxy
+                .get_auth_sources("cursor", "default")
+                .await
+                .expect("sources arrive");
+            assert_eq!(sources[0].id, "cursor-app");
+            assert!(!format!("{sources:?}").contains("session="));
+            let selection = AuthSelection {
+                mode: "cursor-app".into(),
+                candidate: None,
+            };
+            proxy
+                .select_auth_source("cursor", "default", selection.clone())
+                .await
+                .expect("selection arrives");
+            assert_eq!(
+                *selected.lock().expect("no test panics holding this"),
+                Some(selection)
+            );
+        });
     }
 
     #[test]

--- a/crates/tidemark/src/model.rs
+++ b/crates/tidemark/src/model.rs
@@ -107,6 +107,7 @@ mod tests {
             credential: "key".to_owned(),
             credential_hint: "ClinePass console.".to_owned(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         }];
         let titles = titles(&definitions);

--- a/crates/tidemark/src/provider_settings/browser_auth.rs
+++ b/crates/tidemark/src/provider_settings/browser_auth.rs
@@ -90,6 +90,7 @@ impl CandidateRow {
             .title(title)
             .use_markup(false)
             .sensitive(selectable)
+            .activatable(selectable)
             .build();
         if let Some(subtitle) = subtitle {
             row.set_subtitle(subtitle);
@@ -147,14 +148,11 @@ struct Half {
 }
 
 impl Half {
-    fn new(mode: &AuthMode, on_refresh: Rc<dyn Fn()>) -> Self {
-        let group = adw::PreferencesGroup::builder().visible(false).build();
-        let check_again = gtk::Button::builder()
-            .label("Check again")
-            .valign(gtk::Align::Center)
+    fn new(mode: &AuthMode) -> Self {
+        let group = adw::PreferencesGroup::builder()
+            .visible(false)
+            .margin_top(12)
             .build();
-        check_again.connect_clicked(move |_| on_refresh());
-        group.set_header_suffix(Some(&check_again));
 
         Self {
             mode_value: mode.value.clone(),
@@ -295,7 +293,6 @@ impl BrowserAuth {
     pub(super) fn new(
         selector: &AuthSelector,
         status_selection: Option<&AuthSelection>,
-        on_refresh: Rc<dyn Fn()>,
         on_choose: Rc<dyn Fn(AuthSelection)>,
     ) -> Self {
         // Full width, in a row of its own at the top of the group, rather than tucked
@@ -319,11 +316,7 @@ impl BrowserAuth {
             .build();
         pill_row.add_css_class("credential-choice");
 
-        let halves: Vec<Half> = selector
-            .modes
-            .iter()
-            .map(|mode| Half::new(mode, Rc::clone(&on_refresh)))
-            .collect();
+        let halves: Vec<Half> = selector.modes.iter().map(Half::new).collect();
 
         let suppress_toggle = Rc::new(Cell::new(false));
         let navigated = Rc::new(Cell::new(false));
@@ -470,9 +463,14 @@ fn position_halves(halves: &[Half], visible_mode: &str) {
 
 #[cfg(test)]
 mod tests {
-    use tidemark_types::{AuthCandidate, AuthCandidateState};
+    use std::rc::Rc;
 
-    use super::{candidate_selectable, shows_profile_children, state_classes, state_word};
+    use adw::prelude::*;
+    use tidemark_types::{AuthCandidate, AuthCandidateState, AuthMode};
+
+    use super::{
+        CandidateRow, Half, candidate_selectable, shows_profile_children, state_classes, state_word,
+    };
 
     fn candidate(id: &str, state: AuthCandidateState) -> AuthCandidate {
         AuthCandidate {
@@ -487,6 +485,43 @@ mod tests {
     #[test]
     fn only_a_proven_working_candidate_is_selectable() {
         assert!(candidate_selectable(AuthCandidateState::Ready));
+    }
+
+    /// GTK widget state needs a display, while the rest of this module's tests intentionally
+    /// stay headless. Keep all such assertions together: GTK binds initialization to the
+    /// harness thread.
+    fn widgets() -> bool {
+        static READY: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| adw::init().is_ok());
+        *READY
+    }
+
+    #[test]
+    fn browser_auth_widgets_keep_source_rows_separate_from_the_tabs() {
+        if !widgets() {
+            eprintln!("skipped: no display is available");
+            return;
+        }
+
+        let row = CandidateRow::new(
+            "firefox".into(),
+            "Firefox",
+            None,
+            Some(AuthCandidateState::Ready),
+            true,
+            "browser",
+            Rc::new(|_| {}),
+        );
+
+        assert!(row.row.is_activatable());
+
+        let half = Half::new(&AuthMode {
+            value: "browser".into(),
+            title: "Browser".into(),
+        });
+
+        assert!(half.group.title().is_empty());
+        assert!(half.group.header_suffix().is_none());
+        assert_eq!(half.group.margin_top(), 12);
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/browser_auth.rs
+++ b/crates/tidemark/src/provider_settings/browser_auth.rs
@@ -1,0 +1,560 @@
+//! The Authentication halves for a provider whose login comes from one explicitly chosen
+//! local source.
+//!
+//! Everything here is driven by what the daemon publishes: the tabs are the selector's
+//! own mode titles, the rows are an inspected report's candidates, and activating one asks
+//! the daemon to validate and store that choice. Nothing matches Cursor or any browser by
+//! name, reads a file, or opens a socket — that is daemon work this crate only requests.
+//!
+//! Tabs and rows play different parts. A tab only swaps which half is on screen: some
+//! modes need a candidate picked from their half before anything can be stored at all, so
+//! a tab alone is never a complete answer. A row activation is the whole selection.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use adw::prelude::*;
+use tidemark_types::{AuthCandidate, AuthCandidateState, AuthMode, AuthSelection, AuthSelector};
+
+use super::model;
+
+/// Whether activating this candidate may ask the daemon to select it.
+///
+/// Only a proven source is a real offer. Missing and rejected ones are insensitive —
+/// choosing them could only record a failure — and so are locked-keyring and inconclusive
+/// verdicts, which are answers about *checking* rather than about the credential.
+pub(super) fn candidate_selectable(state: AuthCandidateState) -> bool {
+    matches!(state, AuthCandidateState::Ready)
+}
+
+/// Whether a source's children deserve rows of their own.
+///
+/// One ready child needs no second question: activating the parent picks it, in the
+/// stable scan order the daemon resolves with. Only when more than one works does the
+/// rare second choice surface, and then only the working ones.
+pub(super) fn shows_profile_children(children: &[AuthCandidate]) -> bool {
+    children
+        .iter()
+        .filter(|child| child.state().is_some_and(candidate_selectable))
+        .count()
+        > 1
+}
+
+/// The words for a candidate's verdict, whatever the colour says beside them.
+///
+/// A verdict this build does not know counts as inconclusive rather than usable or
+/// broken: a newer daemon invented it, and guessing its meaning here would outvote the
+/// daemon.
+pub(super) fn state_word(state: Option<AuthCandidateState>) -> &'static str {
+    match state {
+        Some(AuthCandidateState::Ready) => "Working",
+        Some(AuthCandidateState::Missing) => "Not found",
+        Some(AuthCandidateState::Rejected) => "Rejected",
+        Some(AuthCandidateState::WaitingForKeyring) => "Keyring locked",
+        Some(AuthCandidateState::Unreachable) | None => "Inconclusive",
+    }
+}
+
+/// How a verdict is coloured: green for proven, red for disproven, plain words otherwise.
+pub(super) fn state_classes(state: Option<AuthCandidateState>) -> &'static [&'static str] {
+    match state {
+        Some(AuthCandidateState::Ready) => &["success"],
+        Some(AuthCandidateState::Missing) | Some(AuthCandidateState::Rejected) => &["error"],
+        _ => &["dim-label"],
+    }
+}
+
+/// One selectable source line, and whether the account currently runs on it.
+#[derive(Debug)]
+struct CandidateRow {
+    id: String,
+    row: adw::ActionRow,
+    in_use: gtk::Image,
+}
+
+impl CandidateRow {
+    /// Activates through `on_choose`, which the detail page turns into a validated write;
+    /// nothing moves on click, because the claim becomes real only where the daemon says.
+    fn new(
+        id: String,
+        title: &str,
+        subtitle: Option<&str>,
+        state: Option<AuthCandidateState>,
+        selectable: bool,
+        mode_value: &str,
+        on_choose: Rc<dyn Fn(AuthSelection)>,
+    ) -> Rc<Self> {
+        // Markup off twice over: titles and subtitles are the daemon's words, which are
+        // data, never markup.
+        let row = adw::ActionRow::builder()
+            .title(title)
+            .use_markup(false)
+            .sensitive(selectable)
+            .build();
+        if let Some(subtitle) = subtitle {
+            row.set_subtitle(subtitle);
+        }
+
+        let word = gtk::Label::builder()
+            .label(state_word(state))
+            .valign(gtk::Align::Center)
+            .css_classes(state_classes(state))
+            .build();
+        row.add_suffix(&word);
+        row.update_property(&[gtk::accessible::Property::Description(&format!(
+            "{title}: {}",
+            state_word(state)
+        ))]);
+
+        let in_use = gtk::Image::builder()
+            .icon_name("object-select-symbolic")
+            .tooltip_text("In use")
+            .valign(gtk::Align::Center)
+            .visible(false)
+            .build();
+        row.add_suffix(&in_use);
+
+        if selectable {
+            let claimed_here = id == mode_value;
+            let mode_claimed = mode_value.to_owned();
+            let identifier = id.clone();
+            row.connect_activated(move |_| {
+                // A self-representing mode is claimed by claiming the mode itself;
+                // everything underneath rides on naming its own identifier.
+                on_choose(AuthSelection {
+                    mode: mode_claimed.clone(),
+                    candidate: (!claimed_here).then(|| identifier.clone()),
+                });
+            });
+        }
+
+        Rc::new(Self { id, row, in_use })
+    }
+}
+
+/// One half of the choice: every source behind one selector mode, plus what an inspection
+/// in flight has to say meanwhile.
+///
+/// Rows are rebuilt together whenever an inspection lands, and left alone until then,
+/// because replacing a row under a pointer that is on it loses the click. The whole half
+/// hides instead of rebuilding when another tab is showing.
+#[derive(Debug)]
+struct Half {
+    mode_value: String,
+    group: adw::PreferencesGroup,
+    notes: RefCell<Vec<adw::ActionRow>>,
+    rows: RefCell<Vec<Rc<CandidateRow>>>,
+}
+
+impl Half {
+    fn new(mode: &AuthMode, on_refresh: Rc<dyn Fn()>) -> Self {
+        let group = adw::PreferencesGroup::builder().visible(false).build();
+        let check_again = gtk::Button::builder()
+            .label("Check again")
+            .valign(gtk::Align::Center)
+            .build();
+        check_again.connect_clicked(move |_| on_refresh());
+        group.set_header_suffix(Some(&check_again));
+
+        Self {
+            mode_value: mode.value.clone(),
+            group,
+            notes: RefCell::new(Vec::new()),
+            rows: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn set_visible(&self, visible: bool) {
+        self.group.set_visible(visible);
+    }
+
+    fn clear_contents(&self) {
+        for note in self.notes.borrow_mut().drain(..) {
+            self.group.remove(&note);
+        }
+        for row in self.rows.borrow_mut().drain(..) {
+            self.group.remove(&row.row);
+        }
+    }
+
+    /// Draws the checking note. Whatever report was shown before stays recorded, so a
+    /// failed inspection puts those same rows back rather than an empty half.
+    fn show_checking(&self) {
+        self.clear_contents();
+        let note = adw::ActionRow::builder()
+            .title("Checking local sources…")
+            .sensitive(false)
+            .use_markup(false)
+            .build();
+        self.group.add(&note);
+        self.notes.borrow_mut().push(note);
+    }
+
+    /// Draws one inspected report: every source of this half's mode.
+    ///
+    /// The body matching the mode carries the rows. One with no children stands for
+    /// itself — activating it claims the whole mode — while one with children lists them
+    /// and never claims itself from behind their backs. A body the report stopped sending
+    /// leaves the half honest rather than drawn from remembered candidates.
+    fn apply_report(&self, report: &[AuthCandidate], on_choose: &Rc<dyn Fn(AuthSelection)>) {
+        self.clear_contents();
+        let Some(body) = report.iter().find(|body| body.id == self.mode_value) else {
+            let note = adw::ActionRow::builder()
+                .title("Not offered right now")
+                .sensitive(false)
+                .use_markup(false)
+                .build();
+            self.group.add(&note);
+            self.notes.borrow_mut().push(note);
+            return;
+        };
+
+        if body.children.is_empty() {
+            self.add_candidate(body, 0, on_choose);
+            return;
+        }
+        for source in &body.children {
+            self.add_candidate(source, 0, on_choose);
+            if shows_profile_children(&source.children) {
+                for profile in &source.children {
+                    self.add_candidate(profile, 18, on_choose);
+                }
+            }
+        }
+    }
+
+    fn add_candidate(
+        &self,
+        candidate: &AuthCandidate,
+        indent: i32,
+        on_choose: &Rc<dyn Fn(AuthSelection)>,
+    ) {
+        let state = candidate.state();
+        let row = CandidateRow::new(
+            candidate.id.clone(),
+            &candidate.title,
+            candidate.subtitle.as_deref(),
+            state,
+            state.is_some_and(candidate_selectable),
+            &self.mode_value,
+            Rc::clone(on_choose),
+        );
+        row.row.set_margin_start(indent);
+        self.group.add(&row.row);
+        self.rows.borrow_mut().push(row);
+    }
+
+    /// Marks the one row the account's published selection names, inside its own mode.
+    fn apply_selection(&self, selection: Option<&AuthSelection>) {
+        let claimed =
+            selection.and_then(|selection| model::selected_candidate(selection, &self.mode_value));
+        for row in self.rows.borrow().iter() {
+            row.in_use.set_visible(claimed == Some(row.id.as_str()));
+        }
+    }
+}
+
+/// The tab pill and every half beneath it, built once and refreshed from inspections.
+///
+/// The active tab is navigation, not a claim: it moves when clicked and stays where the
+/// user leaves it regardless of polls arriving underneath. It follows the published
+/// selection only until the first click, which is the last moment the view belongs to the
+/// account rather than to the person looking at it.
+pub(super) struct BrowserAuth {
+    pill_row: adw::PreferencesRow,
+    toggles: adw::ToggleGroup,
+    modes: Vec<AuthMode>,
+    halves: Vec<Half>,
+    on_choose: Rc<dyn Fn(AuthSelection)>,
+    suppress_toggle: Rc<Cell<bool>>,
+    navigated: Rc<Cell<bool>>,
+    selection: RefCell<Option<AuthSelection>>,
+    report: RefCell<Vec<AuthCandidate>>,
+}
+
+// No closure or stored callback belongs in a Debug rendering: they are wiring, not state.
+impl std::fmt::Debug for BrowserAuth {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BrowserAuth")
+            .field("toggles", &self.toggles)
+            .field("modes", &self.modes)
+            .field("halves", &self.halves)
+            .field("navigated", &self.navigated.get())
+            .field("selection", &self.selection)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BrowserAuth {
+    /// Builds the pill and one half per mode, laid out on the account's published
+    /// selection before anything can be clicked.
+    ///
+    /// Checking starts here already: until [`Self::apply_report`] replaces them, each
+    /// half draws the note a machine deserves while its sources are being looked at.
+    pub(super) fn new(
+        selector: &AuthSelector,
+        status_selection: Option<&AuthSelection>,
+        on_refresh: Rc<dyn Fn()>,
+        on_choose: Rc<dyn Fn(AuthSelection)>,
+    ) -> Self {
+        // Full width, in a row of its own at the top of the group, rather than tucked
+        // into the group's header — the same shape the OAuth/CLI credential pill takes,
+        // because both carry the provider's own names for two alternative logins.
+        let toggles = adw::ToggleGroup::builder()
+            .hexpand(true)
+            .homogeneous(true)
+            .build();
+        for mode in &selector.modes {
+            toggles.add(
+                adw::Toggle::builder()
+                    .name(&mode.value)
+                    .label(&mode.title)
+                    .build(),
+            );
+        }
+        let pill_row = adw::PreferencesRow::builder()
+            .activatable(false)
+            .child(&toggles)
+            .build();
+        pill_row.add_css_class("credential-choice");
+
+        let halves: Vec<Half> = selector
+            .modes
+            .iter()
+            .map(|mode| Half::new(mode, Rc::clone(&on_refresh)))
+            .collect();
+
+        let suppress_toggle = Rc::new(Cell::new(false));
+        let navigated = Rc::new(Cell::new(false));
+
+        let initial = desired_mode(&selector.modes, status_selection);
+        toggles.set_active_name(Some(initial.as_str()));
+        position_halves(&halves, &initial);
+
+        let clicked = toggles.clone();
+        toggles.connect_active_name_notify({
+            let suppress_toggle = Rc::clone(&suppress_toggle);
+            let navigated = Rc::clone(&navigated);
+            let shown: Vec<(String, adw::PreferencesGroup)> = halves
+                .iter()
+                .map(|half| (half.mode_value.clone(), half.group.clone()))
+                .collect();
+            move |_| {
+                if suppress_toggle.get() {
+                    return;
+                }
+                navigated.set(true);
+                if let Some(name) = active_name(&clicked) {
+                    for (mode_value, group) in &shown {
+                        group.set_visible(mode_value == &name);
+                    }
+                }
+            }
+        });
+
+        let built = Self {
+            pill_row,
+            toggles,
+            modes: selector.modes.clone(),
+            halves,
+            on_choose,
+            suppress_toggle,
+            navigated,
+            selection: RefCell::new(status_selection.cloned()),
+            report: RefCell::new(Vec::new()),
+        };
+        built.begin_loading();
+        built
+    }
+
+    /// Adds everything this capability draws to the Authentication group.
+    pub(super) fn attach(&self, authentication: &adw::PreferencesGroup) {
+        authentication.add(&self.pill_row);
+        for half in &self.halves {
+            authentication.add(&half.group);
+        }
+    }
+
+    /// Puts every half into its checking state ahead of an inspection. A report still
+    /// recorded underneath survives the note, so a failed refresh restores those rows.
+    pub(super) fn begin_loading(&self) {
+        for half in &self.halves {
+            half.show_checking();
+        }
+    }
+
+    /// Undoes a check that never answered. With nothing ever inspected there is no
+    /// previous answer to go back to, and the checking note stays up instead.
+    pub(super) fn recover(&self) {
+        if self.report.borrow().is_empty() {
+            self.begin_loading();
+            return;
+        }
+        let kept = self.report.borrow().clone();
+        self.render_report(&kept);
+    }
+
+    /// Renders a fresh inspection, and lets an untouched view settle onto it.
+    pub(super) fn apply_report(&self, report: Vec<AuthCandidate>) {
+        *self.report.borrow_mut() = report;
+        let kept = self.report.borrow().clone();
+        self.render_report(&kept);
+        self.follow_if_untouched();
+    }
+
+    /// Repaints the In-use marks from what the daemon last published, and moves an
+    /// untouched view along with it.
+    pub(super) fn apply_selection(&self, selection: Option<&AuthSelection>) {
+        *self.selection.borrow_mut() = selection.cloned();
+        for half in &self.halves {
+            half.apply_selection(selection);
+        }
+        self.follow_if_untouched();
+    }
+
+    fn render_report(&self, report: &[AuthCandidate]) {
+        for half in &self.halves {
+            half.apply_report(report, &self.on_choose);
+        }
+    }
+
+    /// Snaps the pill and the halves onto the published mode while nobody has navigated.
+    /// Once somebody has, their click owns the view for the life of the dialog, whatever
+    /// lands in the queue afterwards.
+    fn follow_if_untouched(&self) {
+        if self.navigated.get() {
+            return;
+        }
+        let wanted = {
+            let selection = self.selection.borrow();
+            desired_mode(&self.modes, selection.as_ref())
+        };
+        self.set_active_silently(&wanted);
+        position_halves(&self.halves, &wanted);
+    }
+
+    fn set_active_silently(&self, mode_value: &str) {
+        self.suppress_toggle.set(true);
+        self.toggles.set_active_name(Some(mode_value));
+        self.suppress_toggle.set(false);
+    }
+}
+
+fn active_name(toggles: &adw::ToggleGroup) -> Option<String> {
+    toggles.active_name().map(|name| name.to_string())
+}
+
+/// The mode an open view should start on, or stay on while untouched.
+///
+/// The published selection wins when the daemon named a mode this build knows; the first
+/// declared mode covers an account whose source was never picked, and both fall back
+/// harmlessly when a selector has no modes to show at all.
+fn desired_mode(modes: &[AuthMode], selection: Option<&AuthSelection>) -> String {
+    match selection {
+        Some(selection) if modes.iter().any(|mode| mode.value == selection.mode) => {
+            selection.mode.clone()
+        }
+        _ => modes
+            .first()
+            .map(|mode| mode.value.clone())
+            .unwrap_or_default(),
+    }
+}
+
+fn position_halves(halves: &[Half], visible_mode: &str) {
+    for half in halves {
+        half.set_visible(half.mode_value == visible_mode);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tidemark_types::{AuthCandidate, AuthCandidateState};
+
+    use super::{candidate_selectable, shows_profile_children, state_classes, state_word};
+
+    fn candidate(id: &str, state: AuthCandidateState) -> AuthCandidate {
+        AuthCandidate {
+            id: id.into(),
+            title: id.into(),
+            subtitle: None,
+            state: state.as_wire().into(),
+            children: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn only_a_proven_working_candidate_is_selectable() {
+        assert!(candidate_selectable(AuthCandidateState::Ready));
+    }
+
+    #[test]
+    fn a_source_without_a_usable_credential_cannot_be_chosen() {
+        assert!(!candidate_selectable(AuthCandidateState::Missing));
+        assert!(!candidate_selectable(AuthCandidateState::Rejected));
+    }
+
+    #[test]
+    fn locked_keyrings_and_unanswered_checks_are_insensitive_but_never_red() {
+        assert!(!candidate_selectable(AuthCandidateState::WaitingForKeyring));
+        assert!(!candidate_selectable(AuthCandidateState::Unreachable));
+
+        assert_eq!(
+            state_classes(Some(AuthCandidateState::WaitingForKeyring)),
+            &["dim-label"]
+        );
+        assert_eq!(
+            state_classes(Some(AuthCandidateState::Unreachable)),
+            &["dim-label"]
+        );
+        assert_eq!(state_classes(Some(AuthCandidateState::Ready)), &["success"]);
+        assert_eq!(
+            state_classes(Some(AuthCandidateState::Rejected)),
+            &["error"]
+        );
+        assert_eq!(state_classes(Some(AuthCandidateState::Missing)), &["error"]);
+    }
+
+    #[test]
+    fn every_verdict_has_words_so_colour_is_never_the_only_message() {
+        assert_eq!(state_word(Some(AuthCandidateState::Ready)), "Working");
+        assert_eq!(state_word(Some(AuthCandidateState::Missing)), "Not found");
+        assert_eq!(state_word(Some(AuthCandidateState::Rejected)), "Rejected");
+        assert_eq!(
+            state_word(Some(AuthCandidateState::WaitingForKeyring)),
+            "Keyring locked"
+        );
+        assert_eq!(
+            state_word(Some(AuthCandidateState::Unreachable)),
+            "Inconclusive"
+        );
+
+        // A verdict this build does not know draws the neutral words instead of guessing
+        // that a source a newer daemon doubts is usable.
+        assert_eq!(state_word(None), "Inconclusive");
+        assert_eq!(state_classes(None), &["dim-label"]);
+    }
+
+    #[test]
+    fn profiles_surface_only_when_more_than_one_of_them_are_ready() {
+        let two_ready = vec![
+            candidate("zen/A", AuthCandidateState::Ready),
+            candidate("zen/B", AuthCandidateState::Ready),
+        ];
+        assert!(shows_profile_children(&two_ready));
+
+        // One working profile needs no second choice: activating the browser picks it.
+        let one_ready = vec![
+            candidate("zen/A", AuthCandidateState::Ready),
+            candidate("zen/B", AuthCandidateState::Missing),
+        ];
+        assert!(!shows_profile_children(&one_ready));
+
+        let nothing_ready = vec![
+            candidate("zen/A", AuthCandidateState::Missing),
+            candidate("zen/B", AuthCandidateState::Rejected),
+        ];
+        assert!(!shows_profile_children(&nothing_ready));
+    }
+}

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -42,6 +42,7 @@ pub(super) struct ProviderDetail {
     definition: ProviderDefinition,
     status: RefCell<ProviderStatus>,
     page: adw::NavigationPage,
+    header: adw::HeaderBar,
     authentication: adw::PreferencesGroup,
     key: RefCell<Option<KeyRows>>,
     sign_in: RefCell<Option<SignInRow>>,
@@ -346,6 +347,7 @@ impl ProviderDetail {
             definition,
             status: RefCell::new(status),
             page,
+            header,
             authentication,
             key: RefCell::new(None),
             sign_in: RefCell::new(None),
@@ -893,43 +895,51 @@ impl ProviderDetail {
         let Some(selector) = self.definition.browser_auth.clone() else {
             return;
         };
-        let weak = Rc::downgrade(self);
-        let on_refresh: Rc<dyn Fn()> = Rc::new(move || {
-            if let Some(detail) = weak.upgrade() {
-                detail.open_browser_auth();
+        let refresh = gtk::Button::builder()
+            .icon_name("view-refresh-symbolic")
+            .tooltip_text("Check again")
+            .valign(gtk::Align::Center)
+            .css_classes(["circular"])
+            .build();
+        refresh.connect_clicked({
+            let weak = Rc::downgrade(self);
+            move |_| {
+                if let Some(detail) = weak.upgrade() {
+                    detail.open_browser_auth();
+                }
             }
         });
+        self.header.pack_end(&refresh);
+
         let weak = Rc::downgrade(self);
         let on_choose: Rc<dyn Fn(AuthSelection)> = Rc::new(move |selection| {
-            let Some(detail) = weak.upgrade() else {
-                return;
-            };
-            let proxy = detail.proxy.clone();
-            let (provider, account) = {
-                let status = detail.status.borrow();
-                (status.provider.clone(), status.account.clone())
-            };
-            glib::spawn_future_local(async move {
-                // The daemon validates inside the write, so a refused source leaves the
-                // previous one in force; there is nothing local to roll back, only the
-                // reason to say out loud.
-                if let Err(error) = proxy
-                    .select_auth_source(&provider, &account, selection)
-                    .await
-                {
-                    detail.toast(&reason(&error));
-                    return;
-                }
-                // Asking the daemon to publish now makes the accepted selection's In-use
-                // mark arrive with its status rather than at the next scheduled poll.
-                if let Err(error) = proxy.refresh(&provider).await {
-                    detail.toast(&reason(&error));
-                }
-            });
+            if let Some(detail) = weak.upgrade() {
+                let proxy = detail.proxy.clone();
+                let (provider, account) = {
+                    let status = detail.status.borrow();
+                    (status.provider.clone(), status.account.clone())
+                };
+                glib::spawn_future_local(async move {
+                    // The daemon validates inside the write, so a refused source leaves the
+                    // previous one in force; there is nothing local to roll back, only the
+                    // reason to say out loud.
+                    if let Err(error) = proxy
+                        .select_auth_source(&provider, &account, selection)
+                        .await
+                    {
+                        detail.toast(&reason(&error));
+                        return;
+                    }
+                    // Asking the daemon to publish now makes the accepted selection's In-use
+                    // mark arrive with its status rather than at the next scheduled poll.
+                    if let Err(error) = proxy.refresh(&provider).await {
+                        detail.toast(&reason(&error));
+                    }
+                });
+            }
         });
-
         let published = self.status.borrow().auth_selection.clone();
-        let rows = BrowserAuth::new(&selector, published.as_ref(), on_refresh, on_choose);
+        let rows = BrowserAuth::new(&selector, published.as_ref(), on_choose);
         rows.attach(&self.authentication);
         *self.browser_auth.borrow_mut() = Some(rows);
 

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -558,6 +558,10 @@ impl ProviderDetail {
     }
 
     fn build_authentication(self: &Rc<Self>) {
+        if self.definition.browser_auth.is_some() {
+            self.build_browser_auth();
+            return;
+        }
         match self.definition.credential_kind() {
             Some(CredentialKind::Key) => self.build_key_rows(),
             // A provider whose credential can also come from a CLI on this machine gets
@@ -576,15 +580,9 @@ impl ProviderDetail {
                     self.build_local_rows(external);
                 }
             }
-            // Nothing to paste and nobody to sign in to. What remains is the login this
-            // machine already holds: a provider with an explicit local source gets its
-            // tabs instead of an empty box under a heading that promised a control.
+            // A real credential-free service exposes no authentication controls.
             Some(CredentialKind::None) => {
-                if self.definition.browser_auth.is_some() {
-                    self.build_browser_auth();
-                } else {
-                    self.authentication.set_visible(false);
-                }
+                self.authentication.set_visible(false);
             }
             Some(CredentialKind::External) | None => {
                 let status = self.status.borrow();

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -5,9 +5,11 @@ use std::rc::Rc;
 use adw::prelude::*;
 use gtk::glib;
 use tidemark_types::{
-    CredentialKind, ExternalLogin, ProviderDefinition, ProviderOption, ProviderStatus, Remedy,
+    AuthSelection, CredentialKind, ExternalLogin, ProviderDefinition, ProviderOption,
+    ProviderStatus, Remedy,
 };
 
+use super::browser_auth::BrowserAuth;
 use super::model::AuthSource;
 use super::{model, reason};
 use crate::bus::DaemonProxy;
@@ -47,6 +49,9 @@ pub(super) struct ProviderDetail {
     local: RefCell<Option<LocalRows>>,
     /// The pill that picks between the two halves. Absent for a provider with one.
     choice: RefCell<Option<SourceChoice>>,
+    /// The tabs and source rows of an explicitly chosen local login. Absent when the
+    /// daemon published no such selector for this provider.
+    browser_auth: RefCell<Option<BrowserAuth>>,
     external: RefCell<Option<adw::ActionRow>>,
     options: RefCell<BTreeMap<String, Rc<OptionRow>>>,
     notifications: adw::PreferencesGroup,
@@ -346,6 +351,7 @@ impl ProviderDetail {
             sign_in: RefCell::new(None),
             local: RefCell::new(None),
             choice: RefCell::new(None),
+            browser_auth: RefCell::new(None),
             external: RefCell::new(None),
             options: RefCell::new(BTreeMap::new()),
             notifications,
@@ -414,6 +420,9 @@ impl ProviderDetail {
         drop(rows);
         self.apply_local(status);
         self.apply_notifications(status);
+        if let Some(browser) = self.browser_auth.borrow().as_ref() {
+            browser.apply_selection(status.auth_selection.as_ref());
+        }
     }
 
     /// Puts the pill and the two halves where the daemon says the account is.
@@ -565,10 +574,16 @@ impl ProviderDetail {
                     self.build_local_rows(external);
                 }
             }
-            // Nothing to paste and nobody to sign in to: the whole group would be an empty
-            // box under a heading that promised a control. Configuring the account is its
-            // settings alone, which are a group of their own.
-            Some(CredentialKind::None) => self.authentication.set_visible(false),
+            // Nothing to paste and nobody to sign in to. What remains is the login this
+            // machine already holds: a provider with an explicit local source gets its
+            // tabs instead of an empty box under a heading that promised a control.
+            Some(CredentialKind::None) => {
+                if self.definition.browser_auth.is_some() {
+                    self.build_browser_auth();
+                } else {
+                    self.authentication.set_visible(false);
+                }
+            }
             Some(CredentialKind::External) | None => {
                 let status = self.status.borrow();
                 // The row's stay-off-markup rule: the title is the daemon's connection
@@ -867,6 +882,103 @@ impl ProviderDetail {
         });
     }
 
+    /// The tabs and source rows for picking which login on this machine this account
+    /// reads.
+    ///
+    /// The tabs come from the daemon's selector and the rows from its latest inspection;
+    /// a click anywhere lands as one Select that the daemon validates before storing any
+    /// of it. First inspection starts here, so the page never opens as if nothing were
+    /// being checked.
+    fn build_browser_auth(self: &Rc<Self>) {
+        let Some(selector) = self.definition.browser_auth.clone() else {
+            return;
+        };
+        let weak = Rc::downgrade(self);
+        let on_refresh: Rc<dyn Fn()> = Rc::new(move || {
+            if let Some(detail) = weak.upgrade() {
+                detail.open_browser_auth();
+            }
+        });
+        let weak = Rc::downgrade(self);
+        let on_choose: Rc<dyn Fn(AuthSelection)> = Rc::new(move |selection| {
+            let Some(detail) = weak.upgrade() else {
+                return;
+            };
+            let proxy = detail.proxy.clone();
+            let (provider, account) = {
+                let status = detail.status.borrow();
+                (status.provider.clone(), status.account.clone())
+            };
+            glib::spawn_future_local(async move {
+                // The daemon validates inside the write, so a refused source leaves the
+                // previous one in force; there is nothing local to roll back, only the
+                // reason to say out loud.
+                if let Err(error) = proxy
+                    .select_auth_source(&provider, &account, selection)
+                    .await
+                {
+                    detail.toast(&reason(&error));
+                    return;
+                }
+                // Asking the daemon to publish now makes the accepted selection's In-use
+                // mark arrive with its status rather than at the next scheduled poll.
+                if let Err(error) = proxy.refresh(&provider).await {
+                    detail.toast(&reason(&error));
+                }
+            });
+        });
+
+        let published = self.status.borrow().auth_selection.clone();
+        let rows = BrowserAuth::new(&selector, published.as_ref(), on_refresh, on_choose);
+        rows.attach(&self.authentication);
+        *self.browser_auth.borrow_mut() = Some(rows);
+
+        // Construction counts as opening: the report is what turns Checking… into rows.
+        self.open_browser_auth();
+    }
+
+    /// Inspects this account's local sources again.
+    ///
+    /// The halves go to their checking note first, so a slow daemon reads as busy rather
+    /// than broken; a failure then restores whatever was on screen instead of an empty
+    /// page, because refusing to answer is not evidence about any source.
+    fn open_browser_auth(self: &Rc<Self>) {
+        {
+            let guard = self.browser_auth.borrow();
+            let Some(rows) = guard.as_ref() else {
+                return;
+            };
+            rows.begin_loading();
+        }
+        let (provider, account) = {
+            let status = self.status.borrow();
+            (status.provider.clone(), status.account.clone())
+        };
+        let weak = Rc::downgrade(self);
+        glib::spawn_future_local(async move {
+            let report = match weak.upgrade() {
+                Some(detail) => detail.proxy.get_auth_sources(&provider, &account).await,
+                None => return,
+            };
+            let Some(detail) = weak.upgrade() else {
+                return;
+            };
+            match report {
+                Ok(report) => {
+                    if let Some(rows) = detail.browser_auth.borrow().as_ref() {
+                        rows.apply_report(report);
+                    }
+                }
+                Err(error) => {
+                    if let Some(rows) = detail.browser_auth.borrow().as_ref() {
+                        rows.recover();
+                    }
+                    detail.toast(&reason(&error));
+                }
+            }
+        });
+    }
+
     /// The half that reads a login another program on this machine holds.
     ///
     /// Three things, in the order somebody with a problem needs them: whether the login is
@@ -963,11 +1075,15 @@ impl ProviderDetail {
         } else {
             &status.options
         };
+        // Two exclusions, one per control that owns its setting: the credential pill
+        // draws the OAuth source choice, and the authentication tabs own every local
+        // source identifier. What survives is genuinely a menu.
         let auth_option = self.definition.auth_option();
-        let options: Vec<&ProviderOption> = declared
+        let pill_excluded: Vec<&ProviderOption> = declared
             .iter()
             .filter(|option| Some(option.name.as_str()) != auth_option)
             .collect();
+        let options = model::settings_options(pill_excluded, &self.definition);
         group.set_visible(!options.is_empty());
         for option in options {
             let row = self.build_option_row(option);

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -1171,6 +1171,7 @@ mod tests {
             credential: kind.as_wire().into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         }
     }

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -173,9 +173,9 @@ fn update_row(
             .unwrap_or_else(|| status.state.clone())
     };
     row.row.set_subtitle(&subtitle);
-    let editable = definition.is_some_and(|definition| {
-        opens_detail_after_add(&definition.credential, !definition.options.is_empty())
-    });
+    // A provider with a source selector to pick at counts as editable however it logs in:
+    // which local login to read is configuration, not something polling works out.
+    let editable = definition.is_some_and(opens_detail_after_add);
     row.edit.set_visible(editable);
     row.edit.set_sensitive(editable);
     mark::set(&row.image, &status.provider);

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 use tidemark_types::{ProviderDefinition, ProviderStatus, provider_label};
 
-use super::model;
+use super::{model, opens_detail_after_add};
 use crate::mark;
 
 type IdentityCallback = Rc<dyn Fn(String, String)>;
@@ -173,7 +173,11 @@ fn update_row(
             .unwrap_or_else(|| status.state.clone())
     };
     row.row.set_subtitle(&subtitle);
-    row.edit.set_sensitive(definition.is_some());
+    let editable = definition.is_some_and(|definition| {
+        opens_detail_after_add(&definition.credential, !definition.options.is_empty())
+    });
+    row.edit.set_visible(editable);
+    row.edit.set_sensitive(editable);
     mark::set(&row.image, &status.provider);
 }
 

--- a/crates/tidemark/src/provider_settings/mod.rs
+++ b/crates/tidemark/src/provider_settings/mod.rs
@@ -1,5 +1,6 @@
 //! Navigable provider configuration: configured list, add picker, and stable details.
 
+mod browser_auth;
 mod detail;
 mod list;
 pub mod model;
@@ -332,7 +333,7 @@ impl ProviderSettings {
             }
             settings.refresh_views();
             settings.dialog.pop_subpage();
-            if opens_detail_after_add(&definition.credential, !definition.options.is_empty()) {
+            if opens_detail_after_add(&definition) {
                 settings.open_detail(provider, AccountId::default().to_string());
             }
         });
@@ -470,9 +471,13 @@ fn pending_status(definition: &ProviderDefinition) -> ProviderStatus {
 ///
 /// A browser-session provider with no options starts polling immediately. Pushing an empty
 /// detail page in that case looks like the click did nothing; the configured list and card
-/// are the useful confirmation instead.
-pub(super) fn opens_detail_after_add(credential: &str, has_options: bool) -> bool {
-    credential != CredentialKind::None.as_wire() || has_options
+/// are the useful confirmation instead. Choosing among local authentication sources counts
+/// as something to configure even when there is neither a credential nor an ordinary
+/// setting: which login on this machine to read is the whole decision.
+pub(super) fn opens_detail_after_add(definition: &ProviderDefinition) -> bool {
+    definition.browser_auth.is_some()
+        || definition.credential != CredentialKind::None.as_wire()
+        || !definition.options.is_empty()
 }
 
 /// A D-Bus error as one sentence for a toast.
@@ -487,24 +492,70 @@ pub(super) fn reason(error: &zbus::Error) -> String {
 mod tests {
     use std::collections::HashSet;
 
+    use tidemark_types::{AuthMode, AuthSelector, CredentialKind, ProviderDefinition};
+
     use super::detail::{AfterBeginAction, after_begin_action};
     use super::{
         ActiveDetail, DetailCache, PendingLogins, opens_detail_after_add, remove_local_provider,
     };
-    use tidemark_types::CredentialKind;
+
+    fn definition(credential: CredentialKind) -> ProviderDefinition {
+        ProviderDefinition {
+            provider: "zai".into(),
+            title: "Z.ai".into(),
+            credential: credential.as_wire().into(),
+            credential_hint: String::new(),
+            external: None,
+            browser_auth: None,
+            options: Vec::new(),
+        }
+    }
+
+    /// A Cursor-shaped catalog entry: no credential to paste or sign in to, but an explicit
+    /// local source to pick on its own authentication page.
+    fn keyless_with_browser_auth() -> ProviderDefinition {
+        let mut definition = definition(CredentialKind::None);
+        definition.provider = "cursor".into();
+        definition.browser_auth = Some(AuthSelector {
+            option: "auth-source".into(),
+            modes: vec![
+                AuthMode {
+                    value: "cursor-app".into(),
+                    title: "Cursor App".into(),
+                },
+                AuthMode {
+                    value: "browser".into(),
+                    title: "Browser".into(),
+                },
+            ],
+        });
+        definition
+    }
 
     #[test]
-    fn a_keyless_provider_without_options_returns_to_the_configured_list_after_adding() {
-        assert!(!opens_detail_after_add(
-            CredentialKind::None.as_wire(),
-            false
-        ));
+    fn a_keyless_provider_without_sources_or_options_returns_to_the_list_after_adding() {
+        assert!(!opens_detail_after_add(&definition(CredentialKind::None)));
+    }
+
+    #[test]
+    fn a_keyless_provider_that_picks_a_local_source_opens_its_detail_after_adding() {
+        // Nothing was typed or signed in to, yet there is something to configure: choosing
+        // which login on this machine to read is the whole point of adding it.
+        assert!(opens_detail_after_add(&keyless_with_browser_auth()));
     }
 
     #[test]
     fn a_provider_with_a_credential_or_options_opens_its_detail_after_adding() {
-        assert!(opens_detail_after_add(CredentialKind::Key.as_wire(), false));
-        assert!(opens_detail_after_add(CredentialKind::None.as_wire(), true));
+        assert!(opens_detail_after_add(&definition(CredentialKind::Key)));
+        let mut with_options = definition(CredentialKind::None);
+        with_options.options.push(tidemark_types::ProviderOption {
+            name: "model".into(),
+            title: "Model".into(),
+            description: None,
+            value: String::new(),
+            choices: Vec::new(),
+        });
+        assert!(opens_detail_after_add(&with_options));
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/mod.rs
+++ b/crates/tidemark/src/provider_settings/mod.rs
@@ -10,7 +10,7 @@ use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
 use gtk::glib;
-use tidemark_types::{AccountId, ProviderDefinition, ProviderId, ProviderStatus};
+use tidemark_types::{AccountId, CredentialKind, ProviderDefinition, ProviderId, ProviderStatus};
 
 use self::detail::ProviderDetail;
 use self::list::{ConfiguredList, Picker};
@@ -332,7 +332,9 @@ impl ProviderSettings {
             }
             settings.refresh_views();
             settings.dialog.pop_subpage();
-            settings.open_detail(provider, AccountId::default().to_string());
+            if opens_detail_after_add(&definition.credential, !definition.options.is_empty()) {
+                settings.open_detail(provider, AccountId::default().to_string());
+            }
         });
     }
 
@@ -464,6 +466,15 @@ fn pending_status(definition: &ProviderDefinition) -> ProviderStatus {
     status
 }
 
+/// Whether a provider has a configuration detail worth navigating to after it is added.
+///
+/// A browser-session provider with no options starts polling immediately. Pushing an empty
+/// detail page in that case looks like the click did nothing; the configured list and card
+/// are the useful confirmation instead.
+pub(super) fn opens_detail_after_add(credential: &str, has_options: bool) -> bool {
+    credential != CredentialKind::None.as_wire() || has_options
+}
+
 /// A D-Bus error as one sentence for a toast.
 pub(super) fn reason(error: &zbus::Error) -> String {
     match error {
@@ -477,7 +488,24 @@ mod tests {
     use std::collections::HashSet;
 
     use super::detail::{AfterBeginAction, after_begin_action};
-    use super::{ActiveDetail, DetailCache, PendingLogins, remove_local_provider};
+    use super::{
+        ActiveDetail, DetailCache, PendingLogins, opens_detail_after_add, remove_local_provider,
+    };
+    use tidemark_types::CredentialKind;
+
+    #[test]
+    fn a_keyless_provider_without_options_returns_to_the_configured_list_after_adding() {
+        assert!(!opens_detail_after_add(
+            CredentialKind::None.as_wire(),
+            false
+        ));
+    }
+
+    #[test]
+    fn a_provider_with_a_credential_or_options_opens_its_detail_after_adding() {
+        assert!(opens_detail_after_add(CredentialKind::Key.as_wire(), false));
+        assert!(opens_detail_after_add(CredentialKind::None.as_wire(), true));
+    }
 
     #[test]
     fn pending_logins_are_taken_once_for_cancellation() {

--- a/crates/tidemark/src/provider_settings/model.rs
+++ b/crates/tidemark/src/provider_settings/model.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-use tidemark_types::{ExternalLogin, ProviderDefinition, ProviderState, ProviderStatus};
+use tidemark_types::{
+    AuthSelection, ExternalLogin, ProviderDefinition, ProviderOption, ProviderState, ProviderStatus,
+};
 
 /// Catalog entries which have not already been configured and match the query.
 pub fn addable<'a>(
@@ -71,6 +73,42 @@ pub fn auth_source(definition: &ProviderDefinition, status: &ProviderStatus) -> 
             .and_then(AuthSource::from_value)
             .unwrap_or(AuthSource::Tidemark),
     )
+}
+
+/// The candidate row an account's published selection points at within one mode.
+///
+/// Modes that carry no separate candidate — Cursor App is chosen by choosing the mode —
+/// claim their own availability row, so highlighting a source needs no special case.
+pub fn selected_candidate<'a>(
+    selection: &'a AuthSelection,
+    mode_value: &'a str,
+) -> Option<&'a str> {
+    if selection.mode != mode_value {
+        return None;
+    }
+    Some(selection.candidate.as_deref().unwrap_or(mode_value))
+}
+
+/// A provider's own settings that remain after its authentication capability took what is
+/// the daemon's to write.
+///
+/// The selector option draws nothing here — the authentication tabs above choose it — and
+/// an option carrying no choices has no menu to draw at all: those are identifiers, like
+/// which browser was picked, that only daemon source selection may set. Sent as they
+/// arrived when this build speaks with no such capability.
+pub fn settings_options<'a>(
+    declared: impl IntoIterator<Item = &'a ProviderOption>,
+    definition: &ProviderDefinition,
+) -> Vec<&'a ProviderOption> {
+    declared
+        .into_iter()
+        .filter(|option| {
+            !definition
+                .browser_auth
+                .as_ref()
+                .is_some_and(|selector| selector.option == option.name || option.choices.is_empty())
+        })
+        .collect()
 }
 
 /// Concise copy for the configured-provider list, and for the heading of the half in force.
@@ -183,13 +221,15 @@ mod tests {
     use std::collections::HashSet;
 
     use tidemark_types::{
-        AccountId, CredentialKind, ExternalLogin, OptionChoice, ProviderDefinition, ProviderId,
-        ProviderOption, ProviderState, ProviderStatus,
+        AccountId, AuthMode, AuthSelection, AuthSelector, CredentialKind, ExternalLogin,
+        OptionChoice, ProviderDefinition, ProviderId, ProviderOption, ProviderState,
+        ProviderStatus,
     };
 
     use super::{
         AuthSource, NotificationRow, addable, auth_source, connection_text, external_presence_text,
-        merge_local_additions, notification_rows, write_back_text,
+        merge_local_additions, notification_rows, selected_candidate, settings_options,
+        write_back_text,
     };
 
     fn definition(provider: &str, title: &str) -> ProviderDefinition {
@@ -443,5 +483,108 @@ mod tests {
     fn an_account_that_has_never_been_polled_offers_nothing_to_switch() {
         let status = ProviderStatus::pending(&ProviderId::new("claude"), &AccountId::default());
         assert!(notification_rows(&status).is_empty());
+    }
+
+    /// One published choice, as every menu-bearing option carries it.
+    fn choice(value: &str, title: &str) -> OptionChoice {
+        OptionChoice {
+            value: value.into(),
+            title: title.into(),
+        }
+    }
+
+    /// What the daemon publishes for a provider whose login is one explicit local source:
+    /// the selector's own option plus the identifier settings only the daemon may write.
+    fn cursor_like_definition() -> ProviderDefinition {
+        ProviderDefinition {
+            provider: "cursor".into(),
+            title: "Cursor".into(),
+            credential: CredentialKind::None.as_wire().into(),
+            credential_hint: String::new(),
+            external: None,
+            browser_auth: Some(AuthSelector {
+                option: "auth-source".into(),
+                modes: vec![
+                    AuthMode {
+                        value: "cursor-app".into(),
+                        title: "Cursor App".into(),
+                    },
+                    AuthMode {
+                        value: "browser".into(),
+                        title: "Browser".into(),
+                    },
+                ],
+            }),
+            options: vec![
+                ProviderOption {
+                    name: "auth-source".into(),
+                    title: "Authentication source".into(),
+                    description: None,
+                    value: String::new(),
+                    choices: vec![
+                        choice("cursor-app", "Cursor App"),
+                        choice("browser", "Browser"),
+                    ],
+                },
+                ProviderOption {
+                    name: "auth-browser".into(),
+                    title: "Browser".into(),
+                    description: None,
+                    value: String::new(),
+                    choices: Vec::new(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn the_source_selector_owns_its_settings_instead_of_the_menu_below() {
+        // The selector option itself, and every choiceless identifier the daemon writes
+        // through source selection, would each draw a menu of nothing — the tabs above are
+        // where those are chosen.
+        let definition = cursor_like_definition();
+        assert!(settings_options(definition.options.iter(), &definition).is_empty());
+    }
+
+    #[test]
+    fn ordinary_provider_choices_keep_their_place_under_the_tabs() {
+        let mut definition = definition("zai", "Z.ai");
+        definition.options = vec![ProviderOption {
+            name: "model".into(),
+            title: "Model".into(),
+            description: None,
+            value: "auto".into(),
+            choices: vec![choice("auto", "Automatic")],
+        }];
+        let names: Vec<&str> = settings_options(definition.options.iter(), &definition)
+            .iter()
+            .map(|option| option.name.as_str())
+            .collect();
+        assert_eq!(names, ["model"]);
+    }
+
+    #[test]
+    fn a_published_selection_names_the_row_it_claims_inside_its_mode() {
+        let nested = AuthSelection {
+            mode: "browser".into(),
+            candidate: Some("zen/profile-a".into()),
+        };
+        assert_eq!(
+            selected_candidate(&nested, "browser"),
+            Some("zen/profile-a")
+        );
+        assert_eq!(selected_candidate(&nested, "cursor-app"), None);
+    }
+
+    #[test]
+    fn a_mode_without_a_separate_candidate_claims_its_own_row() {
+        let direct = AuthSelection {
+            mode: "cursor-app".into(),
+            candidate: None,
+        };
+        assert_eq!(
+            selected_candidate(&direct, "cursor-app"),
+            Some("cursor-app")
+        );
     }
 }

--- a/crates/tidemark/src/provider_settings/model.rs
+++ b/crates/tidemark/src/provider_settings/model.rs
@@ -199,6 +199,7 @@ mod tests {
             credential: CredentialKind::Key.as_wire().into(),
             credential_hint: "Create a key in the provider dashboard.".into(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         }
     }
@@ -236,6 +237,7 @@ mod tests {
             credential: CredentialKind::OAuth.as_wire().into(),
             credential_hint: "Sign in through a browser.".into(),
             external,
+            browser_auth: None,
             options,
         }
     }

--- a/crates/tidemark/src/tray.rs
+++ b/crates/tidemark/src/tray.rs
@@ -502,6 +502,7 @@ mod tests {
             credential: "key".to_owned(),
             credential_hint: "ClinePass console.".to_owned(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         }]);
         assert_eq!(

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -591,9 +591,9 @@ impl Engine {
             return Err(format!("account {provider}/{account} is not configured"));
         };
         let sources = self.inspect_auth_sources(provider, account).await?;
-        if !is_ready_auth_selection(&sources, &selection) {
+        let Some(selection) = ready_auth_selection(&sources, &selection) else {
             return Err("the selected authentication source is not ready".into());
-        }
+        };
 
         let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
         config
@@ -1294,26 +1294,53 @@ pub fn stored_kind(credential: CredentialKind) -> Option<Kind> {
     }
 }
 
-/// Whether an inspected, ready candidate exactly names the requested local source.
-fn is_ready_auth_selection(sources: &[AuthCandidate], selection: &AuthSelection) -> bool {
-    let Some(mode) = sources
+/// The exact ready source an inspected choice names.
+///
+/// A browser parent is a one-click shorthand only. The persisted choice is its first ready
+/// profile in inspection order, so a later poll cannot re-scan and choose a different account.
+fn ready_auth_selection(
+    sources: &[AuthCandidate],
+    selection: &AuthSelection,
+) -> Option<AuthSelection> {
+    let mode = sources
         .iter()
-        .find(|candidate| candidate.id == selection.mode)
-    else {
-        return false;
-    };
+        .find(|candidate| candidate.id == selection.mode)?;
     match selection.candidate.as_deref() {
-        None => mode.state() == Some(AuthCandidateState::Ready),
-        Some(candidate) => ready_descendant(&mode.children, candidate),
+        None if mode.state() == Some(AuthCandidateState::Ready) => Some(selection.clone()),
+        None => None,
+        Some(candidate) => {
+            ready_descendant(&mode.children, candidate).map(|candidate| AuthSelection {
+                mode: selection.mode.clone(),
+                candidate: Some(candidate.id.clone()),
+            })
+        }
     }
 }
 
-/// Searches only below the selected top-level mode, preserving a mode's candidate scope.
-fn ready_descendant(candidates: &[AuthCandidate], selected: &str) -> bool {
-    candidates.iter().any(|candidate| {
-        (candidate.id == selected && candidate.state() == Some(AuthCandidateState::Ready))
-            || ready_descendant(&candidate.children, selected)
+/// Finds a selected ready candidate and resolves parent shortcuts to their first ready leaf.
+fn ready_descendant<'a>(
+    candidates: &'a [AuthCandidate],
+    selected: &str,
+) -> Option<&'a AuthCandidate> {
+    candidates.iter().find_map(|candidate| {
+        if candidate.id == selected && candidate.state() == Some(AuthCandidateState::Ready) {
+            first_ready_leaf(candidate)
+        } else {
+            ready_descendant(&candidate.children, selected)
+        }
     })
+}
+
+/// The first proven leaf in the daemon's stable discovery order.
+fn first_ready_leaf(candidate: &AuthCandidate) -> Option<&AuthCandidate> {
+    if candidate.state() != Some(AuthCandidateState::Ready) {
+        return None;
+    }
+    candidate
+        .children
+        .iter()
+        .find_map(first_ready_leaf)
+        .or(Some(candidate))
 }
 
 /// What asking the keyring for a credential produced.
@@ -1776,7 +1803,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_ready_browser_auth_source_is_validated_then_persisted_and_rebuilt() {
+    async fn a_browser_parent_persists_its_first_validated_profile_then_rebuilds() {
         // If the validation moved after the write, an unknown candidate could replace the
         // working Cursor App source with a browser the daemon has never proved usable.
         let path = std::env::temp_dir().join(format!(
@@ -1813,13 +1840,22 @@ mod tests {
                     title: "Firefox".into(),
                     subtitle: None,
                     state: "ready".into(),
-                    children: vec![AuthCandidate {
-                        id: "firefox/work".into(),
-                        title: "Work".into(),
-                        subtitle: None,
-                        state: "ready".into(),
-                        children: Vec::new(),
-                    }],
+                    children: vec![
+                        AuthCandidate {
+                            id: "firefox/work".into(),
+                            title: "Work".into(),
+                            subtitle: None,
+                            state: "ready".into(),
+                            children: Vec::new(),
+                        },
+                        AuthCandidate {
+                            id: "firefox/personal".into(),
+                            title: "Personal".into(),
+                            subtitle: None,
+                            state: "ready".into(),
+                            children: Vec::new(),
+                        },
+                    ],
                 }],
             },
         ];
@@ -1873,14 +1909,18 @@ mod tests {
                 "default",
                 AuthSelection {
                     mode: "browser".into(),
-                    candidate: Some("firefox/work".into()),
+                    candidate: Some("firefox".into()),
                 },
             )
             .await
             .expect("ready source is committed");
         let written = Config::at(path.clone()).expect("config parses");
         assert_eq!(written.option("cursor", "auth-browser"), Some("firefox"));
-        assert_eq!(written.option("cursor", "auth-profile"), Some("work"));
+        assert_eq!(
+            written.option("cursor", "auth-profile"),
+            Some("work"),
+            "a one-click browser choice is pinned to the exact ready profile it proved"
+        );
         assert_eq!(
             harness.engine.accounts[0].status.auth_selection,
             Some(AuthSelection {

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -18,8 +18,9 @@ use tidemark_core::providers::{Credential, Provider, ProviderError};
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_core::storage::{History, IngestReport};
 use tidemark_types::{
-    AccountId, CredentialKind, HistoryPoint, Preferences, ProviderId, ProviderOption,
-    ProviderState, ProviderStatus, Snapshot, Timestamp, WindowKey, WindowStatus,
+    AccountId, AuthCandidate, AuthCandidateState, AuthSelection, CredentialKind, HistoryPoint,
+    Preferences, ProviderId, ProviderOption, ProviderState, ProviderStatus, Snapshot, Timestamp,
+    WindowKey, WindowStatus,
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
@@ -116,6 +117,26 @@ pub enum Command {
         /// One of the option's declared values.
         value: String,
         /// Completion sent after persistence and in-memory state agree.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Discovers dynamic local authentication sources for one configured account.
+    InspectAuthSources {
+        /// Stable provider slug.
+        provider: String,
+        /// Stable account name.
+        account: String,
+        /// Secret-free candidate report.
+        reply: oneshot::Sender<Result<Vec<AuthCandidate>, String>>,
+    },
+    /// Revalidates and stores one explicit dynamic local authentication source.
+    SelectAuthSource {
+        /// Stable provider slug.
+        provider: String,
+        /// Stable account name.
+        account: String,
+        /// The mode and opaque candidate identity selected by the client.
+        selection: AuthSelection,
+        /// Completion sent after validation, persistence and publication finish.
         reply: oneshot::Sender<Result<(), String>>,
     },
     /// Switch one window's notifications on or off, in the same queue as topology writes.
@@ -312,6 +333,12 @@ impl Account {
     /// Replaces the published settings of this provider.
     pub fn with_options(mut self, options: Vec<ProviderOption>) -> Self {
         self.status.options = options;
+        self
+    }
+
+    /// Publishes the explicit local browser-cookie source selected in config.
+    pub fn with_auth_selection(mut self, selection: Option<AuthSelection>) -> Self {
+        self.status.auth_selection = selection;
         self
     }
 
@@ -529,6 +556,66 @@ impl Engine {
         Ok(())
     }
 
+    /// Discovers and validates the dynamic local sources one configured account offers.
+    pub async fn inspect_auth_sources(
+        &mut self,
+        provider: &str,
+        account: &str,
+    ) -> Result<Vec<AuthCandidate>, String> {
+        let Some(index) = self.accounts.iter().position(|configured| {
+            configured.provider.as_str() == provider && configured.account.as_str() == account
+        }) else {
+            return Err(format!("account {provider}/{account} is not configured"));
+        };
+        self.ensure_client(index).await;
+        let client = self.accounts[index]
+            .client
+            .as_ref()
+            .ok_or_else(|| format!("{provider} has no client for authentication inspection"))?;
+        client
+            .inspect_auth_sources()
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    /// Revalidates, then atomically persists one selected dynamic local source.
+    pub async fn select_auth_source(
+        &mut self,
+        provider: &str,
+        account: &str,
+        selection: AuthSelection,
+    ) -> Result<(), String> {
+        let Some(index) = self.accounts.iter().position(|configured| {
+            configured.provider.as_str() == provider && configured.account.as_str() == account
+        }) else {
+            return Err(format!("account {provider}/{account} is not configured"));
+        };
+        let sources = self.inspect_auth_sources(provider, account).await?;
+        if !is_ready_auth_selection(&sources, &selection) {
+            return Err("the selected authentication source is not ready".into());
+        }
+
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        config
+            .set_auth_selection(provider, &selection)
+            .map_err(|error| error.to_string())?;
+        let target = &mut self.accounts[index];
+        target.status.options = crate::registry::options(provider, &config);
+        target.status.auth_selection = crate::registry::browser_auth_selection(provider, &config);
+        if target.rebuildable() {
+            target.client = None;
+        }
+        target.failures = 0;
+        target.retry_after = None;
+        target.due = Instant::now();
+        target.status.next_poll_at = Some(Timestamp::now().as_unix());
+        let _ = self
+            .updates
+            .send(Publication::Changed(target.status.clone()))
+            .await;
+        Ok(())
+    }
+
     /// Persists one application preference in the same serial queue as every other config
     /// mutation. Returning the complete set lets the service publish one coherent view.
     ///
@@ -676,6 +763,14 @@ impl Engine {
                     }
                     Some(Command::SetOption { provider, account, name, value, reply }) => {
                         let result = self.set_option(&provider, &account, &name, &value).await;
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::InspectAuthSources { provider, account, reply }) => {
+                        let result = self.inspect_auth_sources(&provider, &account).await;
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::SelectAuthSource { provider, account, selection, reply }) => {
+                        let result = self.select_auth_source(&provider, &account, selection).await;
                         let _ = reply.send(result);
                     }
                     Some(Command::SetWindowNotify { provider, account, window, enabled, reply }) => {
@@ -1199,6 +1294,28 @@ pub fn stored_kind(credential: CredentialKind) -> Option<Kind> {
     }
 }
 
+/// Whether an inspected, ready candidate exactly names the requested local source.
+fn is_ready_auth_selection(sources: &[AuthCandidate], selection: &AuthSelection) -> bool {
+    let Some(mode) = sources
+        .iter()
+        .find(|candidate| candidate.id == selection.mode)
+    else {
+        return false;
+    };
+    match selection.candidate.as_deref() {
+        None => mode.state() == Some(AuthCandidateState::Ready),
+        Some(candidate) => ready_descendant(&mode.children, candidate),
+    }
+}
+
+/// Searches only below the selected top-level mode, preserving a mode's candidate scope.
+fn ready_descendant(candidates: &[AuthCandidate], selected: &str) -> bool {
+    candidates.iter().any(|candidate| {
+        (candidate.id == selected && candidate.state() == Some(AuthCandidateState::Ready))
+            || ready_descendant(&candidate.children, selected)
+    })
+}
+
 /// What asking the keyring for a credential produced.
 enum Loaded {
     /// A client, ready to poll.
@@ -1256,7 +1373,7 @@ mod tests {
     use crate::notify::{Notice, Notifier, NotifyError};
     use std::sync::Mutex;
     use tidemark_core::providers::BoxFuture;
-    use tidemark_types::{Window, WindowKey, WindowLength};
+    use tidemark_types::{AuthCandidate, AuthSelection, Window, WindowKey, WindowLength};
 
     #[test]
     fn a_missing_cli_credential_has_its_own_published_state() {
@@ -1295,6 +1412,26 @@ mod tests {
                 .pop()
                 .unwrap_or(Err(ProviderError::Http { status: 503 }));
             Box::pin(async move { answer })
+        }
+    }
+
+    /// A rebuildable provider whose authentication candidates are fixed test metadata.
+    #[derive(Debug)]
+    struct AuthFake {
+        sources: Vec<AuthCandidate>,
+    }
+
+    impl Provider for AuthFake {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("cursor")
+        }
+
+        fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+            Box::pin(async { Err(ProviderError::NoCredential) })
+        }
+
+        fn inspect_auth_sources(&self) -> BoxFuture<'_, Result<Vec<AuthCandidate>, ProviderError>> {
+            Box::pin(async { Ok(self.sources.clone()) })
         }
     }
 
@@ -1636,6 +1773,135 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&config_path);
+    }
+
+    #[tokio::test]
+    async fn a_ready_browser_auth_source_is_validated_then_persisted_and_rebuilt() {
+        // If the validation moved after the write, an unknown candidate could replace the
+        // working Cursor App source with a browser the daemon has never proved usable.
+        let path = std::env::temp_dir().join(format!(
+            "tidemark-engine-auth-source-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut config = Config::at(path.clone()).expect("empty config parses");
+        config.add_provider("cursor").expect("Cursor configured");
+        config
+            .set_auth_selection(
+                "cursor",
+                &AuthSelection {
+                    mode: "cursor-app".into(),
+                    candidate: None,
+                },
+            )
+            .expect("Cursor App stored");
+        let sources = vec![
+            AuthCandidate {
+                id: "cursor-app".into(),
+                title: "Cursor App".into(),
+                subtitle: None,
+                state: "ready".into(),
+                children: Vec::new(),
+            },
+            AuthCandidate {
+                id: "browser".into(),
+                title: "Browser".into(),
+                subtitle: None,
+                state: "ready".into(),
+                children: vec![AuthCandidate {
+                    id: "firefox".into(),
+                    title: "Firefox".into(),
+                    subtitle: None,
+                    state: "ready".into(),
+                    children: vec![AuthCandidate {
+                        id: "firefox/work".into(),
+                        title: "Work".into(),
+                        subtitle: None,
+                        state: "ready".into(),
+                        children: Vec::new(),
+                    }],
+                }],
+            },
+        ];
+        let source_copy = sources.clone();
+        let account = Account::keyless(
+            ProviderId::new("cursor"),
+            AccountId::default(),
+            Box::new(move |_| {
+                Ok(Arc::new(AuthFake {
+                    sources: source_copy.clone(),
+                }) as Arc<dyn Provider>)
+            }),
+        )
+        .with_options(crate::registry::options("cursor", &config))
+        .with_auth_selection(crate::registry::browser_auth_selection("cursor", &config));
+        let mut harness = harness_with_config(vec![account], path.clone());
+        harness.engine.ensure_client(0).await;
+        assert!(
+            harness.engine.accounts[0].client.is_some(),
+            "old client is live"
+        );
+
+        assert!(
+            harness
+                .engine
+                .select_auth_source(
+                    "cursor",
+                    "default",
+                    AuthSelection {
+                        mode: "browser".into(),
+                        candidate: Some("firefox/unknown".into()),
+                    },
+                )
+                .await
+                .is_err()
+        );
+        let untouched = Config::at(path.clone()).expect("config still parses");
+        assert_eq!(
+            untouched.option("cursor", "auth-source"),
+            Some("cursor-app")
+        );
+        assert!(
+            harness.engine.accounts[0].client.is_some(),
+            "rejection keeps the client"
+        );
+
+        harness
+            .engine
+            .select_auth_source(
+                "cursor",
+                "default",
+                AuthSelection {
+                    mode: "browser".into(),
+                    candidate: Some("firefox/work".into()),
+                },
+            )
+            .await
+            .expect("ready source is committed");
+        let written = Config::at(path.clone()).expect("config parses");
+        assert_eq!(written.option("cursor", "auth-browser"), Some("firefox"));
+        assert_eq!(written.option("cursor", "auth-profile"), Some("work"));
+        assert_eq!(
+            harness.engine.accounts[0].status.auth_selection,
+            Some(AuthSelection {
+                mode: "browser".into(),
+                candidate: Some("firefox/work".into()),
+            })
+        );
+        assert!(
+            harness.engine.accounts[0].client.is_none(),
+            "client is rebuilt on poll"
+        );
+        assert_eq!(
+            harness.wait_secs(),
+            0,
+            "the selected source is due immediately"
+        );
+        assert!(matches!(
+            harness.updates.recv().await,
+            Some(Publication::Changed(status)) if status.auth_selection.is_some()
+        ));
+        let _ = std::fs::remove_file(path);
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -201,6 +201,7 @@ pub fn catalog(config: &Config) -> Vec<ProviderDefinition> {
                 command: entry.external_command.to_owned(),
                 writes_back: entry.writes_back,
             }),
+            browser_auth: None,
             options: options(entry.slug, config),
         })
         .collect();
@@ -210,6 +211,7 @@ pub fn catalog(config: &Config) -> Vec<ProviderDefinition> {
         credential: CredentialKind::Key.as_wire().to_owned(),
         credential_hint: spec.credential_hint.to_owned(),
         external: None,
+        browser_auth: None,
         options: options(spec.id, config),
     }));
     definitions.extend(
@@ -232,6 +234,7 @@ fn hand_written_definition(spec: &keyed::HandSpec, config: &Config) -> ProviderD
         credential: spec.credential.as_wire().to_owned(),
         credential_hint: spec.credential_hint.to_owned(),
         external: None,
+        browser_auth: None,
         options: options(spec.id, config),
     }
 }

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -602,15 +602,24 @@ fn keyed_account(spec: &'static keyed::Spec) -> Account {
 /// builder says what to do with them. It, too, resolves its URLs at build time and refuses
 /// a required option that is unset, naming it.
 fn hand_written_account(spec: &'static keyed::HandSpec) -> Account {
-    if spec.credential == CredentialKind::None {
-        // Nothing is stored and nothing is asked for, so there is no key to hand the
-        // builder — it is given a blank one and ignores it. The settings are the whole of
-        // what this account is, which is why it is built from them alone.
-        return Account::keyless(
+    if matches!(
+        spec.credential,
+        CredentialKind::None | CredentialKind::External
+    ) {
+        // Neither local gateways nor external local sessions have a Tidemark-owned secret.
+        // Both rebuild from settings alone; their published kinds still distinguish the two
+        // contracts for clients. A credential-free service also keeps its hint absent —
+        // there is genuinely nothing to say about where a nonexistent secret comes from.
+        let account = Account::keyless(
             ProviderId::new(spec.id),
             AccountId::default(),
             Box::new(move |options| (spec.build)(Credential::new(String::new()), options)),
-        );
+        )
+        .with_credential(spec.credential);
+        if spec.credential_hint.is_empty() {
+            return account;
+        }
+        return account.with_hint(spec.credential_hint);
     }
     Account::new(
         ProviderId::new(spec.id),
@@ -760,6 +769,9 @@ mod tests {
             .into_iter()
             .find(|definition| definition.provider == cursor::PROVIDER_ID)
             .expect("Cursor is in the catalog");
+        // The session belongs to another application: D-Bus clients must see external,
+        // not none, so their authentication semantics stay honest.
+        assert_eq!(definition.credential_kind(), Some(CredentialKind::External));
         let selector = definition
             .browser_auth
             .expect("Cursor has local source selection");

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use tidemark_core::config::Config;
 use tidemark_core::oauth;
 use tidemark_core::providers::keyed::{
-    self, aiand, codebuff, deepgram, deepinfra, factory, fireworks, groq, ibmbob, kilo, litellm,
-    llmproxy, nanogpt, openai_api, openrouter, poe, sub2api, wayfinder, xai,
+    self, aiand, codebuff, cursor, deepgram, deepinfra, factory, fireworks, groq, ibmbob, kilo,
+    litellm, llmproxy, nanogpt, openai_api, openrouter, poe, sub2api, wayfinder, xai,
 };
 use tidemark_core::providers::{
     AUTO_SOURCE, CLI_SOURCE, Credential, OAUTH_SOURCE, Provider, ProviderError, Source,
@@ -109,6 +109,9 @@ fn oauth_entry(provider: &str) -> Option<&'static OAuthEntry> {
 /// The hand-written key-authenticated providers: those whose fetch is more than one
 /// request, so a `keyed::Spec` cannot describe them — ai& pages a request log,
 /// Codebuff posts for credits and then reads a subscription it can do without,
+/// Cursor reads a usage summary and then the identity, legacy request quota and weekly Bot
+/// allowance an account may or may not have, signing every request with the session cookie
+/// a browser on this machine already holds rather than with anything the user is asked for,
 /// Deepgram lists projects and then reads a usage breakdown for each (and puts its key in
 /// a scheme of its own, `Authorization: Token`, which `keyed::Auth` cannot express),
 /// DeepInfra reads a checklist and a month's usage, Factory walks an
@@ -133,6 +136,7 @@ fn oauth_entry(provider: &str) -> Option<&'static OAuthEntry> {
 static HAND_WRITTEN: &[&keyed::HandSpec] = &[
     &aiand::SPEC,
     &codebuff::SPEC,
+    &cursor::SPEC,
     &deepgram::SPEC,
     &deepinfra::SPEC,
     &factory::SPEC,
@@ -916,7 +920,7 @@ mod tests {
                 .is_empty()
         );
         let definitions = catalog(&config);
-        assert_eq!(definitions.len(), 38);
+        assert_eq!(definitions.len(), 39);
         assert_eq!(definitions[0].provider, "antigravity");
         assert_eq!(definitions[0].credential, CredentialKind::OAuth.as_wire());
         assert_eq!(

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -34,8 +34,8 @@ use tidemark_core::providers::{
 };
 use tidemark_core::secrets::Secrets;
 use tidemark_types::{
-    AccountId, CredentialKind, ExternalLogin, OptionChoice, ProviderDefinition, ProviderId,
-    ProviderOption, ProviderStatus,
+    AccountId, AuthMode, AuthSelection, AuthSelector, CredentialKind, ExternalLogin, OptionChoice,
+    ProviderDefinition, ProviderId, ProviderOption, ProviderStatus,
 };
 
 use crate::engine::Account;
@@ -234,7 +234,7 @@ fn hand_written_definition(spec: &keyed::HandSpec, config: &Config) -> ProviderD
         credential: spec.credential.as_wire().to_owned(),
         credential_hint: spec.credential_hint.to_owned(),
         external: None,
-        browser_auth: None,
+        browser_auth: browser_auth(spec.id),
         options: options(spec.id, config),
     }
 }
@@ -263,8 +263,55 @@ pub fn account(
     Ok(account.map(|account| {
         account
             .with_options(options(provider, config))
+            .with_auth_selection(browser_auth_selection(provider, config))
             .with_notify(notify(provider, config))
     }))
+}
+
+/// The local browser-auth capability one hand-written provider declares.
+///
+/// This is daemon metadata rather than a GUI branch: a later browser-cookie provider adds
+/// its selector here and gets the same wire contract, engine lifecycle and GTK rendering.
+fn browser_auth(provider: &str) -> Option<AuthSelector> {
+    (provider == cursor::PROVIDER_ID).then(|| AuthSelector {
+        option: cursor::AUTH_SOURCE.into(),
+        modes: vec![
+            AuthMode {
+                value: cursor::CURSOR_APP_SOURCE.into(),
+                title: "Cursor App".into(),
+            },
+            AuthMode {
+                value: cursor::BROWSER_SOURCE.into(),
+                title: "Browser".into(),
+            },
+        ],
+    })
+}
+
+/// The durable config source an account is already constrained to, if it is complete.
+///
+/// An incomplete or hand-edited value deliberately remains absent: treating it as another
+/// source would restore the old silent fallback this selector is designed to remove.
+pub(crate) fn browser_auth_selection(provider: &str, config: &Config) -> Option<AuthSelection> {
+    browser_auth(provider)?;
+    match config.option(provider, cursor::AUTH_SOURCE) {
+        Some(cursor::CURSOR_APP_SOURCE) => Some(AuthSelection {
+            mode: cursor::CURSOR_APP_SOURCE.into(),
+            candidate: None,
+        }),
+        Some(cursor::BROWSER_SOURCE) => {
+            let browser = config.option(provider, cursor::AUTH_BROWSER)?;
+            let candidate = match config.option(provider, cursor::AUTH_PROFILE) {
+                Some(profile) => format!("{browser}/{profile}"),
+                None => browser.to_owned(),
+            };
+            Some(AuthSelection {
+                mode: cursor::BROWSER_SOURCE.into(),
+                candidate: Some(candidate),
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Every configured account the daemon polls, in the order of `config.toml`.
@@ -705,6 +752,46 @@ mod tests {
                 definition.provider
             );
         }
+    }
+
+    #[test]
+    fn cursor_publishes_its_browser_auth_capability_and_stored_selection() {
+        let definition = catalog(&empty_config())
+            .into_iter()
+            .find(|definition| definition.provider == cursor::PROVIDER_ID)
+            .expect("Cursor is in the catalog");
+        let selector = definition
+            .browser_auth
+            .expect("Cursor has local source selection");
+        assert_eq!(selector.option, cursor::AUTH_SOURCE);
+        assert_eq!(
+            selector
+                .modes
+                .iter()
+                .map(|mode| (mode.value.as_str(), mode.title.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                (cursor::CURSOR_APP_SOURCE, "Cursor App"),
+                (cursor::BROWSER_SOURCE, "Browser"),
+            ]
+        );
+
+        let path = scratch_config(
+            "cursor-browser-selection",
+            "providers = [\"cursor\"]\n\n[provider.cursor]\nauth-source = \"browser\"\nauth-browser = \"zen\"\nauth-profile = \"work\"\n",
+        );
+        let config = Config::at(path.clone()).expect("config reads");
+        let account = account(cursor::PROVIDER_ID, &secrets(), &config)
+            .expect("builds")
+            .expect("Cursor account builds");
+        assert_eq!(
+            account.status().auth_selection,
+            Some(tidemark_types::AuthSelection {
+                mode: cursor::BROWSER_SOURCE.into(),
+                candidate: Some("zen/work".into()),
+            })
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -40,8 +40,8 @@ use tidemark_core::oauth::Login;
 use tidemark_core::providers::Credential;
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_types::{
-    AccountId, CredentialKind, DataInfo, HistoryPoint, Preferences, ProviderDefinition, ProviderId,
-    ProviderStatus, ids,
+    AccountId, AuthCandidate, AuthSelection, CredentialKind, DataInfo, HistoryPoint, Preferences,
+    ProviderDefinition, ProviderId, ProviderStatus, ids,
 };
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
 use tokio::task::{AbortHandle, JoinHandle};
@@ -373,6 +373,27 @@ impl Daemon {
         let (reply, answer) = oneshot::channel();
         self.commands
             .send(make(reply))
+            .await
+            .map_err(|_| fdo::Error::Failed("the poll loop has stopped".into()))?;
+        answer
+            .await
+            .map_err(|_| fdo::Error::Failed("the poll loop dropped the request".into()))?
+            .map_err(fdo::Error::Failed)
+    }
+
+    /// Sends an inspection request through the owning engine task.
+    async fn auth_sources_request(
+        &self,
+        provider: &str,
+        account: &str,
+    ) -> fdo::Result<Vec<AuthCandidate>> {
+        let (reply, answer) = oneshot::channel();
+        self.commands
+            .send(Command::InspectAuthSources {
+                provider: provider.to_owned(),
+                account: account.to_owned(),
+                reply,
+            })
             .await
             .map_err(|_| fdo::Error::Failed("the poll loop has stopped".into()))?;
         answer
@@ -794,6 +815,35 @@ impl Daemon {
         Ok(())
     }
 
+    /// Inspects the secret-free local authentication sources an account can select.
+    async fn get_auth_sources(
+        &self,
+        provider: &str,
+        account: &str,
+    ) -> fdo::Result<Vec<AuthCandidate>> {
+        self.account(provider, account).await?;
+        self.auth_sources_request(provider, account).await
+    }
+
+    /// Revalidates and persists one explicit local authentication source.
+    async fn select_auth_source(
+        &self,
+        provider: &str,
+        account: &str,
+        selection: AuthSelection,
+    ) -> fdo::Result<()> {
+        let mutation = self.mutation(provider, account).await;
+        let _guard = mutation.lock().await;
+        self.account(provider, account).await?;
+        self.config_request(|reply| Command::SelectAuthSource {
+            provider: provider.to_owned(),
+            account: account.to_owned(),
+            selection,
+            reply,
+        })
+        .await
+    }
+
     /// Switches one window's notifications on or off.
     ///
     /// Per window rather than per provider, and off by default: the five providers report
@@ -1039,7 +1089,9 @@ fn key(provider: &str, account: &str) -> AccountKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidemark_types::{AccountId, ProviderDefinition, ProviderId, ids};
+    use tidemark_types::{
+        AccountId, AuthCandidate, AuthSelection, ProviderDefinition, ProviderId, ids,
+    };
 
     fn status(provider: &str) -> ProviderStatus {
         ProviderStatus::pending(&ProviderId::new(provider), &AccountId::default())
@@ -2071,6 +2123,77 @@ mod tests {
             .await
             .expect("setting task did not panic")
             .expect("engine accepted setting");
+    }
+
+    #[tokio::test]
+    async fn browser_auth_calls_are_serialized_through_the_engine_without_credentials() {
+        let cursor = status("cursor");
+        let (daemon, _secrets, mut commands) = daemon_over(vec![cursor]).await;
+        let daemon = Arc::new(daemon);
+        let inspection = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.get_auth_sources("cursor", "default").await }
+        });
+
+        let Command::InspectAuthSources {
+            provider,
+            account,
+            reply,
+        } = commands.recv().await.expect("inspection reaches engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert_eq!(
+            (provider, account),
+            ("cursor".to_owned(), "default".to_owned())
+        );
+        reply
+            .send(Ok(vec![AuthCandidate {
+                id: "cursor-app".into(),
+                title: "Cursor App".into(),
+                subtitle: None,
+                state: "ready".into(),
+                children: Vec::new(),
+            }]))
+            .expect("report returned");
+        let sources = inspection
+            .await
+            .expect("inspection task did not panic")
+            .expect("inspection succeeds");
+        assert_eq!(sources[0].id, "cursor-app");
+        assert!(!format!("{sources:?}").contains("session="));
+
+        let selection = AuthSelection {
+            mode: "cursor-app".into(),
+            candidate: None,
+        };
+        let selecting = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            let selection = selection.clone();
+            async move {
+                daemon
+                    .select_auth_source("cursor", "default", selection)
+                    .await
+            }
+        });
+        let Command::SelectAuthSource {
+            provider,
+            account,
+            selection: requested,
+            reply,
+        } = commands.recv().await.expect("selection reaches engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert_eq!(
+            (provider, account, requested),
+            ("cursor".into(), "default".into(), selection)
+        );
+        reply.send(Ok(())).expect("selection completed");
+        selecting
+            .await
+            .expect("selection task did not panic")
+            .expect("selection succeeds");
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -1310,6 +1310,7 @@ mod tests {
             credential: "key".into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         }]
     }
@@ -1406,6 +1407,7 @@ mod tests {
             credential: "key".into(),
             credential_hint: "Z.ai dashboard → API keys.".into(),
             external: None,
+            browser_auth: None,
             options: Vec::new(),
         };
         let (daemon, _secrets, _commands) =

--- a/data/icons/hicolor/symbolic/apps/tidemark-cursor-symbolic.svg
+++ b/data/icons/hicolor/symbolic/apps/tidemark-cursor-symbolic.svg
@@ -1,0 +1,6 @@
+<!-- The Cursor mark belongs to Anysphere (cursor.com). Not covered by Tidemark's MIT
+     licence; used nominatively to identify the service a card reports on. See
+     docs/TRADEMARKS.md. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000" fill-rule="evenodd">
+  <path d="M22.106 5.68L12.5.135a.998.998 0 00-.998 0L1.893 5.68a.84.84 0 00-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 00.998 0l9.608-5.547a.84.84 0 00.42-.727V6.407a.84.84 0 00-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 00-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z"/>
+</svg>

--- a/docs/TRADEMARKS.md
+++ b/docs/TRADEMARKS.md
@@ -17,6 +17,7 @@ whose services the cards are about:
 | `tidemark-codex-symbolic.svg` | OpenAI (Codex) |
 | `tidemark-codebuff-symbolic.svg` | Codebuff, Inc. |
 | `tidemark-crof-symbolic.svg` | Crof |
+| `tidemark-cursor-symbolic.svg` | Anysphere, Inc. (Cursor) |
 | `tidemark-deepinfra-symbolic.svg` | DeepInfra |
 | `tidemark-deepgram-symbolic.svg` | Deepgram, Inc. |
 | `tidemark-deepseek-symbolic.svg` | Hangzhou DeepSeek Artificial Intelligence Co., Ltd. |

--- a/docs/superpowers/plans/2026-08-26-browser-cookie-auth-source-selection.md
+++ b/docs/superpowers/plans/2026-08-26-browser-cookie-auth-source-selection.md
@@ -219,7 +219,7 @@ git commit -m "feat(cursor): select an explicit local auth source"
 
 - [x] **Step 1: Write failing config, engine, registry, and service tests**
 
-Test that Cursor App selection removes auth-browser/auth-profile, a browser-parent selection removes only auth-profile, and nested selection retains all fields. Test that unknown/unready candidate selection leaves config unchanged, drops/rebuilds the client only after validation, and publishes an immediate due status. Under dbus-run-session, exercise the two new D-Bus methods and ensure the returned report contains no cookie value.
+Test that Cursor App selection removes auth-browser/auth-profile, a browser-parent selection pins its first ready profile into auth-profile, and nested selection retains all fields. Test that unknown/unready candidate selection leaves config unchanged, drops/rebuilds the client only after validation, and publishes an immediate due status. Under dbus-run-session, exercise the two new D-Bus methods and ensure the returned report contains no cookie value.
 
 ~~~rust
 config.set_auth_selection("cursor", &AuthSelection {
@@ -391,4 +391,3 @@ Use the tidemark-installed-verification skill. Rebuild/install the scoped packag
 
 Run: git status --short && git log --oneline -7
 Expected: only the scoped commits and any explicitly pre-existing user changes. Report the exact command results, installed D-Bus evidence, and commit list before proposing integration.
-

--- a/docs/superpowers/plans/2026-08-26-browser-cookie-auth-source-selection.md
+++ b/docs/superpowers/plans/2026-08-26-browser-cookie-auth-source-selection.md
@@ -1,0 +1,394 @@
+# Browser-Cookie Auth Source Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Let Cursor and future browser-cookie providers use one explicit, daemon-validated local authentication source rather than silently selecting the first one found.
+
+**Architecture:** Add optional, secret-free browser-auth metadata to the shared wire vocabulary. Core owns candidate discovery and provider-specific validation; the daemon exposes inspect/select operations and atomically persists choices. The GTK provider page renders generic Cursor App/Browser tabs exclusively from daemon data.
+
+**Tech Stack:** Rust 2024, GTK4/libadwaita 1.9, zbus, Tokio, reqwest, rusqlite, toml_edit, Secret Service through oo7.
+
+**Spec:** docs/superpowers/specs/2026-08-26-browser-cookie-auth-source-selection-design.md
+
+## Global Constraints
+
+- tidemark is display-only and uses D-Bus only; it must not depend on tidemark-core, reqwest, rusqlite, or browser-storage code.
+- tidemarkd alone owns browser discovery, network validation, config writes, and provider rebuilds.
+- Browser databases are read only through private owner-only snapshots; never write to browser directories.
+- Cookies and Cursor App tokens are credentials: never place them in config, D-Bus types, logs, errors, toasts, or Debug output.
+- Browser/provider slugs and profile identifiers are stable selected-source identifiers; do not rename them after shipping.
+- A selected source is exclusive; a failed source must not fall back to another browser or Cursor App.
+- Existing OAuth/CLI and API-key flows remain behaviorally unchanged.
+- Preserve absent fields as absent in published a{sv} dictionaries.
+- Tests use built-in test support, temporary homes, fake keyring storage, and real loopback HTTP servers; no new test frameworks.
+- Final acceptance includes the full CI gate and installed daemon/GUI/D-Bus validation.
+
+---
+
+### Task 1: Define the generic, secret-free browser-auth wire contract
+
+**Files:**
+- Modify: crates/tidemark-types/src/wire.rs
+- Modify: crates/tidemark-types/src/lib.rs
+- Test: crates/tidemark-types/src/wire.rs
+
+**Interfaces:**
+- Produces: AuthSelector, AuthMode, AuthCandidate, AuthCandidateState, and AuthSelection public wire types.
+- Produces: optional ProviderDefinition.browser_auth and ProviderStatus.auth_selection fields.
+- Consumes: existing ProviderDefinition, ProviderStatus, SerializeDict, DeserializeDict, and zvariant::Type conventions.
+- Used by: core discovery, daemon D-Bus methods, and GTK provider settings.
+
+- [ ] **Step 1: Write the failing wire tests**
+
+Add a round-trip test for a definition containing a browser-auth selector and a nested browser/profile candidate, plus a status test proving an older-style dictionary that omits the new fields still decodes with None.
+
+~~~rust
+let selector = AuthSelector {
+    option: "auth-source".into(),
+    modes: vec![
+        AuthMode { value: "cursor-app".into(), title: "Cursor App".into() },
+        AuthMode { value: "browser".into(), title: "Browser".into() },
+    ],
+};
+assert_eq!(decoded.browser_auth.as_ref(), Some(&selector));
+assert_eq!(decoded.auth_selection, None);
+~~~
+
+- [ ] **Step 2: Run the focused test and verify it fails for missing types/fields**
+
+Run: cargo test -p tidemark-types browser_auth -- --nocapture
+Expected: FAIL because AuthSelector/AuthCandidate/AuthSelection and the optional fields do not exist.
+
+- [ ] **Step 3: Implement the minimal extensible wire vocabulary**
+
+Add the five structs/enums as a{sv}-compatible serializable types. Candidate state must distinguish ready, missing, rejected, waiting-for-keyring, and unreachable. Add optional browser_auth to ProviderDefinition and optional auth_selection to ProviderStatus; initialize both as None in ProviderStatus::pending. Re-export the new types from lib.rs.
+
+~~~rust
+pub struct AuthSelection {
+    pub mode: String,
+    pub candidate: Option<String>,
+}
+
+pub struct AuthCandidate {
+    pub id: String,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub state: String,
+    pub children: Vec<AuthCandidate>,
+}
+~~~
+
+- [ ] **Step 4: Re-run focused and crate tests**
+
+Run: cargo test -p tidemark-types
+Expected: PASS, including legacy decoding and nested candidate round trips.
+
+- [ ] **Step 5: Commit the standalone vocabulary change**
+
+~~~bash
+git add crates/tidemark-types/src/lib.rs crates/tidemark-types/src/wire.rs
+git commit -m "feat(types): describe browser auth sources"
+~~~
+
+### Task 2: Build reusable browser-auth discovery and selection primitives
+
+**Files:**
+- Create: crates/tidemark-core/src/browser/auth.rs
+- Modify: crates/tidemark-core/src/browser/mod.rs
+- Test: crates/tidemark-core/src/browser/auth.rs
+
+**Interfaces:**
+- Consumes: browser::Store, browser::Query, Cookie, SafeStorage, Timestamp, and the Task 1 wire types.
+- Produces: browser::auth::inspect and browser::auth::Selection, returning only AuthCandidate metadata plus an internal credential handle used within core.
+- Used by: Cursor's validator in Task 3 and future browser-cookie provider adapters.
+
+- [ ] **Step 1: Write failing temporary-home tests for browser candidates**
+
+Create Gecko fixture stores for two browsers and two profiles. Assert that an expired cookie is Missing, an accepted validator result is Ready, a validator credential error is Rejected, and two valid profiles stay nested under their browser in stable scan order.
+
+~~~rust
+let report = inspect(&home, &query, storage.as_ref(), validate).await;
+assert_eq!(report[0].children[0].state, AuthCandidateState::Ready.as_wire());
+assert!(report[1].children[0].is_insensitive_candidate());
+~~~
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: cargo test -p tidemark-core browser::auth::tests -- --nocapture
+Expected: FAIL because browser::auth and inspect do not exist.
+
+- [ ] **Step 3: Implement discovery without leaking cookies**
+
+Add an internal candidate/header pair whose Debug implementation does not reveal the header. Read each Store via the current snapshot API, filter live cookies, preserve BROWSERS/profile ordering, and map CookieError::KeyringLocked to the dedicated neutral state. Let the async callback convert each candidate header to Ready, Rejected, or Unreachable; return wire candidates only after dropping headers.
+
+~~~rust
+pub async fn inspect<F, Fut>(
+    stores: Vec<Store>,
+    query: &Query,
+    storage: &dyn SafeStorage,
+    validate: F,
+) -> Vec<AuthCandidate>
+where
+    F: Fn(CandidateCredential) -> Fut,
+    Fut: Future<Output = CandidateState>;
+~~~
+
+- [ ] **Step 4: Run focused and browser module tests**
+
+Run: cargo test -p tidemark-core browser:: -- --nocapture
+Expected: PASS; existing snapshot, domain-match, Chromium, and Gecko tests stay green.
+
+- [ ] **Step 5: Commit the reusable discovery layer**
+
+~~~bash
+git add crates/tidemark-core/src/browser/mod.rs crates/tidemark-core/src/browser/auth.rs
+git commit -m "feat(browser): inspect cookie auth candidates"
+~~~
+
+### Task 3: Make Cursor resolve one explicit source and validate it
+
+**Files:**
+- Modify: crates/tidemark-core/src/providers/keyed/cursor.rs
+- Modify: crates/tidemark-core/src/providers/keyed/mod.rs
+- Test: crates/tidemark-core/src/providers/keyed/cursor.rs
+
+**Interfaces:**
+- Consumes: browser::auth primitives from Task 2 and OptionSchema/Options from keyed::mod.
+- Produces: Cursor auth-source option schema, inspect_sources(options), and a provider that resolves only its selected source.
+- Used by: registry/daemon source inspection and normal Cursor polling.
+
+- [ ] **Step 1: Replace historical fallback tests with failing explicit-selection tests**
+
+Change the tests that currently expect an expired browser to fall through to another browser or Cursor App. Add tests for selecting Cursor App, a selected browser parent, and a selected nested profile. Each must prove requests contain only that candidate's cookie and that a rejection does not try another source.
+
+~~~rust
+let provider = Cursor::for_test(home.path(), Arc::new(NoKeyring))?
+    .with_options(cursor_options("browser", Some("zen"), Some("zz99.Working")));
+let error = runtime.block_on(provider.fetch_inner()).expect_err("selected session rejected");
+assert!(matches!(error, ProviderError::Credential { .. }));
+assert_eq!(summary_requests(&requests), 1);
+~~~
+
+- [ ] **Step 2: Run the focused Cursor tests and verify they fail**
+
+Run: cargo test -p tidemark-core providers::keyed::cursor::tests -- --nocapture
+Expected: FAIL because the provider still scans every source and HandSpec exposes no auth options.
+
+- [ ] **Step 3: Implement Cursor source parsing, inspection, and validation**
+
+Declare stable auth-source, auth-browser, and auth-profile option names and accepted mode values. Parse options into a selected internal source with clear malformed/absent behavior. Reuse the current Cursor request builder for a one-request validator, classify 401/403 as Rejected, and use the generic helper for browsers. Read only the chosen browser/profile or Cursor App in normal fetch; never append fallback headers.
+
+~~~rust
+enum Source {
+    CursorApp,
+    Browser { slug: String, profile: Option<String> },
+}
+
+pub async fn inspect_sources(&self) -> Result<Vec<AuthCandidate>, ProviderError>;
+~~~
+
+- [ ] **Step 4: Run all Cursor/provider tests**
+
+Run: cargo test -p tidemark-core providers::keyed::cursor -- --nocapture
+Expected: PASS, including WAL snapshot, redaction, selected-source, and malformed-option coverage.
+
+- [ ] **Step 5: Commit Cursor's explicit source behavior**
+
+~~~bash
+git add crates/tidemark-core/src/providers/keyed/cursor.rs crates/tidemark-core/src/providers/keyed/mod.rs
+git commit -m "feat(cursor): select an explicit local auth source"
+~~~
+
+### Task 4: Persist and expose source selection through daemon config and D-Bus
+
+**Files:**
+- Modify: crates/tidemark-core/src/config.rs
+- Modify: crates/tidemarkd/src/registry.rs
+- Modify: crates/tidemarkd/src/engine.rs
+- Modify: crates/tidemarkd/src/service.rs
+- Modify: crates/tidemark/src/bus.rs
+- Test: crates/tidemark-core/src/config.rs
+- Test: crates/tidemarkd/src/registry.rs
+- Test: crates/tidemarkd/src/engine.rs
+- Test: crates/tidemarkd/src/service.rs
+
+**Interfaces:**
+- Consumes: Task 1 wire types and Task 3 Cursor inspection/selection APIs.
+- Produces: Config::set_auth_selection, Engine inspect/select commands, and Daemon/GetAuthSources/SelectAuthSource proxy methods.
+- Used by: Task 5 GTK detail page.
+
+- [x] **Step 1: Write failing config, engine, registry, and service tests**
+
+Test that Cursor App selection removes auth-browser/auth-profile, a browser-parent selection removes only auth-profile, and nested selection retains all fields. Test that unknown/unready candidate selection leaves config unchanged, drops/rebuilds the client only after validation, and publishes an immediate due status. Under dbus-run-session, exercise the two new D-Bus methods and ensure the returned report contains no cookie value.
+
+~~~rust
+config.set_auth_selection("cursor", &AuthSelection {
+    mode: "cursor-app".into(),
+    candidate: None,
+})?;
+assert_eq!(config.option("cursor", "auth-browser"), None);
+assert_eq!(config.option("cursor", "auth-profile"), None);
+~~~
+
+- [x] **Step 2: Run focused daemon/config tests and verify they fail**
+
+Run: cargo test -p tidemark-core config::tests && cargo test -p tidemarkd auth_source -- --nocapture
+Expected: FAIL because the atomic config operation and source D-Bus methods do not exist.
+
+- [x] **Step 3: Implement serialized selection lifecycle**
+
+Add Config::set_auth_selection using one staged write that preserves TOML comments and removes stale keys. Let registry publish Cursor's browser-auth selector in ProviderDefinition and resolve its current AuthSelection from config without defaulting to another source. Add engine commands for inspect/select; select must validate inside the account mutation sequence, write config only after success, refresh status/options, clear the rebuildable client, reset scheduling failure state, and set due to now. Service validates account existence, delegates through the engine queue, and exposes generic GetAuthSources/SelectAuthSource. Extend the GUI proxy only with those D-Bus signatures.
+
+~~~rust
+async fn select_auth_source(
+    &self,
+    provider: &str,
+    account: &str,
+    selection: AuthSelection,
+) -> fdo::Result<()>;
+~~~
+
+- [x] **Step 4: Re-run focused tests under a session bus**
+
+Run: dbus-run-session -- cargo test -p tidemarkd auth_source -- --nocapture
+Expected: PASS; config is unchanged on a rejected source and the valid selection publishes a changed provider status.
+
+- [x] **Step 5: Commit daemon-owned source selection**
+
+~~~bash
+git add crates/tidemark-core/src/config.rs crates/tidemarkd/src/registry.rs crates/tidemarkd/src/engine.rs crates/tidemarkd/src/service.rs crates/tidemark/src/bus.rs
+git commit -m "feat(daemon): manage browser auth sources"
+~~~
+
+### Task 5: Render the generic source tabs in provider settings
+
+**Files:**
+- Create: crates/tidemark/src/provider_settings/browser_auth.rs
+- Modify: crates/tidemark/src/provider_settings/mod.rs
+- Modify: crates/tidemark/src/provider_settings/model.rs
+- Modify: crates/tidemark/src/provider_settings/detail.rs
+- Modify: crates/tidemark/src/provider_settings/list.rs
+- Test: crates/tidemark/src/provider_settings/browser_auth.rs
+- Test: crates/tidemark/src/provider_settings/model.rs
+- Test: crates/tidemark/src/provider_settings/mod.rs
+
+**Interfaces:**
+- Consumes: ProviderDefinition.browser_auth, ProviderStatus.auth_selection, AuthCandidate reports, and DaemonProxy GetAuthSources/SelectAuthSource.
+- Produces: reusable browser-auth tab widgets and data-driven configured-list edit eligibility.
+- Must not consume: Cursor core code, cookies, filesystem, HTTP, or SQLite.
+
+- [x] **Step 1: Write failing model/widget tests**
+
+Add pure model tests that mark Ready candidates selectable and Missing/Rejected candidates insensitive, retain WaitingForKeyring/Unreachable as neutral recheckable states, and show nested profiles only when a browser has more than one ready profile. Add a detail navigation test showing a keyless provider with browser_auth opens after add and exposes its pencil.
+
+~~~rust
+assert!(candidate_selectable(AuthCandidateState::Ready));
+assert!(!candidate_selectable(AuthCandidateState::Rejected));
+assert!(shows_profile_children(&two_ready_profiles));
+assert!(!shows_profile_children(&one_ready_profile));
+~~~
+
+- [x] **Step 2: Run focused GUI tests and verify they fail**
+
+Run: cargo test -p tidemark provider_settings::browser_auth -- --nocapture
+Expected: FAIL because browser_auth UI/model helpers do not exist and keyless browser-auth providers are not editable.
+
+- [x] **Step 3: Implement generic Authentication tabs and report refresh**
+
+Add a BrowserAuthRows component owned by ProviderDetail. Build the full-width ToggleGroup from daemon-published mode titles, with Cursor App and Browser halves rather than provider-slug branches. On detail construction and Check again, call GetAuthSources through glib::spawn_future_local, render loading/neutral/red/green accessibility states, and retain the prior authoritative selection on an error. SelectAuthSource handles row activation; after success it asks the daemon to publish the new status. Use profile titles as nested ActionRows only for browsers that need them.
+
+Update opens_detail_after_add and configured-row edit visibility to use the generic capability rather than credential kind/options alone.
+
+~~~rust
+fn open_browser_auth(self: &Rc<Self>) {
+    glib::spawn_future_local(async move {
+        let report = detail.proxy.get_auth_sources(&provider, &account).await?;
+        detail.browser_auth.borrow().as_ref().expect("built").apply(report);
+    });
+}
+~~~
+
+- [x] **Step 4: Run provider-settings tests and an isolated GTK smoke test**
+
+Run: cargo test -p tidemark provider_settings -- --nocapture
+Expected: PASS; existing OAuth/CLI rows retain their current tests and the new Browser Auth page handles loading, retry, selection rollback, and reopen.
+
+- [x] **Step 5: Commit the generic HIG page**
+
+~~~bash
+git add crates/tidemark/src/provider_settings/browser_auth.rs crates/tidemark/src/provider_settings/mod.rs crates/tidemark/src/provider_settings/model.rs crates/tidemark/src/provider_settings/detail.rs crates/tidemark/src/provider_settings/list.rs
+git commit -m "feat(settings): choose browser auth sources"
+~~~
+
+### Task 6: Align normative and user-facing documentation
+
+**Files:**
+- Modify: CONTEXT.md
+- Modify: README.md
+- Modify: docs/TRADEMARKS.md only if a new visible mark is actually added
+
+**Interfaces:**
+- Consumes: the final behavior from Tasks 1-5.
+- Produces: an accurate architecture contract and provider setup explanation.
+
+- [ ] **Step 1: Write documentation assertions as review criteria**
+
+Record the exact statements that must be true: browser-cookie auth is a bounded daemon-only mechanism; reads use snapshots; source selection is explicit; a failed source does not silently fall back; Cursor supports Cursor App and selected browsers.
+
+- [ ] **Step 2: Verify current documentation fails those criteria**
+
+Run: rg -n "No browser-cookie scraping|Cursor reads the session|first" CONTEXT.md README.md
+Expected: FIND the deferred blanket exclusion and the old implicit-selection description.
+
+- [ ] **Step 3: Update only the affected documentation**
+
+Replace the deferred browser-cookie exclusion in CONTEXT.md with the bounded mechanism and its privacy/ownership rules. Update the Cursor README entry to describe explicit source selection, browser/profile behavior, and the local Cursor App choice. Do not change unrelated provider guidance.
+
+- [ ] **Step 4: Review rendered Markdown and terminology**
+
+Run: git diff --check && rg -n "browser-cookie|Cursor App|silent|fallback" CONTEXT.md README.md
+Expected: PASS with coherent, user-facing language and no whitespace errors.
+
+- [ ] **Step 5: Commit documentation alignment**
+
+~~~bash
+git add CONTEXT.md README.md
+git commit -m "docs: explain explicit browser auth selection"
+~~~
+
+### Task 7: Run full verification and installed acceptance
+
+**Files:**
+- Verify: all files changed by Tasks 1-6
+- Verify: scripts/check-layering.sh
+- Verify: scripts/check-desktop-integration.sh
+- Verify: scripts/test-restart-user-daemon.sh
+
+**Interfaces:**
+- Consumes: completed feature commits.
+- Produces: evidence that the source selector works across unit, D-Bus, GUI, package, and installed daemon boundaries.
+
+- [ ] **Step 1: Run formatting and static checks**
+
+Run: cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings
+Expected: PASS with no warnings.
+
+- [ ] **Step 2: Run the workspace test gate exactly as CI does**
+
+Run: dbus-run-session -- cargo test --workspace
+Expected: PASS, including new type/core/daemon/GTK tests.
+
+- [ ] **Step 3: Run architecture, desktop, restart, and shell checks**
+
+Run: scripts/check-layering.sh && scripts/check-desktop-integration.sh && scripts/test-restart-user-daemon.sh && shellcheck scripts/*.sh data/restart-user-daemon data/packaging/deb/postinst data/packaging/rpm/post-install.sh
+Expected: PASS.
+
+- [ ] **Step 4: Verify the installed application**
+
+Use the tidemark-installed-verification skill. Rebuild/install the scoped package, start the installed daemon, inspect its D-Bus surface, and exercise the installed provider page in an isolated display. Prove Cursor opens directly into settings, shows both tabs, accepts a ready source, leaves red candidates inactive, and does not move the user's cursor.
+
+- [ ] **Step 5: Capture final evidence and request review**
+
+Run: git status --short && git log --oneline -7
+Expected: only the scoped commits and any explicitly pre-existing user changes. Report the exact command results, installed D-Bus evidence, and commit list before proposing integration.
+

--- a/docs/superpowers/specs/2026-08-26-browser-cookie-auth-source-selection-design.md
+++ b/docs/superpowers/specs/2026-08-26-browser-cookie-auth-source-selection-design.md
@@ -1,0 +1,155 @@
+# Browser-Cookie Authentication Source Selection Design
+
+## Goal
+
+Let a person choose the exact local authentication source a browser-cookie provider uses.
+Cursor is the first consumer: Cursor App or one browser, optionally a profile in that browser.
+The mechanism is generic so a future browser-cookie provider does not add provider-specific GUI code.
+
+## Scope
+
+- Add a daemon-owned, data-driven authentication-source capability for external providers.
+- Discover Cursor App and every supported browser store, then validate candidates with Cursor.
+- Add a Cursor detail page using the existing authentication-source toggle, with Cursor App and Browser tabs.
+- Persist an explicit source selection and never silently switch to another account.
+- Keep cookies, tokens, browser databases, and HTTP access out of the GTK process and D-Bus output.
+
+Out of scope: multiple quota cards per provider, manually entered cookies, writes to browser data,
+automatic replacement of a failed source, and changes to OAuth/API-key flows.
+
+## Constraints
+
+- tidemark remains display-only and speaks only D-Bus; it does not depend on tidemark-core,
+  reqwest, rusqlite, or browser storage.
+- tidemarkd owns source discovery, remote validation, config mutation, and provider rebuild.
+- Browser databases remain read through owner-only temporary snapshots; no browser directory is
+  opened or modified in place.
+- A cookie or Cursor App token is a Credential: never include it in wire data, config, logs,
+  debug output, errors, or toasts.
+- New wire values are optional and extensible; absent data remains absent.
+- Browser slugs and profile directory identifiers are durable selected-source identities.
+- A source selection is exclusive. Its failure reports a normal credential failure; it never
+  falls back to another browser or Cursor App.
+
+## Architecture
+
+### Generic browser-auth model
+
+tidemark-types gains secret-free structures for a provider's selectable external authentication:
+
+- an authentication-selector definition naming its config option and top-level tabs;
+- an opaque candidate identifier, title, optional subtitle, optional children, and verification state;
+- selected mode and candidate metadata;
+- states ready, missing, rejected/expired, waiting-for-keyring, and temporarily unreachable.
+
+The selector definition travels with ProviderDefinition. Live candidates are fetched separately,
+because availability is machine- and time-dependent. Browser/profile identifiers are opaque to the
+GUI and expose neither cookies nor browser database paths.
+
+tidemark-core::browser continues to own browser inventory and snapshot reads. A generic
+browser-auth helper turns stores matching a provider-supplied cookie query into candidates,
+filters expired cookies, and calls a provider-supplied asynchronous validator. A provider supplies
+only its cookie query and its proof request. Future browser-cookie providers therefore reuse
+discovery, source selection, state handling, and redaction without GUI branches by slug.
+
+Cursor declares two source modes:
+
+- cursor-app, from the Cursor standalone state database in ~/.config/Cursor;
+- browser, from one selected supported browser and optionally one selected profile.
+
+Cursor validation uses the same honest Tidemark HTTP client and request construction as polling.
+A successful usage summary proves that a session works; an explicit credential rejection proves
+that it does not. Validation publishes or retains no response body beyond the request scope.
+
+### Daemon contract and lifecycle
+
+The daemon adds two generic D-Bus operations:
+
+1. Inspect sources for one configured account. It discovers and validates candidates in the daemon
+   and returns only metadata and states.
+2. Select one source. It revalidates the source, atomically writes the selection, removes stale
+   subordinate fields, rebuilds the provider, publishes status, and schedules an immediate poll.
+
+SetOption remains for static settings. It cannot set a browser source identifier because the
+candidate must be revalidated immediately before the config write.
+
+Cursor has provider-local stable settings:
+
+- auth-source = cursor-app or browser
+- auth-browser = browser slug, present only for browser mode
+- auth-profile = profile identifier, present only for an explicit nested-profile choice
+
+Choosing Cursor App removes auth-browser and auth-profile. Choosing a browser parent records its
+browser slug and removes auth-profile, then uses that browser's first validated profile in stable
+scan order. Choosing a nested profile records all three fields. Invalid/missing hand-edited values
+do not choose a different source; they lead to the ordinary no-credential state.
+
+Cursor receives this resolved selection through its options and reads only the selected store.
+The historical implicit scan of every browser plus Cursor App is removed.
+
+### GTK/libadwaita interface
+
+Adding Cursor creates its account and immediately opens its existing ProviderDetail page.
+The configured-provider list retains its existing document-edit-symbolic pencil button; Cursor is
+eligible because it has authentication-source configuration.
+
+The Authentication group uses the existing adw::ToggleGroup tab/pill interaction used by the
+Claude, Codex, and Antigravity OAuth/CLI selector:
+
+- Cursor App shows availability, a short state-database explanation, and Check again.
+- Browser shows browser candidates and Check again. A browser with one usable profile is directly
+  selectable. A browser with several usable profiles reveals only those profiles as nested choices.
+  This rare case does not complicate the common one-click path.
+
+Changing tabs switches the visible Authentication half immediately. Selecting a candidate becomes
+authoritative only after the daemon accepts it; refusal restores the prior choice and shows a toast.
+
+On opening the detail page, source content begins in a neutral checking state. The GUI calls
+Inspect sources through glib::spawn_future_local. It does not read databases or make HTTP requests.
+Candidate widgets are data-driven and do not match Cursor or browser slugs.
+
+Ready candidates show a green check and are selectable. Missing, expired, and rejected candidates
+show red status and are insensitive. Keyring-locked and transport failures are neutral rather than
+red because they do not prove an account invalid; each permits Check again. Status wording always
+accompanies colour. Existing detail-page open-close-open lifecycle behavior is preserved.
+
+## Error handling and privacy
+
+- An unreadable browser database makes that candidate unavailable without hiding other candidates.
+- A locked Secret Service is the existing waiting state, never equivalent to not found.
+- Network failure, timeout, and rate limit are inconclusive. They do not turn a candidate red or
+  overwrite a previous selection.
+- A 401/403 or expired session is red and insensitive. The selected source stays recorded so
+  the provider reports the true failure instead of silently reading a different account.
+- Source selection revalidates under the account mutation lock to close the inspection-to-write gap.
+- Errors use existing query/credential redaction. D-Bus exposes descriptive states, never raw
+  provider errors with paths or request details.
+
+## Tests and acceptance
+
+Core tests use temporary homes, copied SQLite fixtures, fake keyring storage, and loopback HTTP
+servers. Cover Chromium and Gecko, missing/expired/rejected candidates, Cursor App, redaction,
+stable browser/profile identifiers, browser-only and profile selection, and no cross-source fallback.
+
+Daemon/type tests cover wire round trips, omitted optional capability, inspection of unknown accounts,
+validation before config mutation, stale-field removal, rebuild, immediate poll, and D-Bus behavior.
+
+GTK/model tests cover the two tabs, loading/retry/error states, selection rollback, green/red
+sensitivity, nested profiles only when needed, add-to-detail navigation, pencil visibility, and
+dialog reopen after source/status updates.
+
+Final verification runs cargo fmt --all --check; cargo clippy --workspace --all-targets -- -D warnings;
+dbus-run-session -- cargo test --workspace; scripts/check-layering.sh;
+scripts/check-desktop-integration.sh; scripts/test-restart-user-daemon.sh; and shellcheck over the
+repository's scripts and packaging hooks.
+
+Installed-package acceptance verifies the new D-Bus contract and GTK provider page against the
+installed daemon. It exercises Cursor App, a valid browser, and an unavailable browser without
+moving the user's cursor.
+
+## Documentation changes
+
+CONTEXT.md replaces its deferred blanket exclusion of browser-cookie scraping with this bounded
+mechanism and its privacy/ownership rules. README.md explains that Cursor offers an explicit local
+source selector instead of silently using the first session it finds.
+

--- a/docs/superpowers/specs/2026-08-26-browser-cookie-auth-source-selection-design.md
+++ b/docs/superpowers/specs/2026-08-26-browser-cookie-auth-source-selection-design.md
@@ -77,12 +77,14 @@ Cursor has provider-local stable settings:
 
 - auth-source = cursor-app or browser
 - auth-browser = browser slug, present only for browser mode
-- auth-profile = profile identifier, present only for an explicit nested-profile choice
+- auth-profile = profile identifier, present only for browser mode
 
-Choosing Cursor App removes auth-browser and auth-profile. Choosing a browser parent records its
-browser slug and removes auth-profile, then uses that browser's first validated profile in stable
-scan order. Choosing a nested profile records all three fields. Invalid/missing hand-edited values
-do not choose a different source; they lead to the ordinary no-credential state.
+Choosing Cursor App removes auth-browser and auth-profile. Choosing a browser resolves it to that
+browser's first validated profile in stable scan order at selection time and records the resolved
+profile alongside the slug, so every later poll reads exactly the proven store instead of
+rescanning and quietly choosing a different account. A nested choice works the same way, naming
+its explicit profile. Invalid/missing hand-edited values do not choose a different source; they
+lead to the ordinary no-credential state.
 
 Cursor receives this resolved selection through its options and reads only the selected store.
 The historical implicit scan of every browser plus Cursor App is removed.
@@ -152,4 +154,3 @@ moving the user's cursor.
 CONTEXT.md replaces its deferred blanket exclusion of browser-cookie scraping with this bounded
 mechanism and its privacy/ownership rules. README.md explains that Cursor offers an explicit local
 source selector instead of silently using the first session it finds.
-


### PR DESCRIPTION
## Summary

- Add a Cursor provider that reads the browser's live session cookie instead of asking the user for one.
- Discover Gecko and Chromium browser profiles, including Firefox profiles stored under ~/.config/mozilla/firefox.
- Try every matching browser session and move to the next one after Cursor rejects it with HTTP 401/403.
- Keep providers without editable credentials out of the settings detail page and remove their empty edit surface.

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- ./scripts/check-layering.sh
- ./scripts/check-desktop-integration.sh
- Manual desktop QA: added Cursor, confirmed Firefox session login returns Cursor Free, removed Cursor, and confirmed the card disappears immediately.