### PR TITLE
fix(detail): stop rendering two close buttons in the provider window

### DIFF
--- a/crates/tidemark/src/detail.rs
+++ b/crates/tidemark/src/detail.rs
@@ -160,12 +160,9 @@ impl DetailDialog {
             .hscrollbar_policy(gtk::PolicyType::Never)
             .child(&content)
             .build();
-        let close = gtk::Button::builder()
-            .icon_name("window-close-symbolic")
-            .tooltip_text("Close")
-            .build();
+        // AdwDialog forces AdwHeaderBar's decoration layout to include a close button;
+        // packing our own would render two of them.
         let header = adw::HeaderBar::new();
-        header.pack_end(&close);
         let view = adw::ToolbarView::builder().content(&scroller).build();
         view.add_top_bar(&header);
         let dialog = adw::Dialog::builder()
@@ -211,12 +208,6 @@ impl DetailDialog {
                     detail.selection.borrow_mut().0 = Some(key);
                     detail.load_current_segment();
                 }
-            }
-        });
-        close.connect_clicked({
-            let dialog = dialog.clone();
-            move |_| {
-                dialog.close();
             }
         });
         dialog.connect_closed(move |_| on_closed());


### PR DESCRIPTION
## Summary

The provider detail window (opened by clicking a card) showed two close buttons
in its top-right corner. This drops the manually packed one.

## Root cause

Inside an `AdwDialog`, libadwaita forces an embedded `AdwHeaderBar` to always
include a close button in its decoration layout. The detail dialog also packed
its own `window-close-symbolic` button at the end of the header bar, so both
were rendered. The automatic button already closes the dialog, so the `closed`
signal (and the `on_closed` ownership-release callback) still fires and the
programmatic `Detail::close()` path is untouched.

Reference: [Migrating to Adaptive Dialogs — libadwaita docs](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.8/migrating-to-adaptive-dialogs.html)

## Testing

- [x] Full local gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `./scripts/check-layering.sh` — all green
- [x] Visual check of the dialog with a live daemon
