### PR TITLE
Make T3 Chat readable through Vercel's fingerprint gate; fix the auth checkmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config \
+            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config cmake \
             dbus-daemon desktop-file-utils appstream shellcheck
 
       - name: Confirm the toolkit meets the floor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config \
+            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config cmake \
             dbus-daemon desktop-file-utils appstream shellcheck
 
       - name: The tag must agree with Cargo.toml
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config dpkg-dev
+            libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config cmake dpkg-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-deb --locked
       - run: cargo build --release --locked --workspace
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Bootstrap the container
         run: |
-          dnf install -y git gcc gtk4-devel libadwaita-devel sqlite-devel \
+          dnf install -y git gcc cmake gtk4-devel libadwaita-devel sqlite-devel \
             pkgconf-pkg-config rpm-build
       - uses: actions/checkout@v5
       - name: Install rustup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,9 @@ shellcheck scripts/*.sh data/restart-user-daemon \
   data/packaging/deb/postinst data/packaging/rpm/post-install.sh
 ```
 
-Build prerequisites: `libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config` (Fedora:
-`gtk4-devel libadwaita-devel sqlite-devel pkgconf-pkg-config`). There are **no** `build.rs`
+Build prerequisites: `libgtk-4-dev libadwaita-1-dev libsqlite3-dev pkg-config cmake` (Fedora:
+`gtk4-devel libadwaita-devel sqlite-devel pkgconf-pkg-config cmake`; `cmake` builds the
+BoringSSL behind T3 Chat's emulating client). There are **no** `build.rs`
 files, no Blueprint, no gresource — nothing to pre-compile.
 
 Run-by-hand only (no workflow triggers them): `scripts/test-release.sh` and
@@ -133,7 +134,9 @@ human work. Tag push starts the release workflow, so the script runs no tests.
 - **Credentials:** never log a `Credential`. Keyring-locked is a state, not a crash. Third-party
   CLI credential files are field-merged atomically into their canonical vendor path only
   (ADR-0001) — never created, reformatted, or written to discovered copies.
-- **Networking:** identify every request as `Tidemark/<version>`; never impersonate a browser.
+- **Networking:** identify every request as `Tidemark/<version>`. Browser-transport emulation
+  is reserved for an edge that fingerprints clients — T3 Chat rides `wreq` (see
+  `CONTEXT.md` § Networking); embedding web (webview, JS engine) is forbidden outright.
   One proxy configuration for every client and subprocess; never proxy loopback.
 - **Presentation:** never invent history points, quota lengths, reset times, or hide windows.
   70% / 90% are the shared card and notification thresholds. Order is the `providers` array —

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -342,9 +342,18 @@ distribution-wide LTO off; `PKGBUILD` does it with `options=(!lto)`.
 
 Every request sets `User-Agent: Tidemark/<version>`. This is not cosmetic:
 `platform.claude.com` sits behind Cloudflare and answers an unset agent with
-`403 browser_signature_banned`. Identify honestly by product name — never impersonate a
-browser. We authenticate with real credentials to documented endpoints; there is no reason
-to look like anything other than what we are.
+`403 browser_signature_banned`. Identify honestly by product name. We authenticate with
+real credentials to documented endpoints; outside the one exception below there is no
+reason to look like anything other than what we are.
+
+**The one exception: T3 Chat.** Vercel fronts `t3.chat` with a challenge that gates on
+the client's TLS and HTTP/2 fingerprints rather than on cookies or headers — the honest
+client is challenged no matter what it says, and a real browser is let through with no
+session at all. That provider alone rides `wreq` (BoringSSL), emulating the Chrome or
+Firefox fingerprint of the chosen session's browser family while carrying that session's
+own cookies. The impersonation is transport-level only. The prohibition that actually
+matters — and holds without exception — is on embedding web: no webview, no JS engine,
+no bundled browser ever runs inside this process.
 
 **One proxy, set once, applied everywhere.** `[proxy]` in `config.toml` names a mode
 (`off`, `http`, `https`, `socks5`), a host and a port; `tidemark-core`'s `providers::http`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +275,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +345,56 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "boring-sys2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
+dependencies = [
+ "autocfg",
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
+name = "boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
+dependencies = [
+ "bitflags",
+ "boring-sys2",
+ "brotli",
+ "flate2",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "zstd",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -361,7 +459,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -419,6 +526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,9 +567,12 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -608,6 +729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +863,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +913,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1021,6 +1185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "gobject-sys"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1430,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http2"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,12 +1515,32 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
+]
+
+[[package]]
+name = "hyper2"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http2",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1474,6 +1682,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,9 +1708,9 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.20",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1610,6 +1827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1850,21 @@ checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1642,6 +1884,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru-slab"
@@ -1690,6 +1938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1962,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1849,6 +2113,17 @@ dependencies = [
  "zbus_macros",
  "zeroize",
  "zvariant",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2020,8 +2295,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror",
+ "socket2 0.6.5",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2044,7 +2319,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2059,7 +2334,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2141,6 +2416,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,7 +2506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2318,7 +2605,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -2528,6 +2815,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -2575,6 +2868,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2716,11 +3019,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2777,12 +3100,14 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.11.0",
- "thiserror",
+ "thiserror 2.0.20",
  "tidemark-types",
  "time",
  "tokio",
  "toml_edit",
  "tracing",
+ "wreq",
+ "wreq-util",
 ]
 
 [[package]]
@@ -2801,7 +3126,7 @@ dependencies = [
  "rusqlite",
  "semver",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tidemark-core",
  "tidemark-types",
  "tokio",
@@ -2876,10 +3201,21 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
+dependencies = [
+ "boring-sys2",
+ "boring2",
+ "tokio",
 ]
 
 [[package]]
@@ -2900,6 +3236,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3085,6 +3433,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "typenum"
@@ -3279,12 +3647,37 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.9",
+]
+
+[[package]]
+name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -3296,6 +3689,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,13 +3708,33 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3318,7 +3743,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3327,7 +3761,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3345,7 +3779,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3426,6 +3860,57 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wreq"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1248467bcb6aafde3dae847973df892e656ed376c014d11743fd437efac6560"
+dependencies = [
+ "antidote",
+ "arc-swap",
+ "async-compression",
+ "base64 0.22.1",
+ "boring2",
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper2",
+ "ipnet",
+ "linked_hash_set",
+ "log",
+ "lru",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "socket2 0.5.10",
+ "sync_wrapper",
+ "tokio",
+ "tokio-boring2",
+ "tokio-socks",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "typed-builder",
+ "url",
+ "webpki-root-certs 0.26.11",
+ "windows-registry 0.5.3",
+]
+
+[[package]]
+name = "wreq-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80149a1bd2e70c2d621e7467446dbb3c59e44a9aad9e5e72664687073f421f76"
+dependencies = [
+ "typed-builder",
+ "wreq",
+]
 
 [[package]]
 name = "writeable"
@@ -3626,6 +4111,34 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,7 +23,7 @@ license=('MIT')
 # rustls and oo7's native crypto keep OpenSSL and libsecret out; SQLite is the system
 # library rather than a vendored copy, on purpose (CONTEXT.md § API floor).
 depends=('gtk4' 'libadwaita' 'sqlite' 'dbus')
-makedepends=('cargo')
+makedepends=('cargo' 'cmake')
 install=tidemark.install
 source=()
 # !lto is not a preference, it is a link requirement. rustls pulls aws-lc-sys, whose C and

--- a/crates/tidemark-core/Cargo.toml
+++ b/crates/tidemark-core/Cargo.toml
@@ -40,3 +40,11 @@ time = { version = "0.3.47", features = ["formatting", "parsing"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "time", "fs", "sync"] }
 toml_edit = { version = "0.25.13", default-features = false, features = ["parse", "display"] }
 tracing = "0.1.44"
+# wreq: the browser-emulating HTTP stack T3 Chat's Vercel edge demands — it gates on the
+# client's TLS/HTTP2 fingerprint, and no honest rustls ClientHello passes (see
+# `providers/keyed/t3chat.rs`). Pinned below 0.16, which raises the toolchain above this
+# workspace's MSRV. `socks`/`system-proxy`: mirror the reqwest feature set so the one
+# proxy policy holds on both stacks; the compression features because the Chrome preset
+# announces them in `accept-encoding`.
+wreq = { version = "~0.15.3", default-features = false, features = ["webpki-roots", "socks", "charset", "gzip", "brotli", "zstd", "deflate"] }
+wreq-util = "~0.1.0"

--- a/crates/tidemark-core/src/browser/auth.rs
+++ b/crates/tidemark-core/src/browser/auth.rs
@@ -32,6 +32,8 @@ pub enum Validation {
     Rejected,
     /// The proof request could not say whether the source works.
     Unreachable,
+    /// An edge browser challenge answered instead of the provider.
+    Challenged,
 }
 
 /// A selected store's cookie header, kept entirely inside core.
@@ -202,6 +204,7 @@ where
                         Validation::Ready => AuthCandidateState::Ready,
                         Validation::Rejected => AuthCandidateState::Rejected,
                         Validation::Unreachable => AuthCandidateState::Unreachable,
+                        Validation::Challenged => AuthCandidateState::Challenged,
                     }
                 }
             }
@@ -253,6 +256,12 @@ fn aggregate_state(children: &[AuthCandidate]) -> AuthCandidateState {
         .any(|state| state == AuthCandidateState::WaitingForKeyring)
     {
         return AuthCandidateState::WaitingForKeyring;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Challenged)
+    {
+        return AuthCandidateState::Challenged;
     }
     if states
         .clone()

--- a/crates/tidemark-core/src/providers/http.rs
+++ b/crates/tidemark-core/src/providers/http.rs
@@ -1,9 +1,12 @@
 //! The one place an outbound HTTP client is built, and the proxy it is built against.
 //!
-//! Everything that leaves this process identifies itself as `Tidemark/<version>`, and that
-//! is load-bearing rather than polite: `platform.claude.com` sits behind Cloudflare and
-//! answers a request with no user agent with `403 browser_signature_banned`. See
-//! `CONTEXT.md` § Networking.
+//! Everything that leaves this process through this builder identifies itself as
+//! `Tidemark/<version>`, and that is load-bearing rather than polite:
+//! `platform.claude.com` sits behind Cloudflare and answers a request with no user agent
+//! with `403 browser_signature_banned`. See `CONTEXT.md` § Networking. The one client
+//! that deliberately does not start here is T3 Chat's: its edge admits only
+//! browser-shaped clients, so it rides an emulating stack instead — see
+//! `keyed/t3chat.rs`.
 //!
 //! # Why the proxy is process-wide rather than a parameter
 //!

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -449,6 +449,7 @@ fn validation_state(validation: crate::browser::auth::Validation) -> AuthCandida
         crate::browser::auth::Validation::Ready => AuthCandidateState::Ready,
         crate::browser::auth::Validation::Rejected => AuthCandidateState::Rejected,
         crate::browser::auth::Validation::Unreachable => AuthCandidateState::Unreachable,
+        crate::browser::auth::Validation::Challenged => AuthCandidateState::Challenged,
     }
 }
 
@@ -465,6 +466,12 @@ fn candidate_state(candidates: &[AuthCandidate]) -> AuthCandidateState {
         .any(|state| state == AuthCandidateState::WaitingForKeyring)
     {
         return AuthCandidateState::WaitingForKeyring;
+    }
+    if states
+        .clone()
+        .any(|state| state == AuthCandidateState::Challenged)
+    {
+        return AuthCandidateState::Challenged;
     }
     if states
         .clone()

--- a/crates/tidemark-core/src/providers/keyed/qoder.rs
+++ b/crates/tidemark-core/src/providers/keyed/qoder.rs
@@ -246,8 +246,9 @@ fn merge_sources(
 
 fn source_rank(state: Option<AuthCandidateState>) -> u8 {
     match state {
-        Some(AuthCandidateState::Ready) => 5,
-        Some(AuthCandidateState::WaitingForKeyring) => 4,
+        Some(AuthCandidateState::Ready) => 6,
+        Some(AuthCandidateState::WaitingForKeyring) => 5,
+        Some(AuthCandidateState::Challenged) => 4,
         Some(AuthCandidateState::Unreachable) => 3,
         Some(AuthCandidateState::Rejected) => 2,
         Some(AuthCandidateState::Missing) | None => 1,

--- a/crates/tidemark-core/src/providers/keyed/session.rs
+++ b/crates/tidemark-core/src/providers/keyed/session.rs
@@ -281,6 +281,12 @@ fn aggregate_state(candidates: &[AuthCandidate]) -> AuthCandidateState {
     }
     if states
         .clone()
+        .any(|state| state == AuthCandidateState::Challenged)
+    {
+        return AuthCandidateState::Challenged;
+    }
+    if states
+        .clone()
         .any(|state| state == AuthCandidateState::Unreachable)
     {
         return AuthCandidateState::Unreachable;

--- a/crates/tidemark-core/src/providers/keyed/t3chat.rs
+++ b/crates/tidemark-core/src/providers/keyed/t3chat.rs
@@ -6,11 +6,16 @@
 //! the lines around it are tRPC bookkeeping that has changed shape before. Two meters
 //! matter: the four-hour base allowance, and the month's overage, whose reset is the
 //! subscription period's end and nothing else — the billing reset timestamp tracks the
-//! usage window. Vercel fronts the site with a browser challenge; when it asks, that is
-//! reported as a sentence, because this client identifies itself as Tidemark and will not
-//! pretend to be a browser to get past it.
+//! usage window. Vercel fronts the site with a challenge that gates on the client's TLS
+//! and HTTP/2 fingerprints rather than on cookies or headers — this program's honest
+//! rustls client is challenged no matter what it says, and a real browser is let through
+//! with no session at all — so this one provider rides an emulating stack (`wreq`,
+//! BoringSSL under a Chrome or Firefox fingerprint, whichever family the chosen session's
+//! browser is) carrying the session's own cookies. The impersonation is transport-level
+//! only; no web engine runs inside this process. When the edge challenges even that, it
+//! is reported as a sentence.
 
-use super::{HandSpec, Options, ProviderError, redact_query, session};
+use super::{HandSpec, Options, ProviderError, http, session};
 use crate::browser::{self, Keyring, SafeStorage, auth::Selection};
 use crate::providers::{BoxFuture, Credential, Provider};
 use serde::Deserialize;
@@ -21,6 +26,7 @@ use tidemark_types::{
     AccountId, AuthCandidate, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot,
     Timestamp, Window, WindowKey, WindowLength,
 };
+use wreq_util::Emulation;
 
 #[cfg(test)]
 use std::path::Path;
@@ -55,7 +61,7 @@ fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>
 /// One T3 Chat account, authenticated by one explicitly chosen browser profile. The gate
 /// is the whole jar: the site's session cookie has no name worth pinning.
 pub struct T3Chat {
-    client: reqwest::Client,
+    client: wreq::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
     selection: Option<Selection>,
@@ -65,11 +71,15 @@ pub struct T3Chat {
 
 impl T3Chat {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        let selection = session::selection(options);
+        let browser = selection
+            .as_ref()
+            .map_or("chrome", |selection| selection.browser.as_str());
         Ok(Self {
-            client: super::http::client()?,
+            client: Self::browser_client(browser)?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
-            selection: session::selection(options),
+            selection,
             #[cfg(test)]
             base_url: None,
         })
@@ -82,7 +92,7 @@ impl T3Chat {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
-            client: super::http::client()?,
+            client: Self::browser_client("firefox")?,
             home: Some(home.to_path_buf()),
             storage,
             selection: Some(Selection {
@@ -90,6 +100,31 @@ impl T3Chat {
                 profile: None,
             }),
             base_url: Some(base_url.trim_end_matches('/').to_owned()),
+        })
+    }
+
+    /// The browser-shaped client this provider's edge demands: the same proxy policy and
+    /// timeouts as [`http::client`], but wearing a browser's TLS and HTTP/2 fingerprint
+    /// instead of this program's name — see the module docs.
+    fn browser_client(browser: &str) -> Result<wreq::Client, ProviderError> {
+        let mut builder = wreq::Client::builder()
+            .emulation(emulation_for(browser))
+            .timeout(http::REQUEST_TIMEOUT)
+            .connect_timeout(http::CONNECT_TIMEOUT);
+        if let Some(proxy) = http::proxy() {
+            let proxy = wreq::Proxy::all(proxy.url())
+                .map(|proxy| proxy.no_proxy(wreq::NoProxy::from_string(http::NO_PROXY)))
+                .map_err(|error| {
+                    ProviderError::Emulated(format!(
+                        "could not build the browser-emulating client: {error}"
+                    ))
+                })?;
+            builder = builder.proxy(proxy);
+        }
+        builder.build().map_err(|error| {
+            ProviderError::Emulated(format!(
+                "could not build the browser-emulating client: {error}"
+            ))
         })
     }
 
@@ -102,18 +137,20 @@ impl T3Chat {
         url.to_owned()
     }
 
-    fn data_request(&self, url: &str, cookie: &str) -> Result<reqwest::Request, ProviderError> {
+    fn data_request(&self, url: &str, cookie: &str) -> Result<wreq::Request, ProviderError> {
         self.client
             .get(url)
             .query(&[("batch", "1"), ("input", INPUT)])
             .header("trpc-accept", "application/jsonl")
             .header("x-trpc-source", "web-client")
             .header("x-trpc-batch", "true")
-            .header(reqwest::header::REFERER, REFERER)
-            .header(reqwest::header::ORIGIN, ORIGIN)
-            .header(reqwest::header::COOKIE, cookie)
+            .header("referer", REFERER)
+            .header("origin", ORIGIN)
+            .header("cookie", cookie)
             .build()
-            .map_err(|error| ProviderError::Client(redact_query(error)))
+            .map_err(|error| {
+                ProviderError::Emulated(format!("could not build the T3 Chat request: {error}"))
+            })
     }
 
     async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {
@@ -129,28 +166,99 @@ impl T3Chat {
         .await?
         .ok_or(ProviderError::NoCredential)?;
         let request = self.data_request(&self.url(API_URL), &session.header)?;
-        let (body, _) = super::request_inspected(PROVIDER_ID, &self.client, request, |response| {
-            if is_vercel_challenge(response) {
-                return Err(ProviderError::Local(
-                    "T3 Chat asked for a browser check".to_owned(),
-                ));
-            }
-            Ok(())
-        })
-        .await?;
+        let body = self.send_inspected(request).await?;
         parse(&body, Timestamp::now())
     }
 
-    async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
-        let Ok(request) = self.data_request(API_URL, header) else {
-            return crate::browser::auth::Validation::Unreachable;
-        };
-        match super::validate(&self.client, request).await {
-            Ok(()) => crate::browser::auth::Validation::Ready,
-            Err(ProviderError::Credential { status: 401 | 403 }) => {
-                crate::browser::auth::Validation::Rejected
+    /// [`super::request_inspected`] on the emulating stack: the same `Retry-After` read,
+    /// the same challenge-before-status rule, the same `http::check`, the same
+    /// raw-response log and empty-body refusal — against `wreq` types, because the
+    /// request must wear a browser's fingerprint and `request_inspected` speaks
+    /// `reqwest`.
+    async fn send_inspected(&self, request: wreq::Request) -> Result<String, ProviderError> {
+        let url = request.url().as_str().to_owned();
+        let sent = crate::debug::enabled().then(|| crate::debug::Sent::get(&url));
+        let note = |answer| {
+            if let Some(sent) = &sent {
+                crate::debug::record(crate::debug::Exchange {
+                    provider: PROVIDER_ID,
+                    sent: *sent,
+                    answer,
+                });
             }
-            Err(_) => crate::browser::auth::Validation::Unreachable,
+        };
+
+        let response = match self.client.execute(request).await {
+            Ok(response) => response,
+            Err(error) => {
+                let error = ProviderError::Emulated(format!("request failed: {error}"));
+                note(crate::debug::Answer::Failed {
+                    error: &error.to_string(),
+                });
+                return Err(error);
+            }
+        };
+
+        let status = response.status().as_u16();
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        if is_vercel_challenge(&response) {
+            note(crate::debug::Answer::Refused { status });
+            return Err(ProviderError::Challenged(
+                "T3 Chat asked for a browser check".to_owned(),
+            ));
+        }
+        if let Err(error) = http::check(wire_status(status), retry_after.as_deref()) {
+            note(crate::debug::Answer::Refused { status });
+            return Err(error);
+        }
+
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(error) => {
+                let error = ProviderError::Emulated(format!("request failed: {error}"));
+                note(crate::debug::Answer::Failed {
+                    error: &error.to_string(),
+                });
+                return Err(error);
+            }
+        };
+        // Before the emptiness check, as in `request_inspected`: "the provider answered
+        // nothing" is one of the things a person reads the raw-response log to confirm.
+        note(crate::debug::Answer::Body {
+            status,
+            body: &body,
+        });
+        if body.trim().is_empty() {
+            return Err(ProviderError::malformed(
+                "the provider answered an empty body",
+            ));
+        }
+        Ok(body)
+    }
+
+    async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
+        use crate::browser::auth::Validation;
+        let Ok(request) = self.data_request(&self.url(API_URL), header) else {
+            return Validation::Unreachable;
+        };
+        let Ok(response) = self.client.execute(request).await else {
+            return Validation::Unreachable;
+        };
+        if is_vercel_challenge(&response) {
+            return Validation::Challenged;
+        }
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok());
+        match http::check(wire_status(response.status().as_u16()), retry_after) {
+            Ok(()) => Validation::Ready,
+            Err(ProviderError::Credential { status: 401 | 403 }) => Validation::Rejected,
+            Err(_) => Validation::Unreachable,
         }
     }
 
@@ -198,13 +306,29 @@ fn cookie_query() -> browser::Query {
 }
 
 /// Whether the response is Vercel's browser challenge, which arrives stamped as a 429.
-fn is_vercel_challenge(response: &reqwest::Response) -> bool {
-    response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+fn is_vercel_challenge(response: &wreq::Response) -> bool {
+    response.status().as_u16() == 429
         && response
             .headers()
             .get("x-vercel-mitigated")
             .and_then(|value| value.to_str().ok())
             .is_some_and(|value| value.eq_ignore_ascii_case("challenge"))
+}
+
+/// The fingerprint family the emulating client wears: the chosen session's own browser
+/// family, so the handshake, the headers and the cookies all name one browser. Zen is a
+/// Firefox build underneath; an unrecognised name reads as Chrome, the most common shape.
+fn emulation_for(browser: &str) -> Emulation {
+    match browser {
+        "firefox" | "zen" => Emulation::Firefox139,
+        _ => Emulation::Chrome137,
+    }
+}
+
+/// `http::check` speaks `reqwest`'s status type; a status off the wire is the same u16 on
+/// either stack. The fallback only satisfies the type — the wire never sends it here.
+fn wire_status(status: u16) -> reqwest::StatusCode {
+    reqwest::StatusCode::from_u16(status).unwrap_or(reqwest::StatusCode::BAD_GATEWAY)
 }
 
 /// The subscription fields the meters need.
@@ -370,7 +494,7 @@ fn instant(raw: Option<f64>) -> Option<Timestamp> {
 
 #[cfg(test)]
 mod tests {
-    use super::{T3Chat, is_vercel_challenge, parse};
+    use super::{T3Chat, emulation_for, is_vercel_challenge, parse};
     use crate::browser::SafeStorage;
     use crate::providers::{Provider, ProviderError};
     use crate::secrets::SecretError;
@@ -610,8 +734,28 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ProviderError::Local(sentence)) if sentence == "T3 Chat asked for a browser check"
+            Err(ProviderError::Challenged(sentence)) if sentence == "T3 Chat asked for a browser check"
         ));
+    }
+
+    #[test]
+    fn a_vercel_challenge_during_proof_is_reported_as_challenged() {
+        let home = gecko_home();
+        let (base_url, _requests, server) = chained_server(vec![(
+            "GET /api/trpc/getCustomerData?batch=1&input=",
+            429,
+            "x-vercel-mitigated: challenge\r\n",
+            "checkpoint",
+        )]);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let validation =
+            runtime.block_on(provider(&home, &base_url).validate_header("session=t3-value"));
+        server.join().expect("server exits");
+
+        assert_eq!(validation, crate::browser::auth::Validation::Challenged);
     }
 
     #[test]
@@ -662,11 +806,7 @@ mod tests {
                 .build()
                 .expect("runtime");
             let response = runtime
-                .block_on(
-                    reqwest::Client::new()
-                        .get(format!("{base_url}/probe"))
-                        .send(),
-                )
+                .block_on(wreq::Client::new().get(format!("{base_url}/probe")).send())
                 .expect("answers");
             server.join().expect("server exits");
             is_vercel_challenge(&response)
@@ -676,5 +816,16 @@ mod tests {
         assert!(!answered(429, "x-vercel-mitigated: rate-limit\r\n"));
         assert!(!answered(429, ""));
         assert!(!answered(500, "x-vercel-mitigated: challenge\r\n"));
+    }
+
+    #[test]
+    fn the_emulated_fingerprint_follows_the_selected_browser_family() {
+        use wreq_util::Emulation;
+
+        assert!(matches!(emulation_for("chrome"), Emulation::Chrome137));
+        assert!(matches!(emulation_for("chromium"), Emulation::Chrome137));
+        assert!(matches!(emulation_for("firefox"), Emulation::Firefox139));
+        // Zen is a Firefox build underneath; its cookies arrive on a Firefox handshake.
+        assert!(matches!(emulation_for("zen"), Emulation::Firefox139));
     }
 }

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -301,9 +301,18 @@ pub enum ProviderError {
         /// The status.
         status: u16,
     },
+    /// The provider's edge answered with a browser challenge this client does not perform.
+    /// The string is the whole message: the refusal is the edge's, not this machine's.
+    #[error("{0}")]
+    Challenged(String),
     /// A local prerequisite such as a credential file could not be accessed safely.
     #[error("local provider state is unavailable: {0}")]
     Local(String),
+    /// The browser-emulating transport a provider's edge demands failed. The string is
+    /// the whole message: [`ProviderError::Transport`] it cannot be, because that variant
+    /// carries a `reqwest` error and this stack is not `reqwest`.
+    #[error("{0}")]
+    Emulated(String),
     /// The response arrived but does not mean what we expect it to mean.
     #[error("unparseable response: {0}")]
     Malformed(String),

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -274,6 +274,9 @@ pub enum AuthCandidateState {
     WaitingForKeyring,
     /// The daemon could not reach the provider to determine whether the source works.
     Unreachable,
+    /// The provider's edge answered the proof with a browser challenge instead of a
+    /// verdict, so whether the source works could not be determined.
+    Challenged,
 }
 
 impl AuthCandidateState {
@@ -285,6 +288,7 @@ impl AuthCandidateState {
             Self::Rejected => "rejected",
             Self::WaitingForKeyring => "waiting-for-keyring",
             Self::Unreachable => "unreachable",
+            Self::Challenged => "challenged",
         }
     }
 
@@ -297,6 +301,7 @@ impl AuthCandidateState {
             Self::Rejected,
             Self::WaitingForKeyring,
             Self::Unreachable,
+            Self::Challenged,
         ]
         .into_iter()
         .find(|candidate| candidate.as_wire() == value)

--- a/crates/tidemark/src/provider_settings/browser_auth.rs
+++ b/crates/tidemark/src/provider_settings/browser_auth.rs
@@ -20,11 +20,17 @@ use super::model;
 
 /// Whether activating this candidate may ask the daemon to select it.
 ///
-/// Only a proven source is a real offer. Missing and rejected ones are insensitive —
-/// choosing them could only record a failure — and so are locked-keyring and inconclusive
-/// verdicts, which are answers about *checking* rather than about the credential.
+/// A proven source is a real offer, and a challenged one is nearly that: its jar already
+/// holds a live session, and it is the edge refusing the proof rather than the provider
+/// refusing the credential — the choice starts working when the challenge lifts. Missing
+/// and rejected ones are insensitive — choosing them could only record a failure — and so
+/// are locked-keyring and inconclusive verdicts, which are answers about *checking* rather
+/// than about the credential.
 pub(super) fn candidate_selectable(state: AuthCandidateState) -> bool {
-    matches!(state, AuthCandidateState::Ready)
+    matches!(
+        state,
+        AuthCandidateState::Ready | AuthCandidateState::Challenged
+    )
 }
 
 /// Whether a source's children deserve rows of their own.
@@ -51,6 +57,7 @@ pub(super) fn state_word(state: Option<AuthCandidateState>) -> &'static str {
         Some(AuthCandidateState::Missing) => "Not found",
         Some(AuthCandidateState::Rejected) => "Rejected",
         Some(AuthCandidateState::WaitingForKeyring) => "Keyring locked",
+        Some(AuthCandidateState::Challenged) => "Browser check",
         Some(AuthCandidateState::Unreachable) | None => "Inconclusive",
     }
 }
@@ -243,11 +250,28 @@ impl Half {
     }
 
     /// Marks the one row the account's published selection names, inside its own mode.
+    ///
+    /// The claim names a profile leaf, while the rows stop at the browser whenever its
+    /// profiles are not drawn — the row that carries the claim is the longest row id the
+    /// claim is or lives under.
     fn apply_selection(&self, selection: Option<&AuthSelection>) {
         let claimed =
             selection.and_then(|selection| model::selected_candidate(selection, &self.mode_value));
-        for row in self.rows.borrow().iter() {
-            row.in_use.set_visible(claimed == Some(row.id.as_str()));
+        let rows = self.rows.borrow();
+        let marked = claimed.and_then(|claimed| {
+            rows.iter()
+                .filter(|row| {
+                    claimed == row.id
+                        || claimed
+                            .strip_prefix(row.id.as_str())
+                            .is_some_and(|rest| rest.starts_with('/'))
+                })
+                .max_by_key(|row| row.id.len())
+                .map(|row| row.id.clone())
+        });
+        for row in rows.iter() {
+            row.in_use
+                .set_visible(marked.as_deref() == Some(row.id.as_str()));
         }
     }
 }
@@ -410,6 +434,12 @@ impl BrowserAuth {
         for half in &self.halves {
             half.apply_report(report, &self.on_choose);
         }
+        // Rebuilt rows start unmarked: repaint the claim the daemon last published rather
+        // than leaving it to the next unrelated status publication.
+        let selection = self.selection.borrow().clone();
+        for half in &self.halves {
+            half.apply_selection(selection.as_ref());
+        }
     }
 
     /// Snaps the pill and the halves onto the published mode while nobody has navigated.
@@ -466,10 +496,13 @@ mod tests {
     use std::rc::Rc;
 
     use adw::prelude::*;
-    use tidemark_types::{AuthCandidate, AuthCandidateState, AuthMode};
+    use tidemark_types::{
+        AuthCandidate, AuthCandidateState, AuthMode, AuthSelection, AuthSelector,
+    };
 
     use super::{
-        CandidateRow, Half, candidate_selectable, shows_profile_children, state_classes, state_word,
+        BrowserAuth, CandidateRow, Half, candidate_selectable, shows_profile_children,
+        state_classes, state_word,
     };
 
     fn candidate(id: &str, state: AuthCandidateState) -> AuthCandidate {
@@ -483,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_proven_working_candidate_is_selectable() {
+    fn a_proven_candidate_is_selectable() {
         assert!(candidate_selectable(AuthCandidateState::Ready));
     }
 
@@ -496,7 +529,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_auth_widgets_keep_source_rows_separate_from_the_tabs() {
+    fn browser_auth_widgets_keep_rows_separate_and_marks_across_rebuilds() {
         if !widgets() {
             eprintln!("skipped: no display is available");
             return;
@@ -522,6 +555,51 @@ mod tests {
         assert!(half.group.title().is_empty());
         assert!(half.group.header_suffix().is_none());
         assert_eq!(half.group.margin_top(), 12);
+
+        // Inspection rebuilds every row; the In-use mark must not wait for the next
+        // unrelated status publication to come back.
+        let selector = AuthSelector {
+            option: "auth-source".into(),
+            modes: vec![AuthMode {
+                value: "browser".into(),
+                title: "Browser".into(),
+            }],
+        };
+        let selection = AuthSelection {
+            mode: "browser".into(),
+            candidate: Some("firefox".into()),
+        };
+        let auth = BrowserAuth::new(&selector, Some(&selection), Rc::new(|_| {}));
+        let report = || {
+            vec![AuthCandidate {
+                children: vec![candidate("firefox", AuthCandidateState::Ready)],
+                ..candidate("browser", AuthCandidateState::Ready)
+            }]
+        };
+
+        auth.apply_report(report());
+        auth.apply_report(report());
+
+        let marks = |auth: &BrowserAuth| -> Vec<bool> {
+            auth.halves[0]
+                .rows
+                .borrow()
+                .iter()
+                .map(|row| row.in_use.is_visible())
+                .collect()
+        };
+        assert_eq!(marks(&auth), [true]);
+
+        // The claim names a profile leaf while the rows stop at the browser: the browser
+        // row carries it.
+        let leaf = AuthSelection {
+            mode: "browser".into(),
+            candidate: Some("firefox/Default".into()),
+        };
+        let auth = BrowserAuth::new(&selector, Some(&leaf), Rc::new(|_| {}));
+        auth.apply_report(report());
+        auth.apply_report(report());
+        assert_eq!(marks(&auth), [true]);
     }
 
     #[test]
@@ -569,6 +647,21 @@ mod tests {
         // that a source a newer daemon doubts is usable.
         assert_eq!(state_word(None), "Inconclusive");
         assert_eq!(state_classes(None), &["dim-label"]);
+    }
+
+    #[test]
+    fn a_challenged_candidate_is_selectable_with_neutral_words() {
+        // The jar already holds a live session; it is the edge refusing the proof, not the
+        // provider refusing the credential.
+        assert!(candidate_selectable(AuthCandidateState::Challenged));
+        assert_eq!(
+            state_word(Some(AuthCandidateState::Challenged)),
+            "Browser check"
+        );
+        assert_eq!(
+            state_classes(Some(AuthCandidateState::Challenged)),
+            &["dim-label"]
+        );
     }
 
     #[test]

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -593,7 +593,7 @@ impl Engine {
             return Err(format!("account {provider}/{account} is not configured"));
         };
         let sources = self.inspect_auth_sources(provider, account).await?;
-        let Some(selection) = ready_auth_selection(&sources, &selection) else {
+        let Some(selection) = resolvable_auth_selection(&sources, &selection) else {
             return Err("the selected authentication source is not ready".into());
         };
 
@@ -1321,11 +1321,14 @@ pub fn stored_kind(credential: CredentialKind) -> Option<Kind> {
     }
 }
 
-/// The exact ready source an inspected choice names.
+/// The exact usable source an inspected choice names.
 ///
-/// A browser parent is a one-click shorthand only. The persisted choice is its first ready
-/// profile in inspection order, so a later poll cannot re-scan and choose a different account.
-fn ready_auth_selection(
+/// A browser parent is a one-click shorthand only. The persisted choice is its first usable
+/// profile in inspection order, so a later poll cannot re-scan and choose a different
+/// account. Usable is a proven source or a challenged one: an edge challenge refuses the
+/// proof rather than the session, so a challenged choice starts working the moment the edge
+/// lets the client through.
+fn resolvable_auth_selection(
     sources: &[AuthCandidate],
     selection: &AuthSelection,
 ) -> Option<AuthSelection> {
@@ -1333,10 +1336,10 @@ fn ready_auth_selection(
         .iter()
         .find(|candidate| candidate.id == selection.mode)?;
     match selection.candidate.as_deref() {
-        None if mode.state() == Some(AuthCandidateState::Ready) => Some(selection.clone()),
+        None if selectable_state(mode.state()) => Some(selection.clone()),
         None => None,
         Some(candidate) => {
-            ready_descendant(&mode.children, candidate).map(|candidate| AuthSelection {
+            selectable_descendant(&mode.children, candidate).map(|candidate| AuthSelection {
                 mode: selection.mode.clone(),
                 candidate: Some(candidate.id.clone()),
             })
@@ -1344,30 +1347,39 @@ fn ready_auth_selection(
     }
 }
 
-/// Finds a selected ready candidate and resolves parent shortcuts to their first ready leaf.
-fn ready_descendant<'a>(
+/// Finds a selected usable candidate and resolves parent shortcuts to their first usable leaf.
+fn selectable_descendant<'a>(
     candidates: &'a [AuthCandidate],
     selected: &str,
 ) -> Option<&'a AuthCandidate> {
     candidates.iter().find_map(|candidate| {
-        if candidate.id == selected && candidate.state() == Some(AuthCandidateState::Ready) {
-            first_ready_leaf(candidate)
+        if candidate.id == selected && selectable_state(candidate.state()) {
+            first_selectable_leaf(candidate)
         } else {
-            ready_descendant(&candidate.children, selected)
+            selectable_descendant(&candidate.children, selected)
         }
     })
 }
 
-/// The first proven leaf in the daemon's stable discovery order.
-fn first_ready_leaf(candidate: &AuthCandidate) -> Option<&AuthCandidate> {
-    if candidate.state() != Some(AuthCandidateState::Ready) {
+/// The first usable leaf in the daemon's stable discovery order.
+fn first_selectable_leaf(candidate: &AuthCandidate) -> Option<&AuthCandidate> {
+    if !selectable_state(candidate.state()) {
         return None;
     }
     candidate
         .children
         .iter()
-        .find_map(first_ready_leaf)
+        .find_map(first_selectable_leaf)
         .or(Some(candidate))
+}
+
+/// Whether an inspected candidate may be persisted: proven, or blocked only by an edge
+/// challenge the provider never saw.
+fn selectable_state(state: Option<AuthCandidateState>) -> bool {
+    matches!(
+        state,
+        Some(AuthCandidateState::Ready | AuthCandidateState::Challenged)
+    )
 }
 
 /// What asking the keyring for a credential produced.
@@ -1390,7 +1402,9 @@ fn state_for(error: &ProviderError) -> ProviderState {
         ProviderError::Client(_)
         | ProviderError::Transport(_)
         | ProviderError::Http { .. }
-        | ProviderError::Local(_) => ProviderState::Unreachable,
+        | ProviderError::Local(_)
+        | ProviderError::Emulated(_)
+        | ProviderError::Challenged(_) => ProviderState::Unreachable,
     }
 }
 
@@ -1454,7 +1468,7 @@ mod tests {
         assert_eq!(report[0].id, "browser");
         assert_eq!(report[0].children[0].id, "firefox");
         assert_eq!(
-            ready_auth_selection(
+            resolvable_auth_selection(
                 &report,
                 &AuthSelection {
                     mode: "browser".into(),
@@ -1465,6 +1479,67 @@ mod tests {
                 mode: "browser".into(),
                 candidate: Some("firefox/Default".into()),
             })
+        );
+    }
+
+    #[test]
+    fn a_challenged_browser_choice_is_persisted_as_its_challenged_profile() {
+        // An edge challenge refuses the proof, not the session: the recorded profile
+        // starts working the moment the edge lets polls through.
+        let report = browser_mode_report(
+            "t3chat",
+            vec![AuthCandidate {
+                id: "firefox".into(),
+                title: "Firefox".into(),
+                subtitle: None,
+                state: "challenged".into(),
+                children: vec![AuthCandidate {
+                    id: "firefox/Default".into(),
+                    title: "Default".into(),
+                    subtitle: None,
+                    state: "challenged".into(),
+                    children: Vec::new(),
+                }],
+            }],
+        );
+
+        assert_eq!(
+            resolvable_auth_selection(
+                &report,
+                &AuthSelection {
+                    mode: "browser".into(),
+                    candidate: Some("firefox".into()),
+                },
+            ),
+            Some(AuthSelection {
+                mode: "browser".into(),
+                candidate: Some("firefox/Default".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn an_unanswered_browser_choice_is_still_refused() {
+        let report = browser_mode_report(
+            "t3chat",
+            vec![AuthCandidate {
+                id: "firefox".into(),
+                title: "Firefox".into(),
+                subtitle: None,
+                state: "unreachable".into(),
+                children: Vec::new(),
+            }],
+        );
+
+        assert_eq!(
+            resolvable_auth_selection(
+                &report,
+                &AuthSelection {
+                    mode: "browser".into(),
+                    candidate: Some("firefox".into()),
+                },
+            ),
+            None
         );
     }
 

--- a/scripts/test-package-upgrade.sh
+++ b/scripts/test-package-upgrade.sh
@@ -177,7 +177,7 @@ docker build --network host -q -t tidemark-build-ubuntu - >/dev/null <<'DOCKERFI
 FROM ubuntu:26.04
 ENV DEBIAN_FRONTEND=noninteractive PATH=/root/.cargo/bin:$PATH
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential curl ca-certificates pkg-config dpkg-dev \
+        build-essential cmake curl ca-certificates pkg-config dpkg-dev \
         libgtk-4-dev libadwaita-1-dev libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
@@ -196,7 +196,7 @@ DOCKERFILE
 docker build --network host -q -t tidemark-build-fedora - >/dev/null <<'DOCKERFILE'
 FROM fedora:44
 ENV PATH=/root/.cargo/bin:$PATH
-RUN dnf install -y gcc curl git pkgconf-pkg-config rpm-build \
+RUN dnf install -y gcc cmake curl git pkgconf-pkg-config rpm-build \
         gtk4-devel libadwaita-devel sqlite-devel && dnf clean all
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 RUN cargo install cargo-generate-rpm --locked


### PR DESCRIPTION
## What

Two independent fixes, in two commits:

**1. T3 Chat works.** `t3.chat` sits behind a Vercel challenge that gates on the client's **TLS and HTTP/2 fingerprints**, not on cookies, headers, or session state. Measured from this machine:

| Client | Headers | Result |
|---|---|---|
| curl (OpenSSL), `Tidemark/0.2.0` UA | minimal | 429 `x-vercel-mitigated: challenge` |
| curl, Firefox 154 UA | full browser set | 429 challenge |
| reqwest + rustls (our stack), Firefox UA | full browser set | 429 challenge |
| real Chromium, same IP, **no cookies** | its own | **200, live tRPC answer** |
| wreq 0.15 emulating Chrome137 | minimal | **200, live tRPC answer** |

No honest client passes, and a browser passes with no session at all — so cookie reading could never clear it. The provider now rides `wreq` (BoringSSL) emulating the **Chrome or Firefox fingerprint matching the chosen session's browser family**, carrying that session's own cookies. Transport-level impersonation only; **no webview, no JS engine, no embedded browser** — that is the prohibition the rewritten `CONTEXT.md` § Networking now states, with T3 Chat as the named exception (the old "never impersonate" line predates this and did not reflect the project's actual rule).

Supporting work:
- a Vercel challenge is a distinct state end-to-end (`AuthCandidateState::Challenged`, `Validation::Challenged`, dialog label "Browser check"), no longer misreported as a rate limit
- a challenged source stays selectable: the jar is proven, the edge refuses the client, the account recovers on its own when the challenge lifts
- a still-challenged fetch fails with the plain sentence "T3 Chat asked for a browser check" instead of the misleading `local provider state is unavailable:` prefix (`ProviderError::Challenged`)
- the emulating stack has its own error variant (`ProviderError::Emulated`), the same proxy/NO_PROXY/timeout policy as every other client, and the same raw-response log behaviour
- `wreq` is pinned `~0.15.3`: 0.16 raises the toolchain floor above this workspace's MSRV
- `cmake` added to build deps everywhere BoringSSL compiles (CI, release workflows, PKGBUILD, upgrade-test images)

**2. The in-use checkmark renders on every browser-selection provider.** The daemon persists the selection as a profile leaf (`chrome/Default`) while the dialog draws browser-level rows until more than one profile is proven, so the exact-id match never fired. The mark now goes to the longest row the claim is or lives under, and is re-applied when rows rebuild.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — **1313 passed, 0 failed**; `scripts/check-layering.sh` ok; `shellcheck` on the edited script ok
- t3chat loopback suite covers the emulating stack: headers + whole jar, challenge → `Challenged`, plain 429 → `RateLimited`, 401 → `Credential`, fingerprint-family choice
- Live-checked by the maintainer against the real daemon with a logged-in Chrome session: the card reads real quota