### PR TITLE
ci: release asset names and least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+# Read-only is all this workflow ever does; declaring it keeps the repository's default
+# permissions from silently applying.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write
-
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,6 +12,8 @@ jobs:
   # the tag agrees with the manifest.
   checks:
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -53,6 +52,8 @@ jobs:
     # which is the whole reason each format is built on its own target rather than on one
     # shared build host.
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Install the toolkit
@@ -86,6 +87,8 @@ jobs:
     # numbers differently, and the package will not install.
     runs-on: ubuntu-26.04
     container: fedora:44
+    permissions:
+      contents: read
     steps:
       - name: Bootstrap the container
         run: |
@@ -114,6 +117,10 @@ jobs:
   release:
     needs: [checks, deb, rpm]
     runs-on: ubuntu-26.04
+    # The one job that writes: creating the draft release is the only mutation anywhere
+    # in this workflow, so the build jobs above stay read-only.
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,14 @@ jobs:
           path: artifacts
           merge-multiple: true
       - run: ls -l artifacts
+      # The package tools name their outputs the way package managers expect — the -1 is
+      # the Debian revision, the suffix the architecture. The file a person downloads gets
+      # the project's own name instead, shaped by the tag the checks job has already
+      # agreed with Cargo.toml.
+      - name: Give the assets their release names
+        run: |
+          mv artifacts/*.deb "artifacts/Tidemark-${GITHUB_REF_NAME}.deb"
+          mv artifacts/*.rpm "artifacts/Tidemark-${GITHUB_REF_NAME}.rpm"
       - uses: softprops/action-gh-release@v2
         with:
           draft: true


### PR DESCRIPTION
## Summary

Two CI fixes in one branch: the release workflow now publishes its packages as `Tidemark-v<version>.deb` / `Tidemark-v<version>.rpm`, and every workflow declares explicit least-privilege permissions instead of inheriting the repository defaults.

## Changes

- **Release asset names** (`ci(release): name release assets Tidemark-v<version>.deb/.rpm`): the `release` job renames the downloaded packages to `Tidemark-${GITHUB_REF_NAME}.deb` / `.rpm` before attaching them. The tag is already validated against `Cargo.toml` by the `checks` job (`check-tag-version.sh`), so `GITHUB_REF_NAME` is safe to name files from. The package-internal names from cargo-deb / cargo-generate-rpm are deliberately left alone: the `-1` is the Debian revision, and `check-package-deps.sh` plus the manual upgrade test glob the tool-default paths. A failed `mv` glob fails the job, alongside the existing `fail_on_unmatched_files`.
- **Permissions** (`ci: declare least-privilege permissions on every job`): `ci.yml` had no `permissions` block at all, which is what the CodeQL alert fires on — it now declares `contents: read`. `release.yml` dropped its workflow-wide `contents: write`: `checks` / `deb` / `rpm` are read-only, and only the job that creates the draft release keeps `contents: write`.

## Testing

- Both workflows parse as valid YAML; per-job permissions verified by inspection (`checks`/`deb`/`rpm` → read, `release` → write).
- actionlint reports only the five pre-existing `ubuntu-26.04` runner-label warnings — identical to `main`; no new findings.
- No Rust code touched, so the cargo gate is unaffected.
