### PR TITLE
feat(packaging): add Nix flake and NixOS module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,12 @@ jobs:
         run: |
           shellcheck scripts/*.sh data/restart-user-daemon \
             data/packaging/deb/postinst data/packaging/rpm/post-install.sh
+
+  nix:
+    name: Nix flake
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build and exercise the flake in Docker
+        run: scripts/test-nix-flake.sh

--- a/.github/workflows/update-nix-flake.yml
+++ b/.github/workflows/update-nix-flake.yml
@@ -1,0 +1,41 @@
+name: Update Nix flake lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Update the pinned nixpkgs input
+        run: |
+          docker run --rm --network host --entrypoint sh \
+            -v "$GITHUB_WORKSPACE":/src \
+            -w /src \
+            nixos/nix:2.35.2 -eu -c '
+              export NIX_CONFIG="experimental-features = nix-command flakes"
+              nix flake update
+            '
+          sudo chown "$(id -u):$(id -g)" flake.lock
+
+      - name: Build and exercise the updated flake
+        run: scripts/test-nix-flake.sh
+
+      - name: Create or update the review PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/nix-flake-lock
+          delete-branch: true
+          commit-message: "chore(nix): update flake lock"
+          title: "chore(nix): update flake lock"
+          body: |
+            Weekly nixpkgs lock refresh, built and exercised by `scripts/test-nix-flake.sh`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -615,6 +615,11 @@ history that does not exist yet.
 so a build with no provider marks stays a supported configuration: a card without one is a
 state the interface already has.
 
+The repository-local flake exports the Nix package and `nixosModules.default`. Enabling the
+module registers only the D-Bus-activated user daemon; it does not autostart the GTK client.
+The scheduled workflow proposes `flake.lock` updates through a reviewed pull request. DEB,
+RPM, and the local `PKGBUILD` retain their distinct installation and upgrade behavior.
+
 The GTK 4.22 / libadwaita 1.9 floor above is GNOME 50, which became the default in exactly
 two places: **Fedora 44** and **Ubuntu 26.04 LTS**. So the `rpm` targets Fedora 44+ and the
 `deb` targets Ubuntu 26.04+. Nothing older qualifies — Debian's trixie is at GTK 4.18 — and

--- a/README.md
+++ b/README.md
@@ -48,6 +48,46 @@ Install from AUR with yay/paru
 yay -S tidemark-git
 ```
 
+### Nix
+
+Install Tidemark directly from this repository:
+
+```bash
+nix profile install github:zbndev/tidemark
+```
+
+Or run the window without installing it:
+
+```bash
+nix run github:zbndev/tidemark
+```
+
+For NixOS, add Tidemark as a flake input, import its module, and enable the service:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    tidemark.url = "github:zbndev/tidemark";
+  };
+
+  outputs = { nixpkgs, tidemark, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        tidemark.nixosModules.default
+        { services.tidemark.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+The module installs Tidemark and registers its D-Bus-activated user daemon. It does not
+start the GTK window at login. `nix run github:zbndev/tidemark#tidemarkd` is available for
+diagnostics, but normal use should let D-Bus activate the daemon when the window or another
+client asks for it.
+
 ## Getting started
 
 Open Tidemark. With nothing configured yet it says *Add a provider to start tracking your
@@ -134,46 +174,6 @@ cargo run -p tidemark
 provider itself — it only shows what the daemon publishes on D-Bus, which also makes the
 daemon usable from `busctl` or a Waybar module. See [`CONTEXT.md`](CONTEXT.md) for the
 architecture and the design record.
-
-## Nix
-
-Install Tidemark directly from this repository:
-
-```bash
-nix profile install github:zbndev/tidemark
-```
-
-Or run the window without installing it:
-
-```bash
-nix run github:zbndev/tidemark
-```
-
-For NixOS, add Tidemark as a flake input, import its module, and enable the service:
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    tidemark.url = "github:zbndev/tidemark";
-  };
-
-  outputs = { nixpkgs, tidemark, ... }: {
-    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        tidemark.nixosModules.default
-        { services.tidemark.enable = true; }
-      ];
-    };
-  };
-}
-```
-
-The module installs Tidemark and registers its D-Bus-activated user daemon. It does not
-start the GTK window at login. `nix run github:zbndev/tidemark#tidemarkd` is available for
-diagnostics, but normal use should let D-Bus activate the daemon when the window or another
-client asks for it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,46 @@ provider itself — it only shows what the daemon publishes on D-Bus, which also
 daemon usable from `busctl` or a Waybar module. See [`CONTEXT.md`](CONTEXT.md) for the
 architecture and the design record.
 
+## Nix
+
+Install Tidemark directly from this repository:
+
+```bash
+nix profile install github:zbndev/tidemark
+```
+
+Or run the window without installing it:
+
+```bash
+nix run github:zbndev/tidemark
+```
+
+For NixOS, add Tidemark as a flake input, import its module, and enable the service:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    tidemark.url = "github:zbndev/tidemark";
+  };
+
+  outputs = { nixpkgs, tidemark, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        tidemark.nixosModules.default
+        { services.tidemark.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+The module installs Tidemark and registers its D-Bus-activated user daemon. It does not
+start the GTK window at login. `nix run github:zbndev/tidemark#tidemarkd` is available for
+diagnostics, but normal use should let D-Bus activate the daemon when the window or another
+client asks for it.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE).

--- a/docs/superpowers/plans/2026-09-01-nixos-flake.md
+++ b/docs/superpowers/plans/2026-09-01-nixos-flake.md
@@ -1,0 +1,331 @@
+# Nix Flake and NixOS Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Tidemark reproducibly buildable and runnable through this repository's Nix flake, with a NixOS module that exposes only its D-Bus-activated user daemon.
+
+**Architecture:** `flake.nix` is a small public catalogue over `nix/package.nix` and `nix/module.nix`. The package builds and wraps the Rust/GTK workspace; the module registers package-owned D-Bus data and emits a non-autostart systemd user unit. Docker builds the actual flake and calls the daemon over a real session bus; CI executes that same script.
+
+**Tech Stack:** Nix flakes, nixpkgs `nixos-unstable`, `rustPlatform.buildRustPackage`, `wrapGAppsHook4`, NixOS `systemd.user.services` / `services.dbus.packages`, Docker, D-Bus.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-nixos-flake-design.md`
+
+## Global Constraints
+
+- Work stays on `feat/nixos-flake`; do not modify `main`, push, or open a PR without a new request.
+- Support native Linux `x86_64-linux` and `aarch64-linux` only. The GTK/systemd desktop model does not support macOS.
+- Preserve Rust 1.92, GTK 4.22, libadwaita 1.9, workspace layering, and all existing DEB/RPM/Arch packaging.
+- Nix package checks are packaging/runtime checks, not the Rust test suite: set `doCheck = false` and retain the native Rust gate.
+- `services.tidemark.enable` installs and makes available only the daemon. It must not autostart the GTK process or enable `tidemarkd.service` at login.
+- Nix and shell comments are English. New shell is POSIX `sh`, `set -eu`, and shellcheck-clean.
+- Use Docker `--network host` for Nix downloads on this host.
+- Do not use TDD. Add checks after implementing the package/module interfaces.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `flake.nix` | Inputs, packages, apps, dev shell, formatter, module export, evaluation check. |
+| `flake.lock` | Exact nixpkgs revision. |
+| `nix/package.nix` | Workspace build, GTK wrapper, installed immutable assets, D-Bus path rewrite. |
+| `nix/module.nix` | NixOS options, D-Bus registration, daemon-only user unit. |
+| `scripts/test-nix-flake.sh` | Docker acceptance test for flake output and D-Bus runtime. |
+| `.github/workflows/ci.yml` | Independent Nix Docker job. |
+| `README.md`, `CONTEXT.md` | User installation and normative packaging boundary. |
+
+## Task 1: Create the package and flake outputs
+
+**Files:**
+
+- Create: `nix/package.nix`
+- Create: `flake.nix`
+- Create: `flake.lock` through `nix flake lock`
+
+**Interfaces:**
+
+- Consumes: root `Cargo.lock`, release binaries, icons, desktop metadata, AppStream metadata, and the existing session D-Bus service file.
+- Produces: `packages.<system>.{default,tidemark}`, `apps.<system>.{default,tidemark,tidemarkd}`, `devShells.<system>.default`, and `formatter.<system>`.
+
+- [ ] **Step 1: Add `nix/package.nix`**
+
+Implement a `rustPlatform.buildRustPackage` derivation with this mandatory core:
+
+```nix
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tidemark";
+  version = "0.2.1";
+  src = ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+  cargoBuildFlags = [ "--workspace" "--bins" ];
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config cmake clang llvmPackages.libclang wrapGAppsHook4 makeWrapper
+  ];
+  buildInputs = [ gtk4 libadwaita sqlite dbus hicolor-icon-theme ];
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+})
+```
+
+The argument list includes every identifier above plus `lib`. In `postInstall`, use
+`install -Dm755` for both release binaries; install desktop and metainfo below `$out/share`;
+copy `data/icons/hicolor` to `$out/share/icons`; install the D-Bus service below
+`$out/share/dbus-1/services`; then run:
+
+```sh
+substituteInPlace "$out/share/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service" \
+  --replace-fail /usr/bin/tidemarkd "$out/bin/tidemarkd"
+```
+
+Set MIT metadata, homepage, `lib.platforms.linux`, and `mainProgram = "tidemark"`. Do not
+copy the GUI autostart, DEB/RPM upgrade helper, maintainer scripts, or their first-run file.
+
+- [ ] **Step 2: Add the flake catalogue**
+
+Create `flake.nix` with `inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"` and:
+
+```nix
+systems = [ "x86_64-linux" "aarch64-linux" ];
+forAllSystems = nixpkgs.lib.genAttrs systems;
+packageFor = system:
+  let pkgs = import nixpkgs { inherit system; };
+  in pkgs.callPackage ./nix/package.nix { };
+```
+
+For every system, expose both `default` and `tidemark` package attributes. Expose apps with
+programs `${package}/bin/tidemark` and `${package}/bin/tidemarkd`, with the window as default.
+Expose a shell containing Cargo, Rust, rustfmt, clippy, pkg-config, CMake, Clang, libclang,
+GTK4, libadwaita, SQLite, D-Bus, desktop-file-utils, AppStream, and shellcheck; set its
+`LIBCLANG_PATH`. Export `nixfmt-rfc-style` as the formatter. Do not introduce flake-utils.
+
+- [ ] **Step 3: Generate, format, and build**
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' flake lock
+nix --extra-experimental-features 'nix-command flakes' fmt
+nix --extra-experimental-features 'nix-command flakes' flake show
+nix --extra-experimental-features 'nix-command flakes' build --no-link .#tidemark
+```
+
+Expected: the generated lock file is committed, all Linux outputs appear, and the release
+workspace build completes. A missing native tool is fixed by adding its Nix dependency, never
+by changing Cargo or vendoring a system library.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add flake.nix flake.lock nix/package.nix
+git commit -m "feat(packaging): add a Nix flake package"
+```
+
+## Task 2: Add the NixOS daemon module
+
+**Files:**
+
+- Create: `nix/module.nix`
+- Modify: `flake.nix`
+
+**Interfaces:**
+
+- Consumes: `self.packages.${pkgs.stdenv.hostPlatform.system}.tidemark` and its D-Bus service file.
+- Produces: `nixosModules.default`, `services.tidemark.enable`, `services.tidemark.package`, and `checks.<system>.nixos-module`.
+
+- [ ] **Step 1: Implement `nix/module.nix`**
+
+Use this module contract so the default is this flake's package rather than an imaginary
+upstream `pkgs.tidemark`:
+
+```nix
+{ self }:
+{ config, lib, pkgs, ... }:
+
+let cfg = config.services.tidemark;
+in {
+  options.services.tidemark = {
+    enable = lib.mkEnableOption "the Tidemark user daemon";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.tidemark;
+      defaultText = lib.literalExpression "inputs.tidemark.packages.\${pkgs.system}.tidemark";
+      description = "The Tidemark package to run.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    systemd.user.services.tidemarkd = {
+      description = "Tidemark quota daemon";
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "io.github.zbndev.Tidemark.Daemon";
+        ExecStart = "${cfg.package}/bin/tidemarkd";
+        Restart = "on-failure";
+        RestartSec = 5;
+        NoNewPrivileges = true;
+      };
+    };
+  };
+}
+```
+
+Do not add GUI, `WantedBy = [ "default.target" ]`, filesystem sandboxing, user creation, or
+an update restart hook. `services.dbus.packages` is required for package-owned session D-Bus
+files to enter NixOS's service-directory configuration.
+
+- [ ] **Step 2: Export and evaluate the module**
+
+Add `nixosModules.default = import ./nix/module.nix { inherit self; };` to `flake.nix`. Add a
+`checks` output which evaluates `nixpkgs.lib.nixosSystem` with this module and
+`{ services.tidemark.enable = true; }`. Before returning
+`pkgs.runCommandNoCC "tidemark-nixos-module-evaluation" { } "touch $out"`, assert:
+
+```nix
+service.wantedBy == [ ]
+service.serviceConfig.Type == "dbus"
+service.serviceConfig.BusName == "io.github.zbndev.Tidemark.Daemon"
+service.serviceConfig.ExecStart == "${evaluated.config.services.tidemark.package}/bin/tidemarkd"
+```
+
+This is an evaluation-only NixOS integration check, not a VM.
+
+- [ ] **Step 3: Format, build the check, and commit**
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' fmt
+nix --extra-experimental-features 'nix-command flakes' flake check --no-build
+nix --extra-experimental-features 'nix-command flakes' build --no-link .#checks.x86_64-linux.nixos-module
+git add flake.nix nix/module.nix
+git commit -m "feat(nixos): expose the D-Bus activated daemon"
+```
+
+Expected: evaluation succeeds and it starts no daemon.
+
+## Task 3: Add Docker acceptance verification
+
+**Files:**
+
+- Create: `scripts/test-nix-flake.sh`
+
+**Interfaces:**
+
+- Consumes: flake outputs from Tasks 1–2 and Docker Engine.
+- Produces: the local and CI acceptance command.
+
+- [ ] **Step 1: Implement the script after the package and module**
+
+Create executable POSIX shell using `image=nixos/nix:2.35.2`, a `/src:ro` source mount, and
+`docker run --rm --network host --entrypoint sh`. Inside the container run:
+
+```sh
+export NIX_CONFIG='experimental-features = nix-command flakes'
+nix flake check --no-build
+output=$(nix build --no-link --print-out-paths .#tidemark)
+```
+
+Assert `$output` contains both binaries, the desktop file, metainfo, the 512px icon and the
+D-Bus service. Require exactly `Exec=$output/bin/tidemarkd` and
+`SystemdService=tidemarkd.service` in that service file.
+
+Start the daemon with `nix shell --inputs-from . nixpkgs#dbus nixpkgs#systemd -c sh -eu -c ...`
+and a nested `dbus-run-session`. The nested shell starts `$output/bin/tidemarkd`, traps exit to
+kill/wait for it, retries `busctl --user introspect` for at most 30 seconds, requires
+`GetStatus` in the introspection, then calls:
+
+```sh
+busctl --user call io.github.zbndev.Tidemark.Daemon \
+  /io/github/zbndev/Tidemark io.github.zbndev.Tidemark.Daemon1 GetStatus
+```
+
+The source mount remains read-only; the check must not leave host `target/`, `result`, lock,
+or root-owned files.
+
+- [ ] **Step 2: Run and lint the completed check**
+
+```sh
+shellcheck scripts/test-nix-flake.sh
+scripts/test-nix-flake.sh
+```
+
+Expected: it builds the flake, verifies staged assets and the store-qualified D-Bus path, then
+completes a real D-Bus status call. The initial download/build can take time.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add scripts/test-nix-flake.sh
+git commit -m "test(packaging): exercise the Nix flake in Docker"
+```
+
+## Task 4: CI, documentation, and final gate
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Modify: `README.md`
+- Modify: `CONTEXT.md`
+
+**Interfaces:**
+
+- Consumes: the public outputs, module, and Docker command from prior tasks.
+- Produces: continuous flake validation and copy-pasteable standalone Nix/NixOS setup.
+
+- [ ] **Step 1: Add a dedicated CI job**
+
+Append this sibling of `checks` in `.github/workflows/ci.yml`:
+
+```yaml
+  nix:
+    name: Nix flake
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build and exercise the flake in Docker
+        run: scripts/test-nix-flake.sh
+```
+
+Do not install Nix onto the runner or merge this work into the native Rust/toolkit job.
+
+- [ ] **Step 2: Add README instructions**
+
+After source-building, add `## Nix` with `nix profile install github:zbndev/tidemark` and
+`nix run github:zbndev/tidemark`. Include a NixOS flake-input fragment importing
+`tidemark.nixosModules.default` and setting `{ services.tidemark.enable = true; }`. State that
+`nix run github:zbndev/tidemark#tidemarkd` is diagnostic-only and the module does **not**
+autostart the GUI. Do not claim an external nixpkgs package or a separate Nix repository.
+
+- [ ] **Step 3: Amend the normative packaging record**
+
+Add one concise `CONTEXT.md` packaging paragraph: the repo-local flake exports the Nix package
+and `nixosModules.default`; enabling it registers only the D-Bus-activated user daemon. DEB,
+RPM, and local `PKGBUILD` retain their distinct installation and upgrade behavior.
+
+- [ ] **Step 4: Run the complete relevant gate and commit**
+
+```sh
+cargo fmt --check && \
+cargo clippy --workspace --all-targets -- -D warnings && \
+dbus-run-session -- cargo test --workspace && \
+scripts/check-layering.sh && \
+scripts/check-desktop-integration.sh && \
+scripts/test-restart-user-daemon.sh && \
+shellcheck scripts/*.sh data/restart-user-daemon \
+  data/packaging/deb/postinst data/packaging/rpm/post-install.sh && \
+scripts/test-nix-flake.sh
+
+git add .github/workflows/ci.yml README.md CONTEXT.md
+git commit -m "docs: describe Nix and NixOS installation"
+git status --short
+git log --oneline main..HEAD
+```
+
+Expected: native checks remain green and Docker proves the Nix build, staged assets, rewritten
+D-Bus executable, and daemon session-bus contract. Report Docker/Nix network or sandbox
+failures separately from a code regression; do not weaken the check to hide them. The final
+branch is clean and contains only the flake/module, Docker QA, CI hook, and documentation.

--- a/docs/superpowers/plans/2026-09-01-nixos-flake.md
+++ b/docs/superpowers/plans/2026-09-01-nixos-flake.md
@@ -33,6 +33,7 @@
 | `nix/module.nix` | NixOS options, D-Bus registration, daemon-only user unit. |
 | `scripts/test-nix-flake.sh` | Docker acceptance test for flake output and D-Bus runtime. |
 | `.github/workflows/ci.yml` | Independent Nix Docker job. |
+| `.github/workflows/update-nix-flake.yml` | Weekly, reviewable refresh of the pinned nixpkgs lock input. |
 | `README.md`, `CONTEXT.md` | User installation and normative packaging boundary. |
 
 ## Task 1: Create the package and flake outputs
@@ -262,18 +263,17 @@ git add scripts/test-nix-flake.sh
 git commit -m "test(packaging): exercise the Nix flake in Docker"
 ```
 
-## Task 4: CI, documentation, and final gate
+## Task 4: CI and reviewable weekly input refresh
 
 **Files:**
 
 - Modify: `.github/workflows/ci.yml`
-- Modify: `README.md`
-- Modify: `CONTEXT.md`
+- Create: `.github/workflows/update-nix-flake.yml`
 
 **Interfaces:**
 
-- Consumes: the public outputs, module, and Docker command from prior tasks.
-- Produces: continuous flake validation and copy-pasteable standalone Nix/NixOS setup.
+- Consumes: the Docker command and root `flake.lock` from prior tasks.
+- Produces: continuous flake validation and a weekly review PR for the lock file.
 
 - [ ] **Step 1: Add a dedicated CI job**
 
@@ -292,7 +292,74 @@ Append this sibling of `checks` in `.github/workflows/ci.yml`:
 
 Do not install Nix onto the runner or merge this work into the native Rust/toolkit job.
 
-- [ ] **Step 2: Add README instructions**
+- [ ] **Step 2: Add the weekly lock-refresh workflow**
+
+Create `.github/workflows/update-nix-flake.yml` with a manual trigger and
+`schedule: - cron: "0 0 * * 0"`, plus only `contents: write` and `pull-requests: write`
+permissions. Its `ubuntu-26.04` job must:
+
+```yaml
+- uses: actions/checkout@v5
+
+- name: Update the pinned nixpkgs input
+  run: |
+    docker run --rm --network host --entrypoint sh \
+      -v "$GITHUB_WORKSPACE":/src \
+      -w /src \
+      nixos/nix:2.35.2 -eu -c '
+        export NIX_CONFIG="experimental-features = nix-command flakes"
+        nix flake update
+      '
+    sudo chown "$(id -u):$(id -g)" flake.lock
+
+- name: Build and exercise the updated flake
+  run: scripts/test-nix-flake.sh
+
+- name: Create or update the review PR
+  uses: peter-evans/create-pull-request@v7
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    branch: chore/nix-flake-lock
+    delete-branch: true
+    commit-message: "chore(nix): update flake lock"
+    title: "chore(nix): update flake lock"
+    body: |
+      Weekly nixpkgs lock refresh, built and exercised by `scripts/test-nix-flake.sh`.
+```
+
+The update mount is writable only because `nix flake update` must replace `flake.lock`; the
+next Docker invocation is the read-only QA mount from Task 3. The `chown` is necessary because
+the Nix image writes as container root. Do not copy Caelestia's direct-to-main behavior: an
+update can alter Rust, GTK, libadwaita, systemd, and transitive provider build inputs, so this
+workflow must create a reviewable PR rather than merge or push to `main`.
+
+- [ ] **Step 3: Validate and commit the CI workflows**
+
+```sh
+shellcheck scripts/*.sh
+sed -n '/^  nix:/,$p' .github/workflows/ci.yml
+sed -n '1,220p' .github/workflows/update-nix-flake.yml
+scripts/test-nix-flake.sh
+git add .github/workflows/ci.yml .github/workflows/update-nix-flake.yml
+git commit -m "ci: refresh the Nix flake lock weekly"
+```
+
+Expected: the refresh job has one scheduled and one manual trigger, runs Docker QA before PR
+creation, and does not mutate `main`.
+
+## Task 5: Documentation and final gate
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `CONTEXT.md`
+
+**Interfaces:**
+
+- Consumes: the public outputs, module, Docker command, and weekly lock PR behavior from prior tasks.
+- Produces: copy-pasteable standalone Nix/NixOS setup and maintainer expectations for lock refreshes.
+
+- [ ] **Step 1: Add README instructions**
 
 After source-building, add `## Nix` with `nix profile install github:zbndev/tidemark` and
 `nix run github:zbndev/tidemark`. Include a NixOS flake-input fragment importing
@@ -300,13 +367,14 @@ After source-building, add `## Nix` with `nix profile install github:zbndev/tide
 `nix run github:zbndev/tidemark#tidemarkd` is diagnostic-only and the module does **not**
 autostart the GUI. Do not claim an external nixpkgs package or a separate Nix repository.
 
-- [ ] **Step 3: Amend the normative packaging record**
+- [ ] **Step 2: Amend the normative packaging record**
 
 Add one concise `CONTEXT.md` packaging paragraph: the repo-local flake exports the Nix package
-and `nixosModules.default`; enabling it registers only the D-Bus-activated user daemon. DEB,
-RPM, and local `PKGBUILD` retain their distinct installation and upgrade behavior.
+and `nixosModules.default`; enabling it registers only the D-Bus-activated user daemon. State
+that the scheduled workflow proposes `flake.lock` updates through a reviewed PR. DEB, RPM, and
+local `PKGBUILD` retain their distinct installation and upgrade behavior.
 
-- [ ] **Step 4: Run the complete relevant gate and commit**
+- [ ] **Step 3: Run the complete relevant gate and commit**
 
 ```sh
 cargo fmt --check && \
@@ -319,7 +387,7 @@ shellcheck scripts/*.sh data/restart-user-daemon \
   data/packaging/deb/postinst data/packaging/rpm/post-install.sh && \
 scripts/test-nix-flake.sh
 
-git add .github/workflows/ci.yml README.md CONTEXT.md
+git add README.md CONTEXT.md
 git commit -m "docs: describe Nix and NixOS installation"
 git status --short
 git log --oneline main..HEAD

--- a/docs/superpowers/specs/2026-09-01-nixos-flake-design.md
+++ b/docs/superpowers/specs/2026-09-01-nixos-flake-design.md
@@ -1,0 +1,96 @@
+# Nix Flake and NixOS Module Design
+
+- Status: approved for planning
+- Date: 2026-09-01
+
+## Purpose
+
+Tidemark is installable from this repository by Nix users, without a separate package
+repository or an upstream nixpkgs submission. The repository exports a reproducible Linux
+package, runnable apps, a development shell, and a NixOS module. The module makes the
+existing D-Bus-activated **user** daemon available; it does not start the GTK application
+at login.
+
+## Goals
+
+- Commit `flake.nix` and `flake.lock`, pinning nixpkgs at a revision that meets Rust 1.92,
+  GTK 4.22, and libadwaita 1.9.
+- Export native `x86_64-linux` and `aarch64-linux` package outputs, apps for `tidemark` and
+  `tidemarkd`, and a development shell with the documented C/C++ and toolkit dependencies.
+- Package both binaries, icons, desktop metadata, AppStream metadata, and the session
+  D-Bus activation file. Its `Exec` is rewritten to the immutable Nix-store daemon path.
+- Export `nixosModules.default`; `services.tidemark.enable = true` installs the package,
+  registers the D-Bus service, and defines `tidemarkd.service` in systemd user managers.
+- Check the flake in Docker: evaluate the module, build and inspect the package, then start
+  the daemon on a temporary session bus and call the public D-Bus interface.
+
+## Non-goals
+
+- A separate Nix repository, FlakeHub publication, or a nixpkgs pull request.
+- Altering DEB, RPM, or `PKGBUILD` packaging.
+- GUI autostart, a mutable `/etc/xdg/autostart` file, user selection, linger management, or
+  root-side restart logic.
+- Maintaining or manually configuring a NixOS VM. Docker is the acceptance environment.
+- Running the Rust suite inside `buildRustPackage`; native CI already owns that suite.
+
+## Package
+
+`nix/package.nix` uses `rustPlatform.buildRustPackage` with
+`cargoLock.lockFile = ../Cargo.lock`; the committed Cargo lock is therefore authoritative and
+ordinary dependency bumps do not require a hand-maintained vendor hash. The derivation builds
+the whole workspace in release mode, sets `doCheck = false`, uses `wrapGAppsHook4`, and has
+the required build inputs: pkg-config, CMake, Clang, libclang, GTK4, libadwaita, SQLite, D-Bus
+and the hicolor icon theme.
+
+It installs `tidemark`, `tidemarkd`, `share/applications`, `share/metainfo`,
+`share/icons/hicolor`, and `share/dbus-1/services`. It copies the existing D-Bus file then
+substitutes `/usr/bin/tidemarkd` with `$out/bin/tidemarkd`. It deliberately does not copy the
+DEB/RPM upgrade helper, first-run message, or GUI autostart entry.
+
+`flake.nix` pins `github:NixOS/nixpkgs/nixos-unstable` because older release channels may not
+meet the project API floor. It uses a local `genAttrs` helper rather than an extra
+flake-utils dependency and exposes `packages.<system>.{default,tidemark}`,
+`apps.<system>.{default,tidemark,tidemarkd}`, `devShells.<system>.default`, and a Nix
+formatter.
+
+## NixOS module
+
+`nix/module.nix` is parameterized by the flake's `self` and exposes an enable flag and an
+overrideable package option. The package option defaults to
+`self.packages.${pkgs.stdenv.hostPlatform.system}.tidemark`. When enabled, the module adds the
+selected package to `environment.systemPackages` and `services.dbus.packages`, then defines
+`systemd.user.services.tidemarkd` with `Type = "dbus"`, the published bus name, and
+`ExecStart = "${cfg.package}/bin/tidemarkd"`.
+
+`wantedBy = [ ]` is a contract: the unit exists for the D-Bus service file's
+`SystemdService=tidemarkd.service` lookup but is not a login service. The unit keeps the
+current `After`/`PartOf=graphical-session.target`, restart policy, `NoNewPrivileges`, and its
+intentional absence of a filesystem sandbox; several providers read and atomically write
+canonical third-party CLI credential files.
+
+Nix store paths are immutable, so the DEB/RPM root-side upgrade restart hook has no NixOS
+equivalent. A system rebuild changes the unit's `ExecStart` path but does not enumerate and
+restart every graphical user's daemon. An active user may restart their own service normally.
+
+## Verification and CI
+
+`scripts/test-nix-flake.sh` runs `nixos/nix:2.35.2` with a read-only repository mount and
+`--network host`. The upstream image disables Nix's own sandbox by default; Docker supplies
+the isolation for this acceptance test. The script enables `nix-command flakes`, runs
+`nix flake check --no-build`, builds `.#tidemark`, checks staged paths plus the rewritten
+D-Bus `Exec`, and starts the built daemon under `dbus-run-session`. `busctl --user` must
+introspect the documented object and successfully call `GetStatus`.
+
+An evaluation-only flake check evaluates `nixosModules.default` with
+`services.tidemark.enable = true`, asserting the unit's empty `wantedBy`, type, bus name, and
+package-qualified executable. This tests module integration without booting or configuring
+NixOS. The Docker script becomes a separate CI job on `ubuntu-26.04` and remains the local
+maintainer command.
+
+## Documentation
+
+The README presents `nix profile install github:zbndev/tidemark`, `nix run`, and a NixOS
+flake-input example importing `tidemark.nixosModules.default` then enabling the daemon. It
+states explicitly that the module does not autostart the GUI. `CONTEXT.md` records Nix as an
+additional source-install route, while preserving DEB/RPM release assets and the local Arch
+`PKGBUILD` as their separate formats.

--- a/docs/superpowers/specs/2026-09-01-nixos-flake-design.md
+++ b/docs/superpowers/specs/2026-09-01-nixos-flake-design.md
@@ -87,6 +87,14 @@ package-qualified executable. This tests module integration without booting or c
 NixOS. The Docker script becomes a separate CI job on `ubuntu-26.04` and remains the local
 maintainer command.
 
+A second GitHub Actions workflow runs weekly at Sunday 00:00 UTC and on manual dispatch. It
+uses the same pinned Nix Docker image, updates the sole `nixpkgs` input with `nix flake update`,
+restores ownership of the changed lock file to the runner, then runs
+`scripts/test-nix-flake.sh`. On success it creates or updates a PR from
+`chore/nix-flake-lock`; it never commits an upstream compiler, toolkit, or NixOS change directly
+to `main`. The workflow has narrowly declared `contents: write` and `pull-requests: write`
+permissions. A merge still triggers ordinary CI on `main`.
+
 ## Documentation
 
 The README presents `nix profile install github:zbndev/tidemark`, `nix run`, and a NixOS

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
-    { nixpkgs, ... }:
+    { self, nixpkgs, ... }:
     let
       systems = [
         "x86_64-linux"
@@ -48,6 +48,31 @@
             type = "app";
             program = "${package}/bin/tidemarkd";
           };
+        }
+      );
+
+      nixosModules.default = import ./nix/module.nix { inherit self; };
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          evaluated = nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              self.nixosModules.default
+              { services.tidemark.enable = true; }
+            ];
+          };
+          service = evaluated.config.systemd.user.services.tidemarkd;
+        in
+        assert service.wantedBy == [ ];
+        assert service.serviceConfig.Type == "dbus";
+        assert service.serviceConfig.BusName == "io.github.zbndev.Tidemark.Daemon";
+        assert
+          service.serviceConfig.ExecStart == "${evaluated.config.services.tidemark.package}/bin/tidemarkd";
+        {
+          nixos-module = pkgs.runCommandNoCC "tidemark-nixos-module-evaluation" { } "touch $out";
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Tidemark desktop quota tracker";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      packageFor =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.callPackage ./nix/package.nix { };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          package = packageFor system;
+        in
+        {
+          default = package;
+          tidemark = package;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
+          package = packageFor system;
+        in
+        {
+          default = {
+            type = "app";
+            program = "${package}/bin/tidemark";
+          };
+          tidemark = {
+            type = "app";
+            program = "${package}/bin/tidemark";
+          };
+          tidemarkd = {
+            type = "app";
+            program = "${package}/bin/tidemarkd";
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.cargo
+              pkgs.rustc
+              pkgs.rustfmt
+              pkgs.clippy
+              pkgs.pkg-config
+              pkgs.cmake
+              pkgs.clang
+              pkgs.llvmPackages.libclang
+              pkgs.gtk4
+              pkgs.libadwaita
+              pkgs.sqlite
+              pkgs.dbus
+              pkgs.desktop-file-utils
+              pkgs.appstream
+              pkgs.shellcheck
+            ];
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          };
+        }
+      );
+
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.nixfmt-rfc-style
+      );
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,41 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.tidemark;
+in
+{
+  options.services.tidemark = {
+    enable = lib.mkEnableOption "the Tidemark user daemon";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.tidemark;
+      defaultText = lib.literalExpression "inputs.tidemark.packages.\${pkgs.system}.tidemark";
+      description = "The Tidemark package to run.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    systemd.user.services.tidemarkd = {
+      description = "Tidemark quota daemon";
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "io.github.zbndev.Tidemark.Daemon";
+        ExecStart = "${cfg.package}/bin/tidemarkd";
+        Restart = "on-failure";
+        RestartSec = 5;
+        NoNewPrivileges = true;
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -45,9 +45,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm755 target/*/release/tidemarkd -t "$out/bin"
     install -Dm644 data/applications/io.github.zbndev.Tidemark.desktop -t "$out/share/applications"
     install -Dm644 data/metainfo/io.github.zbndev.Tidemark.metainfo.xml -t "$out/share/metainfo"
