### PR TITLE
fix(provider): lead the NanoGPT card with the weekly input pool

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -462,10 +462,13 @@ history that does not exist yet.
 - **Empty state** — when there are no configured providers, the main window says
   `Welcome to Tidemark` and `Add a provider to start tracking your quota.` The providers
   button remains available while the daemon is connected.
-- **Card** — logo, name, plan, state chip; the shortest present window as a large number
+- **Card** — logo, name, plan, state chip; the dominant window as a large number
   over a bar with a pace mark; remaining windows as thin rows; and one quiet line along the
-  bottom saying when the reading was taken. The plan is a convention rather than a field:
-  the first row of the detail section a provider titles `Plan`.
+  bottom saying when the reading was taken. The dominant window is the shortest present
+  one, unless the provider names a lead window of its own — NanoGPT does, because its
+  weekly input pool is the subscription and the hundred-images-a-day allowance beside it
+  would otherwise be the headline at zero, every day. The plan is a convention rather than
+  a field: the first row of the detail section a provider titles `Plan`.
 - **The mark, the name and the plan stand on one baseline**, and the mark is the largest
   thing in the row — it is what the eye finds a card by. Bottom-aligning the widgets does
   not achieve this: GTK aligns allocations, and a label's allocation ends at its font's
@@ -575,7 +578,7 @@ history that does not exist yet.
   machine the bug is on.
 - **Tray** — a static StatusNotifierItem, owned by the interface process rather than by the
   daemon. Left click shows the window; the menu lists the configured accounts with the
-  percentage of their shortest window, in the order the grid uses, and ends with Open,
+  percentage of their dominant window, in the order the grid uses, and ends with Open,
   Refresh and Quit. The icon takes the `NeedsAttention` status at the same threshold the
   bar changes colour at and the notification fires at, so the panel cannot become a third
   opinion about when a window got worrying.

--- a/crates/tidemark-core/src/providers/keyed/nanogpt.rs
+++ b/crates/tidemark-core/src/providers/keyed/nanogpt.rs
@@ -28,7 +28,10 @@
 //! `images/w86400` and `input-tokens/w86400` are two windows, not one. A period this build
 //! has never seen is skipped; a pool whose numbers cannot be read fails the whole fetch. A
 //! stated limit becomes the absolutes under the bar, and a pool with no stated limit keeps
-//! its percentage and prints nothing it would have to invent.
+//! its percentage and prints nothing it would have to invent. The weekly input pool is the
+//! substance of the subscription, so it is the window the card leads with — named in
+//! `tidemark_types::lead_window_key` — and it is published first; the images allowance
+//! beside it is a secondary row.
 //!
 //! A prepaid balance has no denominator. USD is therefore the first row of
 //! [`DetailSection::BALANCE`], which lets the card show the amount without inventing a bar;
@@ -42,7 +45,7 @@ use std::fmt;
 use std::sync::Arc;
 use tidemark_types::{
     AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
-    WindowKey, WindowLength,
+    WindowKey, WindowLength, lead_window_key,
 };
 
 pub const PROVIDER_ID: &str = "nanogpt";
@@ -335,12 +338,20 @@ fn parse(
             limit,
         )?);
     }
-    // Shortest window first, the order the card reads best in. `serde_json` hands back a
-    // sorted map, so this is a presentation order rather than a tie-break for randomness.
+    // The weekly input pool is published first — it is the window the card leads with
+    // (`lead_window_key`), and the detail dialog and any wire client list windows in this
+    // order. After it, shortest first; `serde_json` hands back a sorted map, so this is a
+    // presentation order rather than a tie-break for randomness.
+    let lead = lead_window_key(PROVIDER_ID);
     windows.sort_by(|left, right| {
-        let length = |window: &Window| window.length.map_or(u64::MAX, WindowLength::as_secs);
-        length(left)
-            .cmp(&length(right))
+        let leads = |window: &Window| Some(window.key.as_str()) == lead;
+        leads(right)
+            .cmp(&leads(left))
+            .then_with(|| {
+                let length =
+                    |window: &Window| window.length.map_or(u64::MAX, WindowLength::as_secs);
+                length(left).cmp(&length(right))
+            })
             .then_with(|| left.title.cmp(&right.title))
     });
 