-    cp -r data/icons/hicolor "$out/share/icons"
+    install -d "$out/share/icons"
+    cp -r data/icons/hicolor "$out/share/icons/"
     install -Dm644 data/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service -t "$out/share/dbus-1/services"
+    install -Dm644 data/tidemarkd.service -t "$out/lib/systemd/user"
     substituteInPlace "$out/share/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service" \
+      --replace-fail /usr/bin/tidemarkd "$out/bin/tidemarkd"
+    substituteInPlace "$out/lib/systemd/user/tidemarkd.service" \
       --replace-fail /usr/bin/tidemarkd "$out/bin/tidemarkd"
   '';
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,12 +14,18 @@
   dbus,
   hicolor-icon-theme,
 }:
+let
+  manifest = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tidemark";
-  version = "0.2.1";
+  version = manifest.workspace.package.version;
   src = ../.;
   cargoLock.lockFile = ../Cargo.lock;
-  cargoBuildFlags = [ "--workspace" "--bins" ];
+  cargoBuildFlags = [
+    "--workspace"
+    "--bins"
+  ];
   doCheck = false;
   dontCargoInstall = true;
 
@@ -37,7 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapGAppsHook4
     makeWrapper
   ];
-  buildInputs = [ gtk4 libadwaita sqlite dbus hicolor-icon-theme ];
+  buildInputs = [
+    gtk4
+    libadwaita
+    sqlite
+    dbus
+    hicolor-icon-theme
+  ];
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   postInstall = ''

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  git,
+  clang,
+  llvmPackages,
+  wrapGAppsHook4,
+  makeWrapper,
+  gtk4,
+  libadwaita,
+  sqlite,
+  dbus,
+  hicolor-icon-theme,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tidemark";
+  version = "0.2.1";
+  src = ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+  cargoBuildFlags = [ "--workspace" "--bins" ];
+  doCheck = false;
+  dontCargoInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    git
+    clang
+    llvmPackages.libclang
+    wrapGAppsHook4
+    makeWrapper
+  ];
+  buildInputs = [ gtk4 libadwaita sqlite dbus hicolor-icon-theme ];
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  postInstall = ''
+    install -Dm755 target/*/release/tidemark -t "$out/bin"
+    install -Dm755 target/*/release/tidemarkd -t "$out/bin"
+    install -Dm644 data/applications/io.github.zbndev.Tidemark.desktop -t "$out/share/applications"
+    install -Dm644 data/metainfo/io.github.zbndev.Tidemark.metainfo.xml -t "$out/share/metainfo"
+    cp -r data/icons/hicolor "$out/share/icons"
+    install -Dm644 data/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service -t "$out/share/dbus-1/services"
+    substituteInPlace "$out/share/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service" \
+      --replace-fail /usr/bin/tidemarkd "$out/bin/tidemarkd"
+  '';
+
+  meta = {
+    description = "Track AI provider quota limits";
+    homepage = "https://github.com/zbndev/tidemark";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "tidemark";
+  };
+})

--- a/scripts/test-nix-flake.sh
+++ b/scripts/test-nix-flake.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+image=nixos/nix:2.35.2
+
+docker run --rm --network host --entrypoint sh \
+    -v "$project_root:/src:ro" \
+    -w /src \
+    "$image" -eu -s <<'CONTAINER'
+export NIX_CONFIG='experimental-features = nix-command flakes'
+
+nix flake check --no-build
+output=$(nix build --no-link --print-out-paths .#tidemark)
+
+test -x "$output/bin/tidemark"
+test -x "$output/bin/tidemarkd"
+test -f "$output/share/applications/io.github.zbndev.Tidemark.desktop"
+test -f "$output/share/metainfo/io.github.zbndev.Tidemark.metainfo.xml"
+test -f "$output/share/icons/hicolor/512x512/apps/io.github.zbndev.Tidemark.png"
+
+service="$output/share/dbus-1/services/io.github.zbndev.Tidemark.Daemon.service"
+test -f "$service"
+grep -Fx "Exec=$output/bin/tidemarkd" "$service"
+grep -Fx 'SystemdService=tidemarkd.service' "$service"
+
+export TIDEMARK_OUTPUT="$output"
+nix shell --inputs-from . nixpkgs#dbus nixpkgs#systemd -c sh -eu -s <<'DAEMON'
+dbus-run-session -- sh -eu -s <<'BUS'
+daemon=
+
+cleanup() {
+    if [ -n "$daemon" ]; then
+        kill "$daemon" 2>/dev/null || true
+        wait "$daemon" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT HUP INT TERM
+"$TIDEMARK_OUTPUT/bin/tidemarkd" &
+daemon=$!
+
+deadline=$(( $(date +%s) + 30 ))
+while :; do
+    if introspection=$(busctl --user introspect io.github.zbndev.Tidemark.Daemon \
+        /io/github/zbndev/Tidemark 2>/dev/null) \
+        && printf '%s\n' "$introspection" | grep -Fq GetStatus; then
+        break
+    fi
+
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        printf '%s\n' 'Timed out waiting for Tidemark D-Bus service.' >&2
+        exit 1
+    fi
+
+    sleep 1
+done
+
+busctl --user call io.github.zbndev.Tidemark.Daemon \
+    /io/github/zbndev/Tidemark io.github.zbndev.Tidemark.Daemon1 GetStatus
+BUS
+DAEMON
+CONTAINER

--- a/scripts/test-nix-flake.sh
+++ b/scripts/test-nix-flake.sh
@@ -3,9 +3,25 @@ set -eu
 
 project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 image=nixos/nix:2.35.2
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/tidemark-nix-flake.XXXXXX")
+source_root=$test_root/source
+state_root=$test_root/state
 
-docker run --rm --network host --entrypoint sh \
-    -v "$project_root:/src:ro" \
+cleanup() {
+    rm -rf -- "$test_root"
+}
+
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$source_root" "$state_root"
+(
+    cd "$project_root"
+    git ls-files --cached --others --exclude-standard -z \
+        | tar --null -T - -cf -
+) | tar -xf - -C "$source_root"
+
+docker run -i --rm --network host --entrypoint sh \
+    -v "$source_root:/src:ro" \
+    -v "$state_root:/test-state" \
     -w /src \
     "$image" -eu -s <<'CONTAINER'
 export NIX_CONFIG='experimental-features = nix-command flakes'
@@ -26,6 +42,17 @@ grep -Fx 'SystemdService=tidemarkd.service' "$service"
 
 export TIDEMARK_OUTPUT="$output"
 nix shell --inputs-from . nixpkgs#dbus nixpkgs#systemd -c sh -eu -s <<'DAEMON'
+dbus_daemon=$(command -v dbus-daemon)
+dbus_prefix=${dbus_daemon%/bin/dbus-daemon}
+mkdir -p /etc/dbus-1
+# The nixpkgs file delegates to /etc/dbus-1/session.conf, which is also where
+# dbus-run-session looks in this minimal image. Copy it without that self-include.
+while IFS= read -r line; do
+    if [ "$line" != '  <include ignore_missing="yes">/etc/dbus-1/session.conf</include>' ]; then
+        printf '%s\n' "$line"
+    fi
+done < "$dbus_prefix/share/dbus-1/session.conf" > /etc/dbus-1/session.conf
+
 dbus-run-session -- sh -eu -s <<'BUS'
 daemon=
 
@@ -60,4 +87,8 @@ busctl --user call io.github.zbndev.Tidemark.Daemon \
     /io/github/zbndev/Tidemark io.github.zbndev.Tidemark.Daemon1 GetStatus
 BUS
 DAEMON
+
+touch /test-state/completed
 CONTAINER
+
+test -f "$state_root/completed"


### PR DESCRIPTION
## Summary

- add a repository-local Nix flake with Linux packages, apps, a development shell, formatter, and a NixOS module
- package the GTK application and D-Bus-activated daemon with immutable service paths, while keeping the GUI out of login autostart
- exercise the flake, installed assets, module evaluation, and live daemon D-Bus contract in Docker
- add CI coverage, a weekly review PR for `flake.lock`, and Nix/NixOS installation documentation

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/check-layering.sh`
- `scripts/check-desktop-integration.sh`
- `scripts/test-restart-user-daemon.sh`
- `shellcheck scripts/*.sh data/restart-user-daemon data/packaging/deb/postinst data/packaging/rpm/post-install.sh`
- `scripts/test-nix-flake.sh`