@@ -421,18 +432,15 @@ mod tests {
         let snapshot = parse(LIVE, BALANCE, at(1_787_600_000)).expect("parses");
 
         assert_eq!(snapshot.provider.as_str(), "nanogpt");
-        // Three pools are named; `dailyInputTokens` is null, so two are reported.
+        // Three pools are named; `dailyInputTokens` is null, so two are reported. The
+        // weekly input pool is what the card leads with, so it is published first.
         assert_eq!(snapshot.windows.len(), 2);
+        assert_eq!(
+            snapshot.dominant_window().expect("present").key.as_str(),
+            "input-tokens/w604800"
+        );
 
-        let images = &snapshot.windows[0];
-        assert_eq!(images.key.as_str(), "images/w86400");
-        assert_eq!(images.title, "Daily images");
-        assert_eq!(images.used_percent, 0.0);
-        assert_eq!(images.subtitle.as_deref(), Some("0 / 100 images"));
-        assert_eq!(images.length.expect("known").as_secs(), 86_400);
-        assert_eq!(images.resets_at.expect("reported").as_unix(), 1_787_616_000);
-
-        let tokens = &snapshot.windows[1];
+        let tokens = &snapshot.windows[0];
         assert_eq!(tokens.key.as_str(), "input-tokens/w604800");
         assert_eq!(tokens.title, "Weekly input tokens");
         assert!((tokens.used_percent - 0.155_293_333_333_333_34).abs() < 1e-12);
@@ -442,6 +450,14 @@ mod tests {
         );
         assert_eq!(tokens.length.expect("known").as_secs(), 604_800);
         assert_eq!(tokens.resets_at.expect("reported").as_unix(), 1_788_134_400);
+
+        let images = &snapshot.windows[1];
+        assert_eq!(images.key.as_str(), "images/w86400");
+        assert_eq!(images.title, "Daily images");
+        assert_eq!(images.used_percent, 0.0);
+        assert_eq!(images.subtitle.as_deref(), Some("0 / 100 images"));
+        assert_eq!(images.length.expect("known").as_secs(), 86_400);
+        assert_eq!(images.resets_at.expect("reported").as_unix(), 1_787_616_000);
 
         let balance = snapshot
             .details
@@ -474,13 +490,13 @@ mod tests {
         assert_eq!(
             keys,
             [
+                "input-tokens/w604800",
                 "images/w86400",
-                "input-tokens/w86400",
-                "input-tokens/w604800"
+                "input-tokens/w86400"
             ]
         );
 
-        let tokens = &snapshot.windows[1];
+        let tokens = &snapshot.windows[2];
         assert_eq!(tokens.title, "Daily input tokens");
         assert_eq!(tokens.used_percent, 100.0);
         assert_eq!(tokens.subtitle, None, "no limit is stated for this pool");
@@ -547,6 +563,12 @@ mod tests {
         let snapshot = parse(DOCUMENTED, BALANCE, at(1_738_000_000)).expect("parses");
 
         assert_eq!(snapshot.windows.len(), 2);
+        // No weekly input pool is metered here, so the named lead window is not there and
+        // the card falls back to the shortest present window.
+        assert_eq!(
+            snapshot.dominant_window().expect("present").key.as_str(),
+            "w86400"
+        );
 
         let daily = &snapshot.windows[0];
         assert_eq!(daily.key.as_str(), "w86400");

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -15,7 +15,9 @@ pub mod window;
 pub mod wire;
 
 pub use present::{duration, icon_name, percent};
-pub use snapshot::{AccountId, DetailRow, DetailSection, ProviderId, Snapshot, provider_label};
+pub use snapshot::{
+    AccountId, DetailRow, DetailSection, ProviderId, Snapshot, lead_window_key, provider_label,
+};
 pub use time::{AbsurdTimestamp, Timestamp};
 pub use window::{DANGER_AT, WARNING_AT, Window, WindowKey, WindowLength};
 pub use wire::{

--- a/crates/tidemark-types/src/snapshot.rs
+++ b/crates/tidemark-types/src/snapshot.rs
@@ -125,6 +125,24 @@ pub fn provider_label(slug: &str) -> String {
     }
 }
 
+/// The stable key of the window a provider's card leads with, when the shortest present
+/// window is not it.
+///
+/// Presentation, but shared, for the same reason [`provider_label`] is: the card, the
+/// tray menu and the detail dialog's initial selection must all lead with the same
+/// window, and they run in two different processes. A provider appears here when its
+/// shortest window is the wrong headline — NanoGPT meters a hundred images a day
+/// alongside the weekly input pool that *is* the subscription, and shortest-first would
+/// spend every day showing the images allowance sitting at zero. The key is the
+/// window's stable identity, so a pool the provider stops reporting falls back to the
+/// shortest present window rather than to a window that is not there.
+pub fn lead_window_key(slug: &str) -> Option<&'static str> {
+    match slug {
+        "nanogpt" => Some("input-tokens/w604800"),
+        _ => None,
+    }
+}
+
 /// Everything one poll of one account produced.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Snapshot {
@@ -142,7 +160,8 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    /// The window the card leads with: the shortest one *present*.
+    /// The window the card leads with: the one the provider names for the role when it
+    /// names one — see [`lead_window_key`] — otherwise the shortest one *present*.
     ///
     /// Shortest, because that is the limit a user is about to hit. Present, because a
     /// window the provider did not report this time is not drawn at all — OpenAI switched
@@ -152,6 +171,11 @@ impl Snapshot {
     /// Windows without a declared length sort last: an unknown length cannot be claimed to
     /// be the shortest.
     pub fn dominant_window(&self) -> Option<&Window> {
+        if let Some(key) = lead_window_key(self.provider.as_str())
+            && let Some(named) = self.windows.iter().find(|w| w.key.as_str() == key)
+        {
+            return Some(named);
+        }
         self.windows
             .iter()
             .min_by_key(|w| (w.length.is_none(), w.length.map(WindowLength::as_secs)))
@@ -183,6 +207,26 @@ mod tests {
         }
     }
 
+    fn provider_snapshot(provider: &str, keyed_lengths: &[(&str, Option<u64>)]) -> Snapshot {
+        Snapshot {
+            provider: ProviderId::new(provider),
+            account: AccountId::default(),
+            captured_at: Timestamp::from_unix(1_785_700_000).expect("plausible"),
+            windows: keyed_lengths
+                .iter()
+                .map(|(key, len)| Window {
+                    key: WindowKey::named(key),
+                    title: (*key).to_owned(),
+                    subtitle: None,
+                    used_percent: 0.0,
+                    resets_at: None,
+                    length: len.and_then(WindowLength::from_secs),
+                })
+                .collect(),
+            details: Vec::new(),
+        }
+    }
+
     #[test]
     fn the_dominant_window_is_the_shortest_one() {
         let s = snapshot(&[Some(604_800), Some(18_000), Some(2_592_000)]);
@@ -190,6 +234,33 @@ mod tests {
             s.dominant_window().expect("present").length,
             WindowLength::from_secs(18_000)
         );
+    }
+
+    #[test]
+    fn a_provider_that_names_a_lead_window_leads_with_it_over_a_shorter_one() {
+        // NanoGPT is the reason the naming exists: a hundred images a day sit at
+        // zero while the weekly input pool is the substance of the subscription,
+        // and shortest-first would make the zero the card's large number.
+        let s = provider_snapshot(
+            "nanogpt",
+            &[
+                ("images/w86400", Some(86_400)),
+                ("input-tokens/w604800", Some(604_800)),
+            ],
+        );
+        assert_eq!(
+            s.dominant_window().expect("present").key.as_str(),
+            "input-tokens/w604800"
+        );
+    }
+
+    #[test]
+    fn a_named_lead_window_that_is_not_there_falls_back_to_the_shortest() {
+        // The lead is a stable key, not a promise the pool is still metered. The
+        // documented NanoGPT shape has no weekly input pool; its card leads with
+        // the day it does meter.
+        let s = provider_snapshot("nanogpt", &[("monthly", None), ("w86400", Some(86_400))]);
+        assert_eq!(s.dominant_window().expect("present").key.as_str(), "w86400");
     }
 
     #[test]

--- a/crates/tidemark/src/model.rs
+++ b/crates/tidemark/src/model.rs
@@ -34,18 +34,20 @@ pub fn name(titles: &Titles, slug: &str) -> String {
 
 /// The windows of a reading, in the order the card draws them.
 ///
-/// Shortest first, windows of unknown length last — the same rule as
-/// [`Snapshot::dominant_window`], which is why the first element of this list *is* the
-/// dominant window. A test below pins them together, because two implementations of one
-/// rule is exactly how the card ends up leading with a different window than the one the
-/// rest of the program calls dominant.
+/// The dominant window first — placed there by construction, using the one rule in
+/// [`Snapshot::dominant_window`], so the two cannot drift — then shortest first, windows
+/// of unknown length last. A test below still pins the first element to the dominant
+/// window, because two implementations of one rule is exactly how the card ends up
+/// leading with a different window than the one the rest of the program calls dominant.
 ///
 /// Nothing is added and nothing is filled in: a provider that reported one window this time
 /// and three the last gets one row, and the card silently rearranges.
 pub fn ordered_windows(snapshot: &Snapshot) -> Vec<Window> {
+    let lead = snapshot.dominant_window().map(|window| window.key.clone());
     let mut windows = snapshot.windows.clone();
     windows.sort_by_key(|window| {
         (
+            !lead.as_ref().is_some_and(|key| *key == window.key),
             window.length.is_none(),
             window.length.map(WindowLength::as_secs),
         )
@@ -99,6 +101,17 @@ mod tests {
         }
     }
 
+    fn keyed_window(key: &str, length: Option<u64>) -> Window {
+        Window {
+            key: WindowKey::named(key),
+            title: key.to_owned(),
+            subtitle: None,
+            used_percent: 0.0,
+            resets_at: None,
+            length: length.and_then(WindowLength::from_secs),
+        }
+    }
+
     #[test]
     fn a_provider_is_called_what_the_catalog_calls_it() {
         let definitions = [ProviderDefinition {
@@ -141,6 +154,21 @@ mod tests {
             lengths,
             [Some(18_000), Some(604_800), Some(2_592_000), None]
         );
+    }
+
+    #[test]
+    fn the_window_a_provider_leads_with_is_drawn_first_even_when_it_is_not_the_shortest() {
+        // NanoGPT's weekly input pool is what its card is about; the hundred-images-a-day
+        // allowance beside it is the secondary row.
+        let mut card = snapshot(vec![
+            keyed_window("images/w86400", Some(86_400)),
+            keyed_window("input-tokens/w604800", Some(604_800)),
+        ]);
+        card.provider = ProviderId::new("nanogpt");
+
+        let ordered = ordered_windows(&card);
+        let keys: Vec<&str> = ordered.iter().map(|w| w.key.as_str()).collect();
+        assert_eq!(keys, ["input-tokens/w604800", "images/w86400"]);
     }
 
     #[test]


### PR DESCRIPTION
## What

The NanoGPT card now leads with **Weekly input tokens**; the images allowance becomes the secondary row.

## Why

A live reading meters `dailyImages` (100/day) beside `weeklyInputTokens` (60M/week). Under the card's shortest-window-first rule the images pool — sitting at 0% all day — was the large number, and the weekly input pool that *is* the subscription was a thin row. Confirmed against the recorded live response in the debug log.

## How

- `tidemark_types::lead_window_key`: a provider can name the window its card leads with, by stable key — the same shared-presentation pattern as `provider_label`. NanoGPT names `input-tokens/w604800`.
- `Snapshot::dominant_window` honours the name; `model::ordered_windows` places the dominant window first **by construction**, so the two rules cannot drift. Card, tray and the detail dialog's initial selection all follow.
- NanoGPT publishes the weekly input pool first, so the detail dialog and wire clients (`tidemark usage --json`) list it first too.
- A named key that stops arriving (the documented `daily`/`monthly` shape has no weekly pool) falls back to the shortest present window.
- `CONTEXT.md` card/tray bullets record the refinement.

## Testing

TDD: new failing tests first in `tidemark-types` (named lead beats a shorter window; missing lead falls back), `tidemark` model (draw order), and the NanoGPT fixtures (published order, dominant, documented-shape fallback). Full gate green: `cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace`, `check-layering.sh`.
