### PR TITLE
feat: multi-account providers

### DIFF
--- a/crates/tidemark-core/examples/probe.rs
+++ b/crates/tidemark-core/examples/probe.rs
@@ -14,7 +14,7 @@
 use std::io::Read;
 use tidemark_core::providers::keyed::Options;
 use tidemark_core::providers::{Credential, Provider, keyed, zai};
-use tidemark_types::{Snapshot, Timestamp, Window};
+use tidemark_types::{AccountId, Snapshot, Timestamp, Window};
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
@@ -43,7 +43,12 @@ async fn main() -> std::process::ExitCode {
     let options: Options = [(zai::REGION.to_owned(), region.as_value().to_owned())]
         .into_iter()
         .collect();
-    let provider = match keyed::Keyed::new(&zai::SPEC, Credential::new(key.trim()), &options) {
+    let provider = match keyed::Keyed::new(
+        AccountId::default(),
+        &zai::SPEC,
+        Credential::new(key.trim()),
+        &options,
+    ) {
         Ok(provider) => provider,
         Err(e) => {
             eprintln!("{e}");

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -28,6 +28,8 @@ use crate::paths;
 /// Table every provider's own settings live under: `[provider.zai]`.
 const PROVIDER_TABLE: &str = "provider";
 const PROVIDERS_KEY: &str = "providers";
+/// The account ids configured for a provider.
+const ACCOUNTS_KEY: &str = "accounts";
 /// The shared storage keys used by browser-cookie authentication providers.
 const AUTH_SOURCE_KEY: &str = "auth-source";
 const AUTH_BROWSER_KEY: &str = "auth-browser";
@@ -104,6 +106,16 @@ pub enum ConfigError {
         /// The file.
         path: PathBuf,
         /// Why the provider list is invalid.
+        reason: String,
+    },
+    /// A provider's account list is not an array of strings.
+    #[error("{path}: [{PROVIDER_TABLE}.{provider}] {ACCOUNTS_KEY} {reason}")]
+    InvalidAccounts {
+        /// The file.
+        path: PathBuf,
+        /// Whose list it is.
+        provider: String,
+        /// Why the account list is invalid.
         reason: String,
     },
     /// A provider's notification opt-in list is not an array of window keys.
@@ -480,6 +492,38 @@ impl Config {
             }
         }
         Ok(providers)
+    }
+
+    /// Returns a provider's configured accounts in file order.
+    ///
+    /// A provider without an account list uses the single default account. A present account
+    /// list with the wrong shape is refused rather than silently choosing a different account.
+    pub fn accounts(&self, provider: &str) -> Result<Vec<String>, ConfigError> {
+        let Some(item) = self
+            .document
+            .get(PROVIDER_TABLE)
+            .and_then(|table| table.get(provider))
+            .and_then(|table| table.get(ACCOUNTS_KEY))
+        else {
+            return Ok(vec!["default".to_owned()]);
+        };
+        let array = item
+            .as_array()
+            .ok_or_else(|| ConfigError::InvalidAccounts {
+                path: self.path.clone(),
+                provider: provider.to_owned(),
+                reason: "must be an array of strings".to_owned(),
+            })?;
+        let mut accounts = Vec::new();
+        for entry in array.iter() {
+            let account = entry.as_str().ok_or_else(|| ConfigError::InvalidAccounts {
+                path: self.path.clone(),
+                provider: provider.to_owned(),
+                reason: "every accounts entry must be a string".to_owned(),
+            })?;
+            accounts.push(account.to_owned());
+        }
+        Ok(accounts)
     }
 
     /// Adds a provider to the configured set and normalizes any existing duplicates.
@@ -1037,6 +1081,42 @@ mod tests {
     fn a_first_run_has_no_configured_providers() {
         let config = Config::at(scratch("providers-absent")).expect("missing is valid");
         assert_eq!(config.providers().expect("readable"), Vec::<String>::new());
+    }
+    #[test]
+    fn a_provider_without_an_accounts_key_has_its_default_account() {
+        let path = scratch("accounts-absent");
+        std::fs::write(&path, "providers = [\"zai\"]\n").expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert_eq!(config.accounts("zai").unwrap(), vec!["default".to_string()]);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn accounts_come_back_in_file_order() {
+        let path = scratch("accounts-order");
+        std::fs::write(
+            &path,
+            "[provider.claude]\naccounts = [\"default\", \"work\"]\n",
+        )
+        .expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert_eq!(
+            config.accounts("claude").unwrap(),
+            vec!["default".to_string(), "work".to_string()]
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn a_non_array_accounts_key_is_refused() {
+        let path = scratch("accounts-invalid");
+        std::fs::write(&path, "[provider.zai]\naccounts = \"work\"\n").expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert!(matches!(
+            config.accounts("zai"),
+            Err(ConfigError::InvalidAccounts { .. })
+        ));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 
     #[test]

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -664,6 +664,36 @@ impl Config {
         self.write()
     }
 
+    /// Sets one provider's ordered account list and writes the file.
+    pub fn set_accounts(&mut self, provider: &str, accounts: &[String]) -> Result<(), ConfigError> {
+        self.normalize_providers(None)?;
+        let providers = self
+            .document
+            .entry(PROVIDER_TABLE)
+            .or_insert_with(|| Item::Table(implicit_table()));
+        let providers = providers
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: PROVIDER_TABLE.to_owned(),
+            })?;
+        let table = providers
+            .entry(provider)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let table = table
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: format!("{PROVIDER_TABLE}.{provider}"),
+            })?;
+        let mut array = Array::new();
+        for account in accounts {
+            array.push(Value::from(account.as_str()));
+        }
+        table.insert(ACCOUNTS_KEY, Item::Value(array.into()));
+        self.write()
+    }
+
     /// Stores one daemon-validated browser-cookie source in one staged config write.
     ///
     /// Browser candidates travel over D-Bus as opaque `browser` or `browser/profile` paths.
@@ -1103,6 +1133,27 @@ mod tests {
         assert_eq!(
             config.accounts("claude").unwrap(),
             vec!["default".to_string(), "work".to_string()]
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn an_accounts_list_can_be_written_and_read_back_in_order() {
+        let path = scratch("accounts-write");
+        let _ = std::fs::remove_file(&path);
+        let mut config = Config::at(path.clone()).expect("empty");
+        let accounts = ["default".to_owned(), "work".to_owned()];
+
+        config
+            .set_accounts("zai", &accounts)
+            .expect("accounts written");
+
+        let reread = Config::at(path.clone()).expect("parses");
+        assert_eq!(reread.accounts("zai").expect("accounts readable"), accounts);
+        let text = std::fs::read_to_string(&path).expect("written");
+        assert!(
+            text.contains("[provider.zai]\naccounts = [\"default\", \"work\"]"),
+            "{text}"
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -629,6 +629,26 @@ impl Config {
         }
         Ok(configured)
     }
+    /// Removes one account from a provider's ordered account list.
+    ///
+    /// Removing the default promotes the first survivor to the default id so that the
+    /// configured list always has one canonical first account. Removing the final account
+    /// removes the provider and its settings through [`Self::remove_provider`].
+    pub fn remove_account(&mut self, provider: &str, account: &str) -> Result<bool, ConfigError> {
+        let mut accounts = self.accounts(provider)?;
+        let Some(index) = accounts.iter().position(|configured| configured == account) else {
+            return Ok(false);
+        };
+        accounts.remove(index);
+        if accounts.is_empty() {
+            return self.remove_provider(provider);
+        }
+        if account == "default" {
+            accounts[0] = "default".to_owned();
+        }
+        self.set_accounts(provider, &accounts)?;
+        Ok(true)
+    }
 
     /// Sets one provider setting and writes the file.
     ///
@@ -1429,6 +1449,56 @@ mod tests {
         assert!(text.contains("# owned by the user"));
         assert!(text.contains("[unrelated]"));
         assert!(!text.contains("[provider.claude]"));
+        let _ = std::fs::remove_file(path);
+    }
+    #[test]
+    fn account_removals_preserve_default_promote_survivors_and_drop_provider() {
+        let path = scratch("account-mutations");
+        std::fs::write(
+            &path,
+            "providers = [\"claude\"]\n\
+             [provider.claude]\n\
+             accounts = [\"default\", \"work\"]\n",
+        )
+        .expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+
+        assert!(config.remove_account("claude", "work").expect("removed"));
+        assert_eq!(
+            Config::at(path.clone())
+                .expect("reloaded")
+                .accounts("claude")
+                .expect("accounts read"),
+            ["default"]
+        );
+
+        config
+            .set_accounts("claude", &["default".into(), "work".into()])
+            .expect("second account added");
+        assert!(
+            config
+                .remove_account("claude", "default")
+                .expect("promoted")
+        );
+        assert_eq!(
+            Config::at(path.clone())
+                .expect("reloaded")
+                .accounts("claude")
+                .expect("accounts read"),
+            ["default"]
+        );
+
+        assert!(config.remove_account("claude", "default").expect("dropped"));
+        let reread = Config::at(path.clone()).expect("reloaded");
+        assert!(reread.providers().expect("providers read").is_empty());
+        assert_eq!(
+            reread
+                .accounts("claude")
+                .expect("missing provider defaults"),
+            ["default"]
+        );
+        let text = std::fs::read_to_string(path.clone()).expect("read back");
+        assert!(!text.contains("[provider.claude]"), "{text}");
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/tidemark-core/src/providers/antigravity/direct.rs
+++ b/crates/tidemark-core/src/providers/antigravity/direct.rs
@@ -19,11 +19,30 @@ const DAY_SECONDS: u64 = 86_400;
 const WEEK_SECONDS: u64 = 7 * DAY_SECONDS;
 
 /// Fetches direct quota using the OAuth access token and the discovered project, if any.
+/// Fetches direct quota using the default account identity.
 pub async fn fetch(
     client: &reqwest::Client,
     endpoint: &str,
     access_token: &str,
     project_id: Option<&str>,
+) -> Result<Snapshot, ProviderError> {
+    fetch_for_account(
+        client,
+        endpoint,
+        access_token,
+        project_id,
+        &AccountId::default(),
+    )
+    .await
+}
+
+/// Fetches direct quota using the OAuth access token and the discovered project, if any.
+pub async fn fetch_for_account(
+    client: &reqwest::Client,
+    endpoint: &str,
+    access_token: &str,
+    project_id: Option<&str>,
+    account: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let url = format!(
         "{}/v1internal:fetchAvailableModels",
@@ -53,11 +72,19 @@ pub async fn fetch(
         response,
     )
     .await?;
-    parse(&body, Timestamp::now())
+    parse_for_account(&body, Timestamp::now(), account)
 }
 
 /// Turns a direct `fetchAvailableModels` response into one window per shared counter.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let response: AvailableModels = serde_json::from_str(body).map_err(|error| {
         ProviderError::malformed(format!("not a direct Antigravity quota response: {error}"))
     })?;
@@ -144,7 +171,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: Vec::new(),

--- a/crates/tidemark-core/src/providers/antigravity/mod.rs
+++ b/crates/tidemark-core/src/providers/antigravity/mod.rs
@@ -80,7 +80,7 @@ const REFRESH_MARGIN_MS: i64 = 5 * 60 * 1_000;
 
 trait LocalQuota: std::fmt::Debug + Send + Sync {
     fn available(&self) -> bool;
-    fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>>;
+    fn fetch(&self, account: &AccountId) -> BoxFuture<'_, Result<Snapshot, ProviderError>>;
 }
 
 #[derive(Debug)]
@@ -99,11 +99,12 @@ impl LocalQuota for AgyQuota {
         agy::is_available()
     }
 
-    fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+    fn fetch(&self, account: &AccountId) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+        let account = account.clone();
         Box::pin(async move {
             let ready = self.agy.ready().await?;
             let quota = self.agy.rpc(ready.port, agy::QUOTA_SUMMARY_PATH).await?;
-            parse(&quota, &ready.status_body, Timestamp::now())
+            parse_for_account(&quota, &ready.status_body, Timestamp::now(), &account)
         })
     }
 }
@@ -183,7 +184,7 @@ impl Antigravity {
     /// running" is not news to a user whose account also has a login.
     async fn fetch_auto(&self) -> Result<Snapshot, ProviderError> {
         let local = if self.local.available() {
-            match self.local.fetch().await {
+            match self.local.fetch(&self.account).await {
                 Ok(snapshot) => return Ok(snapshot),
                 Err(error) => Some(error),
             }
@@ -199,7 +200,7 @@ impl Antigravity {
     /// The local server, or the reason there is nothing to read.
     async fn fetch_local(&self) -> Result<Snapshot, ProviderError> {
         if self.local.available() {
-            self.local.fetch().await
+            self.local.fetch(&self.account).await
         } else {
             Err(ProviderError::NoCredential)
         }
@@ -341,11 +342,12 @@ impl Antigravity {
         &self,
         credentials: &OwnedCredentials,
     ) -> Result<Snapshot, ProviderError> {
-        direct::fetch(
+        direct::fetch_for_account(
             &self.client,
             &self.direct_endpoint,
             credentials.access_token.expose(),
             credentials.project_id.as_deref(),
+            &self.account,
         )
         .await
     }
@@ -470,6 +472,15 @@ pub fn logged_in(body: &str) -> Result<(), String> {
 /// inverted fraction, the two pools of one length, the cadence that is sometimes declared
 /// and sometimes only implied by an id — is reachable from a test without a running server.
 pub fn parse(quota: &str, status: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(quota, status, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    quota: &str,
+    status: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: QuotaEnvelope = serde_json::from_str(quota)
         .map_err(|error| format!("not a quota summary: {error}"))
         .map_err(ProviderError::malformed)?;
@@ -517,7 +528,7 @@ pub fn parse(quota: &str, status: &str, captured_at: Timestamp) -> Result<Snapsh
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: details(status, models),
@@ -1024,7 +1035,7 @@ mod tests {
             self.available
         }
 
-        fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+        fn fetch(&self, _account: &AccountId) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let result = self
                 .result

--- a/crates/tidemark-core/src/providers/antigravity/mod.rs
+++ b/crates/tidemark-core/src/providers/antigravity/mod.rs
@@ -436,6 +436,9 @@ impl Provider for Antigravity {
     fn account(&self) -> AccountId {
         self.account.clone()
     }
+    fn source(&self) -> Option<Source> {
+        Some(self.source)
+    }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
         Box::pin(self.fetch_inner())

--- a/crates/tidemark-core/src/providers/antigravity/mod.rs
+++ b/crates/tidemark-core/src/providers/antigravity/mod.rs
@@ -123,11 +123,17 @@ pub struct Antigravity {
     token_endpoint: String,
     local: Box<dyn LocalQuota>,
     source: Source,
+    /// The configured account whose Tidemark login this client reads.
+    account: AccountId,
 }
 
 impl Antigravity {
     /// Builds the provider. The local source starts no process until it is selected.
-    pub fn new(own: Option<Arc<dyn Secrets>>, source: Source) -> Result<Self, ProviderError> {
+    pub fn new(
+        account: AccountId,
+        own: Option<Arc<dyn Secrets>>,
+        source: Source,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
             client: http::client()?,
             own,
@@ -135,6 +141,7 @@ impl Antigravity {
             token_endpoint: oauth::TOKEN_URL.to_owned(),
             local: Box::new(AgyQuota::new()?),
             source,
+            account,
         })
     }
 
@@ -153,6 +160,7 @@ impl Antigravity {
             token_endpoint,
             local,
             source,
+            account: AccountId::default(),
         })
     }
 
@@ -205,7 +213,7 @@ impl Antigravity {
             .get(
                 secrets::Kind::Token,
                 &ProviderId::new(PROVIDER_ID),
-                &AccountId::default(),
+                &self.account,
             )
             .await
             .map_err(ProviderError::from_secret_error)?;
@@ -298,7 +306,7 @@ impl Antigravity {
             .compare_and_set(
                 secrets::Kind::Token,
                 &ProviderId::new(PROVIDER_ID),
-                &AccountId::default(),
+                &self.account,
                 &credentials.source,
                 &replacement,
             )
@@ -315,7 +323,7 @@ impl Antigravity {
             .get(
                 secrets::Kind::Token,
                 &ProviderId::new(PROVIDER_ID),
-                &AccountId::default(),
+                &self.account,
             )
             .await
             .map_err(ProviderError::from_secret_error)?
@@ -426,7 +434,7 @@ impl Provider for Antigravity {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/claude.rs
+++ b/crates/tidemark-core/src/providers/claude.rs
@@ -136,6 +136,8 @@ pub struct Claude {
     own: Option<Arc<dyn Secrets>>,
     /// Which of the two credentials this account reads — see the module docs.
     source: Source,
+    /// The configured account whose Tidemark login this client reads.
+    account: AccountId,
     usage_url: String,
     refresh_url: String,
     profile_url: String,
@@ -155,7 +157,11 @@ pub fn cli_credentials_path() -> Option<PathBuf> {
 
 impl Claude {
     /// Builds the canonical Claude Code account at `~/.claude/.credentials.json`.
-    pub fn new(own: Option<Arc<dyn Secrets>>, source: Source) -> Result<Self, ProviderError> {
+    pub fn new(
+        account: AccountId,
+        own: Option<Arc<dyn Secrets>>,
+        source: Source,
+    ) -> Result<Self, ProviderError> {
         let path = cli_credentials_path().ok_or_else(|| {
             ProviderError::Local("HOME does not name an absolute directory".into())
         })?;
@@ -168,6 +174,7 @@ impl Claude {
         )?;
         claude.own = own;
         claude.source = source;
+        claude.account = account;
         Ok(claude)
     }
 
@@ -182,6 +189,7 @@ impl Claude {
             credentials,
             own: None,
             source: Source::Auto,
+            account: AccountId::default(),
             usage_url,
             refresh_url,
             profile_url,
@@ -291,7 +299,7 @@ impl Claude {
                     .get(
                         secrets::Kind::Token,
                         &ProviderId::new(PROVIDER_ID),
-                        &AccountId::default(),
+                        &self.account,
                     )
                     .await
                     .map_err(ProviderError::from_secret_error)?;
@@ -303,9 +311,8 @@ impl Claude {
             Source::Auto => {
                 if let Some(own) = &self.own {
                     let provider = ProviderId::new(PROVIDER_ID);
-                    let account = AccountId::default();
                     let stored = own
-                        .get(secrets::Kind::Token, &provider, &account)
+                        .get(secrets::Kind::Token, &provider, &self.account)
                         .await
                         .map_err(ProviderError::from_secret_error)?;
                     if let Some(stored) = stored {
@@ -382,7 +389,7 @@ impl Claude {
         own.set(
             secrets::Kind::Token,
             &ProviderId::new(PROVIDER_ID),
-            &AccountId::default(),
+            &self.account,
             &Credential::new(document.to_string()),
         )
         .await
@@ -495,7 +502,7 @@ impl Provider for Claude {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/claude.rs
+++ b/crates/tidemark-core/src/providers/claude.rs
@@ -130,7 +130,7 @@ pub fn document_from_login(
 /// One Claude Code account.
 pub struct Claude {
     client: reqwest::Client,
-    credentials: CredentialFile,
+    credentials: Option<CredentialFile>,
     /// Where a login performed from Tidemark is kept, when the caller has somewhere to
     /// keep one. `None` in tests that only exercise the CLI file.
     own: Option<Arc<dyn Secrets>>,
@@ -146,7 +146,7 @@ pub struct Claude {
     plan: OnceLock<String>,
 }
 
-/// The canonical Claude Code credential file, or `None` when `HOME` is unusable.
+/// The canonical Claude Code credential file used when a client reads the vendor login.
 ///
 /// Free-standing rather than a method so that a caller can ask whether the CLI's login
 /// exists on this machine without building the provider.
@@ -155,19 +155,31 @@ pub fn cli_credentials_path() -> Option<PathBuf> {
     Some(Path::new(&home).join(".claude/.credentials.json"))
 }
 
+fn credentials_for(
+    account: &AccountId,
+    source: Source,
+) -> Result<Option<CredentialFile>, ProviderError> {
+    if account.as_str() != "default" && source == Source::OAuth {
+        return Ok(None);
+    }
+    let path = cli_credentials_path()
+        .ok_or_else(|| ProviderError::Local("HOME does not name an absolute directory".into()))?;
+    let write_lock = path.with_file_name(".storage-write.lock");
+    Ok(Some(
+        CredentialFile::new(path.clone(), path).coordinated_by(write_lock),
+    ))
+}
+
 impl Claude {
-    /// Builds the canonical Claude Code account at `~/.claude/.credentials.json`.
+    /// Builds the canonical Claude Code account when this account uses its vendor login.
     pub fn new(
         account: AccountId,
         own: Option<Arc<dyn Secrets>>,
         source: Source,
     ) -> Result<Self, ProviderError> {
-        let path = cli_credentials_path().ok_or_else(|| {
-            ProviderError::Local("HOME does not name an absolute directory".into())
-        })?;
-        let write_lock = path.with_file_name(".storage-write.lock");
-        let mut claude = Self::with_endpoints(
-            CredentialFile::new(path.clone(), path).coordinated_by(write_lock),
+        let credentials = credentials_for(&account, source)?;
+        let mut claude = Self::with_credentials(
+            credentials,
             USAGE_URL.to_owned(),
             REFRESH_URL.to_owned(),
             PROFILE_URL.to_owned(),
@@ -178,8 +190,18 @@ impl Claude {
         Ok(claude)
     }
 
+    #[cfg(test)]
     fn with_endpoints(
         credentials: CredentialFile,
+        usage_url: String,
+        refresh_url: String,
+        profile_url: String,
+    ) -> Result<Self, ProviderError> {
+        Self::with_credentials(Some(credentials), usage_url, refresh_url, profile_url)
+    }
+
+    fn with_credentials(
+        credentials: Option<CredentialFile>,
         usage_url: String,
         refresh_url: String,
         profile_url: String,
@@ -326,7 +348,10 @@ impl Claude {
 
     /// The CLI's file, refreshed in place if the token in it is spent.
     async fn cli_file_credential(&self) -> Result<(Credential, Option<String>), ProviderError> {
-        let locked = self.credentials.lock().map_err(map_file_error)?;
+        let credentials = self.credentials.as_ref().ok_or_else(|| {
+            ProviderError::Local("Claude CLI credentials are unavailable for this account".into())
+        })?;
+        let locked = credentials.lock().map_err(map_file_error)?;
         let document = locked.read_json().map_err(map_file_error)?;
         let mut credentials = ClaudeCredentials::from_document(&document)?;
         let now_ms = now_millis();
@@ -503,6 +528,9 @@ impl Provider for Claude {
 
     fn account(&self) -> AccountId {
         self.account.clone()
+    }
+    fn source(&self) -> Option<Source> {
+        Some(self.source)
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -920,6 +948,15 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    #[test]
+    fn an_extra_oauth_account_skips_the_cli_credentials_path() {
+        let account = AccountId::new("work");
+        assert!(
+            credentials_for(&account, Source::OAuth)
+                .expect("OAuth-only accounts do not need a CLI path")
+                .is_none()
+        );
+    }
     struct TestCredentials {
         dir: PathBuf,
         path: PathBuf,

--- a/crates/tidemark-core/src/providers/claude.rs
+++ b/crates/tidemark-core/src/providers/claude.rs
@@ -237,7 +237,7 @@ impl Claude {
             response,
         )
         .await?;
-        let mut snapshot = parse(&body, Timestamp::now())?;
+        let mut snapshot = parse_for_account(&body, Timestamp::now(), &self.account)?;
         // Asked after the reading, never before it: the plan is one line on the card and
         // the windows are the point of the poll, so nothing about the plan may delay or
         // fail one.
@@ -540,6 +540,14 @@ impl Provider for Claude {
 
 /// Turns a usage response into a snapshot.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body).map_err(|error| {
         ProviderError::malformed(format!("not a Claude usage response: {error}"))
     })?;
@@ -565,7 +573,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -149,7 +149,7 @@ const TOKEN_SUBTREE: &str = "tokens";
 #[derive(Debug)]
 pub struct Codex {
     client: reqwest::Client,
-    credentials: CredentialFile,
+    credentials: Option<CredentialFile>,
     /// Where a login performed from Tidemark is kept, when the caller has somewhere to
     /// keep one.
     own: Option<Arc<dyn Secrets>>,
@@ -161,29 +161,45 @@ pub struct Codex {
     refresh_url: String,
 }
 
+fn credentials_for(
+    account: &AccountId,
+    source: Source,
+) -> Result<Option<CredentialFile>, ProviderError> {
+    if account.as_str() != "default" && source == Source::OAuth {
+        return Ok(None);
+    }
+    let path = cli_credentials_path()
+        .ok_or_else(|| ProviderError::Local("HOME does not name an absolute directory".into()))?;
+    Ok(Some(CredentialFile::new(path.clone(), path)))
+}
+
 impl Codex {
-    /// Builds the canonical Codex account at `$CODEX_HOME/auth.json`, or `~/.codex`.
+    /// Builds the canonical Codex account when this account uses its vendor login.
     pub fn new(
         account: AccountId,
         own: Option<Arc<dyn Secrets>>,
         source: Source,
     ) -> Result<Self, ProviderError> {
-        let path = cli_credentials_path().ok_or_else(|| {
-            ProviderError::Local("HOME does not name an absolute directory".into())
-        })?;
-        let mut codex = Self::with_endpoints(
-            CredentialFile::new(path.clone(), path),
-            USAGE_URL.to_owned(),
-            REFRESH_URL.to_owned(),
-        )?;
+        let credentials = credentials_for(&account, source)?;
+        let mut codex =
+            Self::with_credentials(credentials, USAGE_URL.to_owned(), REFRESH_URL.to_owned())?;
         codex.own = own;
         codex.source = source;
         codex.account = account;
         Ok(codex)
     }
 
+    #[cfg(test)]
     fn with_endpoints(
         credentials: CredentialFile,
+        usage_url: String,
+        refresh_url: String,
+    ) -> Result<Self, ProviderError> {
+        Self::with_credentials(Some(credentials), usage_url, refresh_url)
+    }
+
+    fn with_credentials(
+        credentials: Option<CredentialFile>,
         usage_url: String,
         refresh_url: String,
     ) -> Result<Self, ProviderError> {
@@ -293,7 +309,10 @@ impl Codex {
         now: i64,
         force: bool,
     ) -> Result<CodexCredentials, ProviderError> {
-        let locked = self.credentials.lock().map_err(map_file_error)?;
+        let credentials = self.credentials.as_ref().ok_or_else(|| {
+            ProviderError::Local("Codex CLI credentials are unavailable for this account".into())
+        })?;
+        let locked = credentials.lock().map_err(map_file_error)?;
         let document = locked.read_json().map_err(map_file_error)?;
         let credentials = CodexCredentials::from_document(&document)?;
         if force || credentials.is_expired_at(now) {
@@ -460,6 +479,9 @@ impl Provider for Codex {
 
     fn account(&self) -> AccountId {
         self.account.clone()
+    }
+    fn source(&self) -> Option<Source> {
+        Some(self.source)
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -962,6 +984,16 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+
+    #[test]
+    fn an_extra_oauth_account_skips_the_cli_credentials_path() {
+        let account = AccountId::new("work");
+        assert!(
+            credentials_for(&account, Source::OAuth)
+                .expect("OAuth-only accounts do not need a CLI path")
+                .is_none()
+        );
+    }
 
     static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -155,13 +155,19 @@ pub struct Codex {
     own: Option<Arc<dyn Secrets>>,
     /// Which of the two credentials this account reads — see the module docs.
     source: Source,
+    /// The configured account whose Tidemark login this client reads.
+    account: AccountId,
     usage_url: String,
     refresh_url: String,
 }
 
 impl Codex {
     /// Builds the canonical Codex account at `$CODEX_HOME/auth.json`, or `~/.codex`.
-    pub fn new(own: Option<Arc<dyn Secrets>>, source: Source) -> Result<Self, ProviderError> {
+    pub fn new(
+        account: AccountId,
+        own: Option<Arc<dyn Secrets>>,
+        source: Source,
+    ) -> Result<Self, ProviderError> {
         let path = cli_credentials_path().ok_or_else(|| {
             ProviderError::Local("HOME does not name an absolute directory".into())
         })?;
@@ -172,6 +178,7 @@ impl Codex {
         )?;
         codex.own = own;
         codex.source = source;
+        codex.account = account;
         Ok(codex)
     }
 
@@ -185,6 +192,7 @@ impl Codex {
             credentials,
             own: None,
             source: Source::Auto,
+            account: AccountId::default(),
             usage_url,
             refresh_url,
         })
@@ -303,7 +311,7 @@ impl Codex {
             .get(
                 secrets::Kind::Token,
                 &ProviderId::new(PROVIDER_ID),
-                &AccountId::default(),
+                &self.account,
             )
             .await
             .map_err(ProviderError::from_secret_error)?;
@@ -351,7 +359,7 @@ impl Codex {
         own.set(
             secrets::Kind::Token,
             &ProviderId::new(PROVIDER_ID),
-            &AccountId::default(),
+            &self.account,
             &Credential::new(document.to_string()),
         )
         .await
@@ -451,7 +459,7 @@ impl Provider for Codex {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -256,7 +256,7 @@ impl Codex {
                 response,
             )
             .await?;
-            return parse(&body, Timestamp::now());
+            return parse_for_account(&body, Timestamp::now(), &self.account);
         }
     }
 
@@ -505,6 +505,14 @@ pub fn cli_credentials_path() -> Option<PathBuf> {
 
 /// Turns a usage response into a snapshot.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body).map_err(|error| {
         ProviderError::malformed(format!("not a Codex usage response: {error}"))
     })?;
@@ -575,7 +583,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: details(&envelope),

--- a/crates/tidemark-core/src/providers/keyed/abacus.rs
+++ b/crates/tidemark-core/src/providers/keyed/abacus.rs
@@ -60,12 +60,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Abacus::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Abacus::new_for_account(account, options)?))
 }
 
 /// One Abacus account, authenticated by one explicitly chosen browser profile.
 pub struct Abacus {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -76,7 +81,12 @@ pub struct Abacus {
 
 impl Abacus {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -93,6 +103,7 @@ impl Abacus {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -164,7 +175,12 @@ impl Abacus {
                 self.billing_request(&self.billing_url(), &session.header)?,
             ),
         );
-        parse(&points?, billing.ok().as_deref(), Timestamp::now())
+        parse_for_account(
+            &points?,
+            billing.ok().as_deref(),
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -215,7 +231,7 @@ impl Provider for Abacus {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -266,6 +282,20 @@ pub fn parse(
     billing_info: Option<&str>,
     captured_at: Timestamp,
 ) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        compute_points,
+        billing_info,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    compute_points: &str,
+    billing_info: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let points = envelope(compute_points, "compute points")?;
     let total = number(&points, "totalComputePoints")?;
     let left = number(&points, "computePointsLeft")?;
@@ -315,7 +345,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/aiand.rs
+++ b/crates/tidemark-core/src/providers/keyed/aiand.rs
@@ -72,12 +72,17 @@ pub static SPEC: HandSpec = HandSpec {
 };
 
 /// Builds a pollable client from the stored key. ai& has nothing to configure.
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(AiAnd::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(AiAnd::new_for_account(account, credential)?))
 }
 
 /// One ai& account: the key, and the paged request log it unlocks.
 pub struct AiAnd {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -86,7 +91,15 @@ impl AiAnd {
     /// Builds a client. One host, so the URL is a constant and there is nothing to
     /// resolve at build time.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -123,7 +136,12 @@ impl AiAnd {
         let now = Timestamp::now();
         let (rows, complete) = self.pages().await?;
         let spend = summarise(&rows)?;
-        Ok(snapshot(spend.as_ref(), complete, now))
+        Ok(snapshot_for_account(
+            spend.as_ref(),
+            complete,
+            now,
+            &self.tidemark_account,
+        ))
     }
 
     /// Walks the pages, keeping every row that lands. Transport, status and shape
@@ -174,7 +192,7 @@ impl Provider for AiAnd {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -318,7 +336,17 @@ fn decimal_nanos(raw: &str) -> Option<i128> {
 /// No window, ever: ai& is prepaid with no quota to draw a bar against, and the shape
 /// for that is details only — the card renders empty when nothing priced landed, which
 /// is accepted.
+#[cfg(test)]
 fn snapshot(spend: Option<&Spend>, complete: bool, now: Timestamp) -> Snapshot {
+    snapshot_for_account(spend, complete, now, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    spend: Option<&Spend>,
+    complete: bool,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let rows = match spend {
         Some(spend) => vec![DetailRow {
             label: if complete {
@@ -346,7 +374,7 @@ fn snapshot(spend: Option<&Spend>, complete: bool, now: Timestamp) -> Snapshot {
     };
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: Vec::new(),
         details,
@@ -616,7 +644,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "ai&");
         assert!(SPEC.options.is_empty(), "ai& has nothing to choose");
-        assert!(build(Credential::new("fixture-key"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("fixture-key"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/alibaba.rs
+++ b/crates/tidemark-core/src/providers/keyed/alibaba.rs
@@ -89,14 +89,21 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
     if credential.expose().trim().is_empty() {
         return Err(ProviderError::Local(
             "an empty key is not a DashScope API key; paste one from the Model Studio console"
                 .into(),
         ));
     }
-    Ok(Arc::new(Alibaba::new(credential.expose())?))
+    Ok(Arc::new(Alibaba::new_for_account(
+        account,
+        credential.expose(),
+    )?))
 }
 
 /// One of the two gateways the same RPC lives on, with everything about the request the
@@ -156,6 +163,7 @@ impl Region {
 
 /// One DashScope key against the Coding Plan RPC.
 pub struct Alibaba {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     key: String,
     /// The two gateways, kept as fields so a test can point each at a loopback.
@@ -166,7 +174,12 @@ pub struct Alibaba {
 impl Alibaba {
     /// Builds the account against the real gateways.
     pub fn new(key: &str) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), key)
+    }
+
+    fn new_for_account(account_id: AccountId, key: &str) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: super::http::client()?,
             key: key.trim().to_owned(),
             intl_base: INTL_BASE.to_owned(),
@@ -177,6 +190,7 @@ impl Alibaba {
     #[cfg(test)]
     fn for_test(intl_base: &str, cn_base: &str, key: &str) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: super::http::client()?,
             key: key.to_owned(),
             intl_base: intl_base.trim_end_matches('/').to_owned(),
@@ -228,7 +242,7 @@ impl Alibaba {
         let body = super::request(PROVIDER_ID, &self.client, request)
             .await
             .map_err(Attempt::Exchange)?;
-        parse_quota(&body, Timestamp::now())
+        parse_quota_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 }
 
@@ -246,7 +260,7 @@ impl Provider for Alibaba {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -321,7 +335,16 @@ fn region_shaped(error: &ProviderError) -> bool {
 ///
 /// Pure — the body and the clock decide everything — so every recorded envelope is
 /// reachable from a test.
+#[cfg(test)]
 fn parse_quota(body: &str, now: Timestamp) -> Result<Snapshot, Attempt> {
+    parse_quota_for_account(body, now, &AccountId::default())
+}
+
+fn parse_quota_for_account(
+    body: &str,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, Attempt> {
     let document: Value = serde_json::from_str(body).map_err(|error| {
         Attempt::Malformed(format!("not an Alibaba Coding Plan response: {error}"))
     })?;
@@ -445,7 +468,7 @@ fn parse_quota(body: &str, now: Timestamp) -> Result<Snapshot, Attempt> {
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details,
@@ -1126,15 +1149,24 @@ mod tests {
 
     #[test]
     fn an_empty_key_is_refused_at_build() {
-        let error = (SPEC.build)(Credential::new("   "), &Options::new())
-            .expect_err("an empty key is not a credential");
+        let error = (SPEC.build)(
+            AccountId::default(),
+            Credential::new("   "),
+            &Options::new(),
+        )
+        .expect_err("an empty key is not a credential");
         assert!(
             matches!(error, ProviderError::Local(ref message) if message.contains("key")),
             "{error:?}"
         );
 
         assert!(
-            (SPEC.build)(Credential::new("cpk-live"), &Options::new()).is_ok(),
+            (SPEC.build)(
+                AccountId::default(),
+                Credential::new("cpk-live"),
+                &Options::new()
+            )
+            .is_ok(),
             "a pasted key builds"
         );
     }

--- a/crates/tidemark-core/src/providers/keyed/amp.rs
+++ b/crates/tidemark-core/src/providers/keyed/amp.rs
@@ -189,6 +189,14 @@ struct Display {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -316,7 +324,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -662,7 +670,7 @@ pub static SPEC: Spec = Spec {
     },
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "ampcode.com settings → API key (AMP_API_KEY).",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/augment.rs
+++ b/crates/tidemark-core/src/providers/keyed/augment.rs
@@ -48,12 +48,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Augment::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Augment::new_for_account(account, options)?))
 }
 
 /// One Augment account, authenticated by one explicitly chosen browser profile.
 pub struct Augment {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -64,7 +69,12 @@ pub struct Augment {
 
 impl Augment {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -81,6 +91,7 @@ impl Augment {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -141,7 +152,12 @@ impl Augment {
                 self.request(&self.subscription_url(), &session.header)?,
             ),
         );
-        parse(&credits?, subscription.ok().as_deref(), Timestamp::now())
+        parse_for_account(
+            &credits?,
+            subscription.ok().as_deref(),
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -184,7 +200,7 @@ impl Provider for Augment {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -226,6 +242,20 @@ pub fn parse(
     credits_body: &str,
     subscription_body: Option<&str>,
     captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        credits_body,
+        subscription_body,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    credits_body: &str,
+    subscription_body: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let credits: Credits = serde_json::from_str(credits_body)
         .map_err(|error| ProviderError::malformed(format!("not Augment credits: {error}")))?;
@@ -317,7 +347,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/chutes.rs
+++ b/crates/tidemark-core/src/providers/keyed/chutes.rs
@@ -229,6 +229,14 @@ struct Draft {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let json: Value = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     // An array root is a quotas list with the wrapper omitted, as the source reads it.
@@ -403,7 +411,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -938,7 +946,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "chutes.ai account settings → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/clawrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/clawrouter.rs
@@ -103,6 +103,14 @@ struct Provider {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -215,7 +223,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -308,7 +316,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "ClawRouter policy page → API keys.",
     options: &[OptionSchema {
         name: "base_url",

--- a/crates/tidemark-core/src/providers/keyed/clinepass.rs
+++ b/crates/tidemark-core/src/providers/keyed/clinepass.rs
@@ -54,6 +54,14 @@ fn length_of(kind: &str) -> Option<u64> {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     match envelope.success {
@@ -98,7 +106,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: Vec::new(),
@@ -113,7 +121,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Cline dashboard → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/codebuff.rs
+++ b/crates/tidemark-core/src/providers/keyed/codebuff.rs
@@ -285,6 +285,15 @@ pub fn snapshot(
     subscription: Option<&Subscription>,
     captured_at: Timestamp,
 ) -> Snapshot {
+    snapshot_for_account(usage, subscription, captured_at, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    usage: &Usage,
+    subscription: Option<&Subscription>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut windows = Vec::new();
 
     // The allowance where it is stated, otherwise arrived at from the other end.
@@ -400,7 +409,7 @@ pub fn snapshot(
 
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: if rows.is_empty() {
@@ -434,13 +443,18 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
     let _ = options;
-    Ok(Arc::new(Codebuff::new(credential)?))
+    Ok(Arc::new(Codebuff::new_for_account(account, credential)?))
 }
 
 /// One Codebuff account: the key, and the two endpoints it is polled at.
 pub struct Codebuff {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -448,7 +462,15 @@ pub struct Codebuff {
 impl Codebuff {
     /// Builds a client.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -495,7 +517,12 @@ impl Codebuff {
         let usage =
             parse_usage(&super::request(PROVIDER_ID, &self.client, self.usage_request()?).await?)?;
         let subscription = self.subscription().await;
-        Ok(snapshot(&usage, subscription.as_ref(), Timestamp::now()))
+        Ok(snapshot_for_account(
+            &usage,
+            subscription.as_ref(),
+            Timestamp::now(),
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -515,7 +542,7 @@ impl Provider for Codebuff {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/keyed/commandcode.rs
+++ b/crates/tidemark-core/src/providers/keyed/commandcode.rs
@@ -62,12 +62,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(CommandCode::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(CommandCode::new_for_account(account, options)?))
 }
 
 /// One CommandCode account, authenticated by one explicitly chosen browser profile.
 pub struct CommandCode {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -78,7 +83,12 @@ pub struct CommandCode {
 
 impl CommandCode {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -95,6 +105,7 @@ impl CommandCode {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -157,7 +168,12 @@ impl CommandCode {
                 self.request(&self.subscriptions_url(), &session.header)?,
             ),
         );
-        parse(&credits?, subscriptions.ok().as_deref(), Timestamp::now())
+        parse_for_account(
+            &credits?,
+            subscriptions.ok().as_deref(),
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -200,7 +216,7 @@ impl Provider for CommandCode {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -241,6 +257,20 @@ pub fn parse(
     credits_body: &str,
     subscriptions_body: Option<&str>,
     captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        credits_body,
+        subscriptions_body,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    credits_body: &str,
+    subscriptions_body: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let root: Value = serde_json::from_str(credits_body)
         .map_err(|error| ProviderError::malformed(format!("not CommandCode credits: {error}")))?;
@@ -345,7 +375,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/crof.rs
+++ b/crates/tidemark-core/src/providers/keyed/crof.rs
@@ -74,6 +74,14 @@ fn count(requests: f64) -> String {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     if !envelope.credits.is_finite() {
@@ -119,7 +127,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: Vec::new(),
@@ -134,7 +142,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Crof dashboard → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/cursor.rs
+++ b/crates/tidemark-core/src/providers/keyed/cursor.rs
@@ -172,8 +172,12 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Cursor::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Cursor::new_for_account(account, options)?))
 }
 
 /// The one local Cursor session a provider instance may read.
@@ -213,6 +217,7 @@ impl Source {
 }
 
 pub struct Cursor {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -223,7 +228,12 @@ pub struct Cursor {
 
 impl Cursor {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -241,6 +251,7 @@ impl Cursor {
         storage: Arc<dyn SafeStorage>,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -434,12 +445,13 @@ impl Cursor {
             None => None,
         };
 
-        parse(
+        parse_for_account(
             &summary,
             identity.as_deref(),
             legacy.as_deref(),
             sand.as_deref(),
             Timestamp::now(),
+            &self.tidemark_account,
         )
     }
 }
@@ -591,7 +603,7 @@ impl Provider for Cursor {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -763,12 +775,31 @@ fn money(used: f64, limit: Option<f64>) -> String {
     }
 }
 
+#[cfg(test)]
 fn parse(
     summary_body: &str,
     identity_body: Option<&str>,
     legacy_body: Option<&str>,
     sand_body: Option<&str>,
     captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        summary_body,
+        identity_body,
+        legacy_body,
+        sand_body,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    summary_body: &str,
+    identity_body: Option<&str>,
+    legacy_body: Option<&str>,
+    sand_body: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let summary: Summary = serde_json::from_str(summary_body)
         .map_err(|e| ProviderError::malformed(format!("unreadable usage summary: {e}")))?;
@@ -1003,7 +1034,7 @@ fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,
@@ -1014,7 +1045,7 @@ fn parse(
 mod tests {
     use super::{Cursor, Options, SPEC, parse};
     use crate::providers::{Credential, Provider, ProviderError};
-    use tidemark_types::{AuthCandidateState, CredentialKind, DetailSection, Timestamp};
+    use tidemark_types::{AccountId, AuthCandidateState, CredentialKind, DetailSection, Timestamp};
 
     /// A live Pro account's `GET /api/usage-summary`, as CodexBar's own regression test
     /// records it: fractional lane percentages that are percentages, not fractions.
@@ -1382,8 +1413,12 @@ mod tests {
             ["auth-source", "auth-browser", "auth-profile"]
         );
 
-        let provider =
-            (SPEC.build)(Credential::new(String::new()), &Options::new()).expect("builds");
+        let provider = (SPEC.build)(
+            AccountId::default(),
+            Credential::new(String::new()),
+            &Options::new(),
+        )
+        .expect("builds");
         assert_eq!(provider.id().as_str(), "cursor");
     }
 

--- a/crates/tidemark-core/src/providers/keyed/deepgram.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepgram.rs
@@ -241,6 +241,15 @@ fn integer(value: f64) -> String {
 
 /// The rows the totals make, in the plugin's own order and wording.
 pub fn snapshot(projects: &[Project], totals: &Totals, captured_at: Timestamp) -> Snapshot {
+    snapshot_for_account(projects, totals, captured_at, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    projects: &[Project],
+    totals: &Totals,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut rows = vec![DetailRow {
         label: "Requests".to_owned(),
         value: integer(totals.requests),
@@ -291,7 +300,7 @@ pub fn snapshot(projects: &[Project], totals: &Totals, captured_at: Timestamp) -
 
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         // Deepgram meters; nothing here is out of anything. See the module doc.
         windows: Vec::new(),
@@ -381,12 +390,19 @@ pub static SPEC: HandSpec = HandSpec {
 /// Builds a pollable client from the stored key and the account's settings. The base URL is
 /// resolved here so a value the shared reader refuses is a [`ProviderError::Local`] naming
 /// the setting, rather than a panic mid-fetch.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Deepgram::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Deepgram::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One Deepgram account: the key, the host, and the project it is pinned to if any.
 pub struct Deepgram {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     base: String,
@@ -397,12 +413,21 @@ impl Deepgram {
     /// Builds a client. The URL is resolved once, here, because a setting that changed the
     /// host would otherwise take effect only on the next daemon restart.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let base = base_url(options, BASE_URL, DEFAULT_BASE_URL)?;
         let project = options
             .get(PROJECT_ID)
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty());
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             base,
@@ -457,7 +482,12 @@ impl Deepgram {
             let body = self.get(&breakdown_url(&self.base, &project.id)).await?;
             parse_breakdown(&body, &mut totals)?;
         }
-        Ok(snapshot(&projects, &totals, Timestamp::now()))
+        Ok(snapshot_for_account(
+            &projects,
+            &totals,
+            Timestamp::now(),
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -479,7 +509,7 @@ impl Provider for Deepgram {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/keyed/deepinfra.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepinfra.rs
@@ -67,12 +67,17 @@ pub static SPEC: HandSpec = HandSpec {
 };
 
 /// Builds a pollable client from the stored key. DeepInfra has nothing to configure.
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(DeepInfra::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(DeepInfra::new_for_account(account, credential)?))
 }
 
 /// One DeepInfra account: the key, and the two payment endpoints it unlocks.
 pub struct DeepInfra {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -81,7 +86,15 @@ impl DeepInfra {
     /// Builds a client. One host, so the URLs are constants and there is nothing to
     /// resolve at build time.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -139,7 +152,7 @@ impl Provider for DeepInfra {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -573,7 +586,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "DeepInfra");
         assert!(SPEC.options.is_empty(), "DeepInfra has nothing to choose");
-        assert!(build(Credential::new("fixture-token"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("fixture-token"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/deepseek.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepseek.rs
@@ -91,6 +91,14 @@ fn amount(raw: &str, field: &str) -> Result<f64, ProviderError> {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -165,7 +173,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows: Vec::new(),
         details: vec![DetailSection {
@@ -183,7 +191,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "DeepSeek platform → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/elevenlabs.rs
+++ b/crates/tidemark-core/src/providers/keyed/elevenlabs.rs
@@ -143,6 +143,14 @@ fn display_tier(tier: Option<&str>, status: Option<&str>) -> Option<String> {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let subscription: Subscription = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -193,7 +201,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -208,7 +216,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Header("xi-api-key"),
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "ElevenLabs profile → API Keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/factory.rs
+++ b/crates/tidemark-core/src/providers/keyed/factory.rs
@@ -129,12 +129,17 @@ pub static SPEC: HandSpec = HandSpec {
 
 /// Builds a pollable client from the stored key. Factory exposes no settings: one
 /// host, one ladder.
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Factory::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Factory::new_for_account(account, credential)?))
 }
 
 /// One Factory account: the key, against the one host the ladder lives on.
 pub struct Factory {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -142,7 +147,15 @@ pub struct Factory {
 impl Factory {
     /// Builds a client.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -216,7 +229,12 @@ impl Factory {
             .clone()
             .or_else(|| jwt_subject(self.credential.expose()));
         if let Some(reading) = self.limits().await {
-            return Ok(rate_limits_snapshot(&auth, &reading, now));
+            return Ok(rate_limits_snapshot_for_account(
+                &auth,
+                &reading,
+                now,
+                &self.tidemark_account,
+            ));
         }
         let body = super::request(
             PROVIDER_ID,
@@ -225,7 +243,12 @@ impl Factory {
         )
         .await?;
         let usage = parse_usage(&body)?;
-        Ok(classic_snapshot(&auth, &usage, now))
+        Ok(classic_snapshot_for_account(
+            &auth,
+            &usage,
+            now,
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -245,7 +268,7 @@ impl Provider for Factory {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -607,7 +630,17 @@ fn normalized(value: Option<&str>) -> Option<String> {
 /// the core pool's three when it reports any usage data — plus the plan and the
 /// extra usage balance. Pure, so every recorded billing body is reachable from a
 /// test.
+#[cfg(test)]
 fn rate_limits_snapshot(auth: &Auth, reading: &BillingReading, now: Timestamp) -> Snapshot {
+    rate_limits_snapshot_for_account(auth, reading, now, &AccountId::default())
+}
+
+fn rate_limits_snapshot_for_account(
+    auth: &Auth,
+    reading: &BillingReading,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut windows = vec![
         billing_window(
             WindowKey::for_length(length(FIVE_HOURS)),
@@ -669,7 +702,7 @@ fn rate_limits_snapshot(auth: &Auth, reading: &BillingReading, now: Timestamp) -
     });
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details,
@@ -697,7 +730,17 @@ fn billing_window(
 
 /// The billing-period card: two windows — standard and premium — each tokens used
 /// against a stated allowance, reset at the period's end. Pure.
+#[cfg(test)]
 fn classic_snapshot(auth: &Auth, usage: &Usage, now: Timestamp) -> Snapshot {
+    classic_snapshot_for_account(auth, usage, now, &AccountId::default())
+}
+
+fn classic_snapshot_for_account(
+    auth: &Auth,
+    usage: &Usage,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let windows = vec![
         pool_window("standard", "Standard", &usage.standard, usage.period_end),
         pool_window("premium", "Premium", &usage.premium, usage.period_end),
@@ -718,7 +761,7 @@ fn classic_snapshot(auth: &Auth, usage: &Usage, now: Timestamp) -> Snapshot {
     }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details,
@@ -1387,7 +1430,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "Factory");
         assert!(SPEC.options.is_empty());
-        assert!(build(Credential::new("fk-test-key"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("fk-test-key"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/fireworks.rs
+++ b/crates/tidemark-core/src/providers/keyed/fireworks.rs
@@ -82,13 +82,20 @@ pub static SPEC: HandSpec = HandSpec {
 /// Builds a pollable client from the stored key and the account's settings. The
 /// account id is read and validated here, so a missing or invalid one is named on the
 /// card rather than reaching the wire as a malformed URL.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Fireworks::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Fireworks::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One Fireworks account: the key, and the billing summary it unlocks when the account
 /// id says whose.
 pub struct Fireworks {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     account: String,
@@ -98,6 +105,14 @@ impl Fireworks {
     /// Builds a client. The account id is part of the path, so it is resolved once,
     /// here, against the source's slug alphabet.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let account = required(options, ACCOUNT, "Account ID")?;
         if !account
             .bytes()
@@ -108,6 +123,7 @@ impl Fireworks {
             )));
         }
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             account,
@@ -133,7 +149,11 @@ impl Fireworks {
         }
         let now = Timestamp::now();
         let body = super::request(PROVIDER_ID, &self.client, self.summary_request(now)?).await?;
-        Ok(snapshot(parse_summary(&body)?.as_ref(), now))
+        Ok(snapshot_for_account(
+            parse_summary(&body)?.as_ref(),
+            now,
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -154,7 +174,7 @@ impl Provider for Fireworks {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -284,7 +304,12 @@ fn parse_summary(body: &str) -> Result<Option<Spend>, ProviderError> {
 /// No window, ever: Fireworks is prepaid with no quota to draw a bar against, and the
 /// shape for that is details only — the card renders empty when nothing is rated,
 /// which is accepted.
+#[cfg(test)]
 fn snapshot(spend: Option<&Spend>, now: Timestamp) -> Snapshot {
+    snapshot_for_account(spend, now, &AccountId::default())
+}
+
+fn snapshot_for_account(spend: Option<&Spend>, now: Timestamp, account_id: &AccountId) -> Snapshot {
     let details = spend
         .map(|spend| {
             vec![DetailSection {
@@ -298,7 +323,7 @@ fn snapshot(spend: Option<&Spend>, now: Timestamp) -> Snapshot {
         .unwrap_or_default();
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: Vec::new(),
         details,
@@ -507,10 +532,22 @@ mod tests {
         assert_eq!(SPEC.options.len(), 1);
         assert!(SPEC.options[0].required);
         assert!(
-            build(Credential::new("fw-key"), &options("x0mh0x")).is_ok(),
+            build(
+                AccountId::default(),
+                Credential::new("fw-key"),
+                &options("x0mh0x")
+            )
+            .is_ok(),
             "a slug and a key build a client"
         );
-        assert!(build(Credential::new("fw-key"), &Options::new()).is_err());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("fw-key"),
+                &Options::new()
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/gemini.rs
+++ b/crates/tidemark-core/src/providers/keyed/gemini.rs
@@ -77,12 +77,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Gemini::new()?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Gemini::new_for_account(account)?))
 }
 
 /// One Gemini CLI login on this machine.
 pub struct Gemini {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credentials: CredentialFile,
     /// The home the credentials and the CLI's settings live under, when `$HOME` says.
@@ -98,6 +103,10 @@ pub struct Gemini {
 impl Gemini {
     /// Builds the canonical account at `~/.gemini/oauth_creds.json`.
     pub fn new() -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default())
+    }
+
+    fn new_for_account(account_id: AccountId) -> Result<Self, ProviderError> {
         let path = cli_credentials_path().ok_or_else(|| {
             ProviderError::Local("HOME does not name an absolute directory".into())
         })?;
@@ -107,6 +116,7 @@ impl Gemini {
             std::env::var("GEMINI_OAUTH_CLIENT_SECRET").ok(),
         );
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: super::http::client()?,
             credentials: CredentialFile::new(path.clone(), path),
             home,
@@ -123,6 +133,7 @@ impl Gemini {
         let base = base.trim_end_matches('/').to_owned();
         let credentials = home.join(".gemini/oauth_creds.json");
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: super::http::client()?,
             credentials: CredentialFile::new(credentials.clone(), credentials),
             home: Some(home.to_path_buf()),
@@ -242,7 +253,8 @@ impl Gemini {
             Ok(())
         })
         .await?;
-        let mut snapshot = parse_quota(&body, Timestamp::now())?;
+        let mut snapshot =
+            parse_quota_for_account(&body, Timestamp::now(), &self.tidemark_account)?;
 
         if let Some(email) = email {
             snapshot.details.push(DetailSection {
@@ -370,7 +382,7 @@ impl Provider for Gemini {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -454,6 +466,14 @@ impl Tier {
 /// Turns a quota response into a snapshot: one window per tier, drawn at the lowest
 /// fraction any of the tier's models reported.
 pub fn parse_quota(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_quota_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_quota_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let response: QuotaResponse = serde_json::from_str(body).map_err(|error| {
         ProviderError::malformed(format!("not a Gemini quota response: {error}"))
     })?;
@@ -514,7 +534,7 @@ pub fn parse_quota(body: &str, captured_at: Timestamp) -> Result<Snapshot, Provi
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: Vec::new(),

--- a/crates/tidemark-core/src/providers/keyed/grok.rs
+++ b/crates/tidemark-core/src/providers/keyed/grok.rs
@@ -68,7 +68,11 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
     if credential
         .expose()
         .trim()
@@ -80,11 +84,12 @@ fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>
                 .into(),
         ));
     }
-    Ok(Arc::new(Grok::new()?))
+    Ok(Arc::new(Grok::new_for_account(account)?))
 }
 
 /// One grok CLI login on this machine.
 pub struct Grok {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     login: PathBuf,
     /// The CLI proxy host, kept as a field so a test can point it at a loopback.
@@ -94,10 +99,15 @@ pub struct Grok {
 impl Grok {
     /// Builds the account at the CLI's own login path.
     pub fn new() -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default())
+    }
+
+    fn new_for_account(account_id: AccountId) -> Result<Self, ProviderError> {
         let login = cli_credentials_path().ok_or_else(|| {
             ProviderError::Local("neither GROK_HOME nor HOME names a directory".into())
         })?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: super::http::client()?,
             login,
             proxy_base: PROXY_BASE.to_owned(),
@@ -107,6 +117,7 @@ impl Grok {
     #[cfg(test)]
     fn for_test(home: &Path, base: &str) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: super::http::client()?,
             login: credentials_path(home),
             proxy_base: base.trim_end_matches('/').to_owned(),
@@ -155,7 +166,7 @@ impl Grok {
             Ok(())
         })
         .await?;
-        let billing = parse_billing(&body, Timestamp::now())?;
+        let billing = parse_billing_for_account(&body, Timestamp::now(), &self.tidemark_account)?;
 
         // Advisory, as upstream treats it: a refusal here costs the Plan row only.
         let settings_tier = self.settings_tier(token).await;
@@ -217,7 +228,7 @@ impl Provider for Grok {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -301,6 +312,14 @@ pub struct Billing {
 /// the body states it, else the on-demand use against its cap. A body with neither is
 /// malformed — upstream carries it as an unknown, but a card cannot be drawn unnumbered.
 pub fn parse_billing(body: &str, captured_at: Timestamp) -> Result<Billing, ProviderError> {
+    parse_billing_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_billing_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Billing, ProviderError> {
     let response: BillingResponse = serde_json::from_str(body).map_err(|error| {
         ProviderError::malformed(format!("not a Grok billing response: {error}"))
     })?;
@@ -341,7 +360,7 @@ pub fn parse_billing(body: &str, captured_at: Timestamp) -> Result<Billing, Prov
     Ok(Billing {
         snapshot: Snapshot {
             provider: ProviderId::new(PROVIDER_ID),
-            account: AccountId::default(),
+            account: account_id.clone(),
             captured_at,
             windows: vec![Window {
                 key: WindowKey::named("credits"),
@@ -948,8 +967,12 @@ mod tests {
 
     #[test]
     fn a_pasted_xai_key_is_refused_at_build() {
-        let error = (SPEC.build)(Credential::new("xai-abc123"), &Options::new())
-            .expect_err("that key belongs to another provider");
+        let error = (SPEC.build)(
+            AccountId::default(),
+            Credential::new("xai-abc123"),
+            &Options::new(),
+        )
+        .expect_err("that key belongs to another provider");
 
         match error {
             ProviderError::Local(message) => {

--- a/crates/tidemark-core/src/providers/keyed/groq.rs
+++ b/crates/tidemark-core/src/providers/keyed/groq.rs
@@ -78,12 +78,19 @@ pub static SPEC: HandSpec = HandSpec {
 
 /// Builds a pollable client from the stored key and the account's settings. The query
 /// URL is resolved here, so a changed base URL takes effect on the next build.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Groq::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Groq::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One Groq account: the key, and the one query endpoint four questions share.
 pub struct Groq {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     query_url: String,
@@ -92,8 +99,17 @@ pub struct Groq {
 impl Groq {
     /// Builds a client. The metrics path hangs off the API root, resolved once here.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let base = base_url(options, BASE_URL, DEFAULT_BASE_URL)?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             query_url: format!("{base}/metrics/prometheus/api/v1/query"),
@@ -125,7 +141,7 @@ impl Groq {
             self.scalar(OUTPUT_QUERY),
             self.scalar(CACHE_QUERY),
         );
-        Ok(snapshot(
+        Ok(snapshot_for_account(
             &Rates {
                 requests: requests?,
                 input_tokens: input?,
@@ -133,6 +149,7 @@ impl Groq {
                 cache_hits: cache?,
             },
             now,
+            &self.tidemark_account,
         ))
     }
 
@@ -166,7 +183,7 @@ impl Provider for Groq {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -244,7 +261,12 @@ fn parse_scalar(body: &str) -> Result<f64, ProviderError> {
 ///
 /// No window, ever: a throughput rate is not a quota, and the shape for that is details
 /// only — the card renders empty, which is accepted.
+#[cfg(test)]
 fn snapshot(rates: &Rates, now: Timestamp) -> Snapshot {
+    snapshot_for_account(rates, now, &AccountId::default())
+}
+
+fn snapshot_for_account(rates: &Rates, now: Timestamp, account_id: &AccountId) -> Snapshot {
     let mut rows = vec![
         labeled(
             "Requests",
@@ -266,7 +288,7 @@ fn snapshot(rates: &Rates, now: Timestamp) -> Snapshot {
     }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: Vec::new(),
         details: vec![DetailSection {
@@ -525,7 +547,14 @@ mod tests {
         assert_eq!(SPEC.title, "Groq");
         assert_eq!(SPEC.options.len(), 1);
         assert!(!SPEC.options[0].required, "the default host stands in");
-        assert!(build(Credential::new("gsk_test"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("gsk_test"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/ibmbob.rs
+++ b/crates/tidemark-core/src/providers/keyed/ibmbob.rs
@@ -84,12 +84,17 @@ pub static SPEC: HandSpec = HandSpec {
 
 /// Builds a pollable client from the stored key. Nothing to resolve: the profile host
 /// is fixed and the regional hosts come from the response.
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(IBMBob::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(IBMBob::new_for_account(account, credential)?))
 }
 
 /// One IBM Bob account: the key, and the profile host it unlocks.
 pub struct IBMBob {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -97,7 +102,15 @@ pub struct IBMBob {
 impl IBMBob {
     /// Builds a client.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -190,7 +203,7 @@ impl IBMBob {
                 "the IBM Bob profile carried no teams for this key",
             ));
         }
-        Ok(snapshot(&teams, now))
+        Ok(snapshot_for_account(&teams, now, &self.tidemark_account))
     }
 }
 
@@ -210,7 +223,7 @@ impl Provider for IBMBob {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -480,7 +493,12 @@ fn non_empty(value: Option<&Value>) -> Option<String> {
 /// every team states a limit, as the source sums it. A balance has no length to key
 /// on: the wire states no budget duration. The reset is the soonest of the instances'
 /// refresh times.
+#[cfg(test)]
 fn snapshot(teams: &[TeamUsage], now: Timestamp) -> Snapshot {
+    snapshot_for_account(teams, now, &AccountId::default())
+}
+
+fn snapshot_for_account(teams: &[TeamUsage], now: Timestamp, account_id: &AccountId) -> Snapshot {
     let used: f64 = teams.iter().map(|team| team.used_bobcoins).sum();
     let limits: Vec<f64> = teams
         .iter()
@@ -530,7 +548,7 @@ fn snapshot(teams: &[TeamUsage], now: Timestamp) -> Snapshot {
         .collect();
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details: vec![DetailSection {
@@ -959,7 +977,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "IBM Bob");
         assert!(SPEC.options.is_empty(), "one host, nothing to choose");
-        assert!(build(Credential::new("fixture-key"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("fixture-key"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     /// The ladder's pure half: pairs the profile's instances with their team budgets

--- a/crates/tidemark-core/src/providers/keyed/kilo.rs
+++ b/crates/tidemark-core/src/providers/keyed/kilo.rs
@@ -864,6 +864,22 @@ pub fn snapshot(
     organization: Option<&str>,
     captured_at: Timestamp,
 ) -> Snapshot {
+    snapshot_for_account(
+        reading,
+        profile,
+        organization,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn snapshot_for_account(
+    reading: &Reading,
+    profile: Option<&Profile>,
+    organization: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut windows = Vec::new();
 
     let total = reading
@@ -965,7 +981,7 @@ pub fn snapshot(
 
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: if rows.is_empty() {
@@ -1025,12 +1041,19 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Kilo::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Kilo::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One Kilo account: the key, and the organization it is scoped to if any.
 pub struct Kilo {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     organization: Option<String>,
@@ -1039,7 +1062,16 @@ pub struct Kilo {
 impl Kilo {
     /// Builds a client.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             organization: options
@@ -1097,11 +1129,12 @@ impl Kilo {
         let reading =
             parse_batch(&super::request(PROVIDER_ID, &self.client, self.batch_request()?).await?)?;
         let profile = self.profile().await;
-        Ok(snapshot(
+        Ok(snapshot_for_account(
             &reading,
             profile.as_ref(),
             self.organization.as_deref(),
             Timestamp::now(),
+            &self.tidemark_account,
         ))
     }
 }
@@ -1123,7 +1156,7 @@ impl Provider for Kilo {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {

--- a/crates/tidemark-core/src/providers/keyed/kimi.rs
+++ b/crates/tidemark-core/src/providers/keyed/kimi.rs
@@ -75,13 +75,21 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Kimi Code Console → API keys. This is Kimi For Coding, not the Open Platform.",
     options: &[],
 };
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -124,7 +132,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows: measured.iter().map(|m| m.window.clone()).collect(),
         details: details(&envelope, &measured),

--- a/crates/tidemark-core/src/providers/keyed/litellm.rs
+++ b/crates/tidemark-core/src/providers/keyed/litellm.rs
@@ -90,13 +90,20 @@ pub static SPEC: HandSpec = HandSpec {
 /// Builds a pollable client from the stored key and the account's settings. The base
 /// URL is required — LiteLLM has no default host — and resolved here, so a changed one
 /// takes effect on the next build.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(LiteLLM::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(LiteLLM::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One LiteLLM deployment: the key, and the management root its two endpoints hang
 /// from.
 pub struct LiteLLM {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     management: String,
@@ -106,11 +113,20 @@ impl LiteLLM {
     /// Builds a client. The `/v1` trimming happens once, here, so every request of a
     /// fetch agrees on the root.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let raw = required(options, BASE_URL, "Base URL")?;
         // `required` proved a value exists; the shared reader then enforces the
         // HTTPS-or-loopback rule on it.
         let base = base_url(&Options::from([(BASE_URL.to_owned(), raw)]), BASE_URL, "")?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             management: management_root(&base),
@@ -182,7 +198,12 @@ impl LiteLLM {
                 "the LiteLLM key info did not include a user_id or team_id",
             ));
         };
-        Ok(snapshot(&reading, &key, now))
+        Ok(snapshot_for_account(
+            &reading,
+            &key,
+            now,
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -203,7 +224,7 @@ impl Provider for LiteLLM {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -392,7 +413,17 @@ fn parse_team_info(body: &str, key: &KeyInfo) -> Result<TeamBudget, ProviderErro
 /// survives either way. The personal window keys `personal` — it states no duration, so
 /// there is no length to key on — and a team window keys on its `budget_duration` when
 /// that is whole days, else `team`.
+#[cfg(test)]
 fn snapshot(reading: &Reading, key: &KeyInfo, now: Timestamp) -> Snapshot {
+    snapshot_for_account(reading, key, now, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    reading: &Reading,
+    key: &KeyInfo,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut windows = Vec::new();
     let mut rows = Vec::new();
     match reading {
@@ -443,7 +474,7 @@ fn snapshot(reading: &Reading, key: &KeyInfo, now: Timestamp) -> Snapshot {
     }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details,
@@ -1109,19 +1140,24 @@ mod tests {
     fn the_base_url_is_required_and_enforced() {
         // The procedure's fourth test: the option resolves, and a missing one names
         // itself rather than producing a malformed URL.
-        let error = build(Credential::new("sk-test"), &Options::new())
-            .expect_err("the required option is unset");
+        let error = build(
+            AccountId::default(),
+            Credential::new("sk-test"),
+            &Options::new(),
+        )
+        .expect_err("the required option is unset");
         assert!(
             matches!(error, ProviderError::Local(ref message)
                 if message == "Base URL is not set for this account"),
             "{error}"
         );
         let remote = options("http://litellm.lan:4000");
-        let error = build(Credential::new("sk-test"), &remote)
+        let error = build(AccountId::default(), Credential::new("sk-test"), &remote)
             .expect_err("a key over plain HTTP to a remote host is refused");
         assert!(matches!(error, ProviderError::Local(_)), "{error}");
         assert!(
             build(
+                AccountId::default(),
                 Credential::new("sk-test"),
                 &options("http://127.0.0.1:4000")
             )

--- a/crates/tidemark-core/src/providers/keyed/llmproxy.rs
+++ b/crates/tidemark-core/src/providers/keyed/llmproxy.rs
@@ -196,6 +196,14 @@ fn usd(value: f64) -> String {
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a
 /// test, including the reset filter's dependence on the clock the caller supplies.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let data: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -325,7 +333,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![DetailSection {
@@ -367,12 +375,19 @@ pub static SPEC: HandSpec = HandSpec {
 /// URL is required — LLM Proxy has no default host — and resolved here, so a changed
 /// one takes effect on the next build and a value the shared reader refuses is a
 /// [`ProviderError::Local`] naming the setting, not a panic mid-fetch.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(LLMProxy::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(LLMProxy::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One LLM Proxy deployment: the key, and the `/v1/quota-stats` URL it is polled at.
 pub struct LLMProxy {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     url: String,
@@ -382,12 +397,21 @@ impl LLMProxy {
     /// Builds a client. The URL is resolved once, here, because a setting that changed
     /// the host would otherwise take effect only on the next daemon restart.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         // `required` proved a value exists and `base_url` the HTTPS-or-loopback rule on
         // it, the same two checks a catalogued spec's build makes; both name the setting
         // when they refuse.
         let raw = required(options, BASE_URL, "Base URL")?;
         let base = base_url(&Options::from([(BASE_URL.to_owned(), raw)]), BASE_URL, "")?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             url: quota_stats_url(&base),
@@ -415,7 +439,7 @@ impl LLMProxy {
             return Err(ProviderError::Credential { status: 401 });
         }
         let body = super::request(PROVIDER_ID, &self.client, self.quota_stats_request()?).await?;
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 }
 
@@ -436,7 +460,7 @@ impl Provider for LLMProxy {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -725,7 +749,11 @@ mod tests {
         // state. The daemon's factory calls this same `build`, so proving it here is
         // proving the daemon cannot panic on these inputs.
         for bad in ["http://remote.host", "myproxy.example.com"] {
-            let Err(error) = build(Credential::new("sk-test"), &options(bad)) else {
+            let Err(error) = build(
+                AccountId::default(),
+                Credential::new("sk-test"),
+                &options(bad),
+            ) else {
                 panic!("{bad} must refuse the build, not panic");
             };
             assert!(
@@ -744,7 +772,11 @@ mod tests {
     fn an_unset_base_url_names_itself_rather_than_malforming_the_url() {
         // Without this refusal the user would see "Unreachable: relative URL without a
         // base" on every poll, with nothing pointing at the settings field that fixes it.
-        let Err(error) = build(Credential::new("sk-test"), &Options::new()) else {
+        let Err(error) = build(
+            AccountId::default(),
+            Credential::new("sk-test"),
+            &Options::new(),
+        ) else {
             panic!("the required option is unset, so the build must refuse")
         };
         assert!(
@@ -752,7 +784,11 @@ mod tests {
                 if message == "Base URL is not set for this account"),
             "{error}"
         );
-        let Err(blank) = build(Credential::new("sk-test"), &options("  ")) else {
+        let Err(blank) = build(
+            AccountId::default(),
+            Credential::new("sk-test"),
+            &options("  "),
+        ) else {
             panic!("a blank value is an unset value, so the build must refuse")
         };
         assert!(

--- a/crates/tidemark-core/src/providers/keyed/longcat.rs
+++ b/crates/tidemark-core/src/providers/keyed/longcat.rs
@@ -46,12 +46,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(LongCat::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(LongCat::new_for_account(account, options)?))
 }
 
 /// One LongCat account, authenticated by one explicitly chosen browser profile.
 pub struct LongCat {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -62,7 +67,12 @@ pub struct LongCat {
 
 impl LongCat {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -79,6 +89,7 @@ impl LongCat {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -197,12 +208,13 @@ impl LongCat {
         .ok()
         .and_then(|body| data_object(&body, "pending fuel").ok());
 
-        parse(
+        parse_for_account(
             Some(&account),
             packs.as_ref(),
             usage.as_ref(),
             fuel.as_ref(),
             Timestamp::now(),
+            &self.tidemark_account,
         )
     }
 
@@ -254,7 +266,7 @@ impl Provider for LongCat {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -410,6 +422,24 @@ pub fn parse(
     pending_fuel: Option<&Map<String, Value>>,
     captured_at: Timestamp,
 ) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        account,
+        token_pack_summary,
+        token_usage,
+        pending_fuel,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    account: Option<&Map<String, Value>>,
+    token_pack_summary: Option<&Map<String, Value>>,
+    token_usage: Option<&Map<String, Value>>,
+    pending_fuel: Option<&Map<String, Value>>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     // A quota the wire recognises but does not fully describe — an active lot without its
     // consumption, a usage without its used or remaining tokens — fails the fetch rather
     // than drawing zero, because "nothing spent" and "nothing said" are different answers.
@@ -526,7 +556,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/manus.rs
+++ b/crates/tidemark-core/src/providers/keyed/manus.rs
@@ -39,12 +39,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Manus::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Manus::new_for_account(account, options)?))
 }
 
 /// One Manus account, authenticated by one explicitly chosen browser profile.
 pub struct Manus {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -55,7 +60,12 @@ pub struct Manus {
 
 impl Manus {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -72,6 +82,7 @@ impl Manus {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -126,7 +137,7 @@ impl Manus {
             self.request(&self.credits_url(), &session.session_value)?,
         )
         .await?;
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -178,7 +189,7 @@ impl Provider for Manus {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -215,6 +226,14 @@ struct Credits {
 
 /// Turns Manus's credit inventory into the stated monthly credit pool.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let root: Value = serde_json::from_str(body)
         .map_err(|error| ProviderError::malformed(format!("not Manus credits: {error}")))?;
     let object = root
@@ -304,7 +323,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![DetailSection {

--- a/crates/tidemark-core/src/providers/keyed/mimo.rs
+++ b/crates/tidemark-core/src/providers/keyed/mimo.rs
@@ -53,12 +53,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(MiMo::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(MiMo::new_for_account(account, options)?))
 }
 
 /// One MiMo account, authenticated by one explicitly chosen browser profile.
 pub struct MiMo {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -69,7 +74,12 @@ pub struct MiMo {
 
 impl MiMo {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -86,6 +96,7 @@ impl MiMo {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -151,11 +162,12 @@ impl MiMo {
                 self.api_request(&self.url(PLAN_USAGE_URL), &session.header)?,
             ),
         );
-        parse(
+        parse_for_account(
             &balance?,
             detail.ok().as_deref(),
             usage.ok().as_deref(),
             Timestamp::now(),
+            &self.tidemark_account,
         )
     }
 
@@ -207,7 +219,7 @@ impl Provider for MiMo {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -315,6 +327,22 @@ pub fn parse(
     plan_usage_body: Option<&str>,
     captured_at: Timestamp,
 ) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        balance_body,
+        plan_detail_body,
+        plan_usage_body,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    balance_body: &str,
+    plan_detail_body: Option<&str>,
+    plan_usage_body: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let balance = parse_balance(balance_body)?;
     let detail = plan_detail_body.and_then(parse_plan_detail);
     let usage = plan_usage_body.and_then(parse_plan_usage);
@@ -359,7 +387,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/minimax.rs
+++ b/crates/tidemark-core/src/providers/keyed/minimax.rs
@@ -379,6 +379,14 @@ fn window_of(quota: &Quota<'_>, captured_at: Timestamp) -> Result<Option<Window>
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -503,7 +511,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: if rows.is_empty() {
@@ -528,7 +536,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "MiniMax platform → Coding Plan → API key (sk-cp-…).",
     options: &[OptionSchema {
         name: REGION,

--- a/crates/tidemark-core/src/providers/keyed/mistral.rs
+++ b/crates/tidemark-core/src/providers/keyed/mistral.rs
@@ -55,12 +55,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Mistral::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Mistral::new_for_account(account, options)?))
 }
 
 /// One Mistral account, authenticated by one explicitly chosen browser profile.
 pub struct Mistral {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -71,7 +76,12 @@ pub struct Mistral {
 
 impl Mistral {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -88,6 +98,7 @@ impl Mistral {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -199,7 +210,13 @@ impl Mistral {
             None
         };
 
-        parse(usage, credits, vibe, Timestamp::now())
+        parse_for_account(
+            usage,
+            credits,
+            vibe,
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -243,7 +260,7 @@ impl Provider for Mistral {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -339,6 +356,16 @@ pub fn parse(
     vibe: Option<Vibe>,
     captured_at: Timestamp,
 ) -> Result<Snapshot, ProviderError> {
+    parse_for_account(usage, credits, vibe, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    usage: Usage,
+    credits: Option<Credits>,
+    vibe: Option<Vibe>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let mut windows = Vec::new();
     if let Some(vibe) = vibe {
         let length = WindowLength::from_secs(MONTHLY).expect("a fixed span is not zero");
@@ -405,7 +432,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -171,8 +171,8 @@ pub struct Spec {
     pub auth: Auth,
     /// Headers beyond auth and the shared user agent.
     pub headers: &'static [(&'static str, &'static str)],
-    /// Turns a response body into a snapshot. Pure by construction.
-    pub parse: fn(&str, Timestamp) -> Result<Snapshot, ProviderError>,
+    /// Turns a response body into a snapshot for the account being polled.
+    pub parse: fn(&str, Timestamp, &AccountId) -> Result<Snapshot, ProviderError>,
     /// One sentence saying which page the key is on.
     pub credential_hint: &'static str,
     /// What the user may choose.
@@ -182,7 +182,7 @@ pub struct Spec {
 /// Builds a pollable client from the stored key and the account's settings: what a
 /// [`HandSpec`] hands the registry so the daemon can construct the provider the same way
 /// it constructs a [`Keyed`].
-pub type Builder = fn(Credential, &Options) -> Result<Arc<dyn Provider>, ProviderError>;
+pub type Builder = fn(AccountId, Credential, &Options) -> Result<Arc<dyn Provider>, ProviderError>;
 
 /// Everything a hand-written key-authenticated provider publishes about itself: the parts
 /// of a [`Spec`] that are not about one request, and how to build a pollable client from
@@ -297,7 +297,7 @@ impl Keyed {
             return Err(ProviderError::Credential { status: 401 });
         }
         let body = request(self.spec.id, &self.client, self.build_request()?).await?;
-        (self.spec.parse)(&body, Timestamp::now())
+        (self.spec.parse)(&body, Timestamp::now(), &self.account)
     }
 }
 
@@ -590,7 +590,11 @@ mod tests {
         }
     }
 
-    fn parse_ok(_body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    fn parse_ok(
+        _body: &str,
+        captured_at: Timestamp,
+        _account: &AccountId,
+    ) -> Result<Snapshot, ProviderError> {
         Ok(snapshot_of("test", captured_at))
     }
 

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -226,6 +226,7 @@ pub struct Keyed {
     client: reqwest::Client,
     credential: Credential,
     url: String,
+    account: AccountId,
 }
 
 impl Keyed {
@@ -236,6 +237,7 @@ impl Keyed {
     /// what is missing instead of the `Unreachable` a malformed URL would produce on
     /// every poll.
     pub fn new(
+        account: AccountId,
         spec: &'static Spec,
         credential: Credential,
         options: &Options,
@@ -257,6 +259,7 @@ impl Keyed {
             client: http::client()?,
             credential,
             url: (spec.endpoint)(options),
+            account,
         })
     }
 
@@ -530,7 +533,7 @@ impl Provider for Keyed {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -684,7 +687,13 @@ mod tests {
 
     #[test]
     fn a_bearer_key_goes_in_the_authorization_header() {
-        let keyed = Keyed::new(&BEARER, Credential::new("sk-1"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &BEARER,
+            Credential::new("sk-1"),
+            &options(&[]),
+        )
+        .expect("builds");
         let request = keyed.build_request().expect("builds");
         assert_eq!(
             request
@@ -702,7 +711,13 @@ mod tests {
 
     #[test]
     fn a_header_key_goes_in_the_header_the_spec_names() {
-        let keyed = Keyed::new(&HEADER, Credential::new("sk-2"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &HEADER,
+            Credential::new("sk-2"),
+            &options(&[]),
+        )
+        .expect("builds");
         let request = keyed.build_request().expect("builds");
         assert_eq!(request.headers().get("x-api-key").expect("present"), "sk-2");
         assert!(
@@ -716,7 +731,13 @@ mod tests {
 
     #[test]
     fn a_query_key_goes_in_the_query_string_and_is_escaped() {
-        let keyed = Keyed::new(&QUERY, Credential::new("a b&c"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &QUERY,
+            Credential::new("a b&c"),
+            &options(&[]),
+        )
+        .expect("builds");
         let request = keyed.build_request().expect("builds");
         assert_eq!(request.url().query_pairs().count(), 1);
         assert_eq!(
@@ -732,7 +753,13 @@ mod tests {
 
     #[test]
     fn a_posting_spec_sends_its_body_and_content_type() {
-        let keyed = Keyed::new(&POSTING, Credential::new("sk-3"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &POSTING,
+            Credential::new("sk-3"),
+            &options(&[]),
+        )
+        .expect("builds");
         let request = keyed.build_request().expect("builds");
         assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
@@ -752,8 +779,15 @@ mod tests {
 
     #[test]
     fn the_endpoint_reads_the_accounts_options() {
-        let global = Keyed::new(&REGIONAL, Credential::new("sk-4"), &options(&[])).expect("builds");
+        let global = Keyed::new(
+            AccountId::default(),
+            &REGIONAL,
+            Credential::new("sk-4"),
+            &options(&[]),
+        )
+        .expect("builds");
         let cn = Keyed::new(
+            AccountId::default(),
             &REGIONAL,
             Credential::new("sk-4"),
             &options(&[("region", "cn")]),
@@ -770,8 +804,13 @@ mod tests {
         // mechanism's own guard: without it a future spec with no default host would say
         // "Unreachable: relative URL without a base" on every poll, with nothing pointing
         // at the settings field that fixes it.
-        let error = Keyed::new(&SELF_HOSTED, Credential::new("sk-6"), &options(&[]))
-            .expect_err("the required option is unset");
+        let error = Keyed::new(
+            AccountId::default(),
+            &SELF_HOSTED,
+            Credential::new("sk-6"),
+            &options(&[]),
+        )
+        .expect_err("the required option is unset");
         assert!(
             matches!(error, ProviderError::Local(ref message)
                 if message == "Base URL is not set for this account"),
@@ -779,6 +818,7 @@ mod tests {
         );
 
         let blank = Keyed::new(
+            AccountId::default(),
             &SELF_HOSTED,
             Credential::new("sk-6"),
             &options(&[("base_url", "  ")]),
@@ -790,6 +830,7 @@ mod tests {
         );
 
         let set = Keyed::new(
+            AccountId::default(),
             &SELF_HOSTED,
             Credential::new("sk-6"),
             &options(&[("base_url", "https://self.example.invalid/")]),
@@ -837,7 +878,13 @@ mod tests {
 
     #[tokio::test]
     async fn a_blank_credential_is_refused_before_a_request_is_spent() {
-        let keyed = Keyed::new(&BEARER, Credential::new("   "), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &BEARER,
+            Credential::new("   "),
+            &options(&[]),
+        )
+        .expect("builds");
         assert!(matches!(
             keyed.fetch().await,
             Err(ProviderError::Credential { status: 401 })
@@ -862,6 +909,7 @@ mod tests {
             options: &[],
         };
         let keyed = Keyed::new(
+            AccountId::default(),
             &QUERY_LEAK,
             Credential::new("sk-query-secret"),
             &options(&[]),
@@ -877,15 +925,26 @@ mod tests {
 
     #[test]
     fn the_client_reports_the_specs_identity() {
-        let keyed = Keyed::new(&BEARER, Credential::new("sk-5"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &BEARER,
+            Credential::new("sk-5"),
+            &options(&[]),
+        )
+        .expect("builds");
         assert_eq!(keyed.id(), ProviderId::new("test"));
         assert_eq!(keyed.account(), AccountId::default());
     }
 
     #[test]
     fn a_keyed_client_never_prints_its_credential() {
-        let keyed =
-            Keyed::new(&BEARER, Credential::new("sk-super-secret"), &options(&[])).expect("builds");
+        let keyed = Keyed::new(
+            AccountId::default(),
+            &BEARER,
+            Credential::new("sk-super-secret"),
+            &options(&[]),
+        )
+        .expect("builds");
         let rendered = format!("{keyed:?}");
         assert!(!rendered.contains("super-secret"), "{rendered}");
     }

--- a/crates/tidemark-core/src/providers/keyed/moonshot.rs
+++ b/crates/tidemark-core/src/providers/keyed/moonshot.rs
@@ -111,6 +111,14 @@ fn dollars(amount: f64) -> String {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -160,7 +168,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         // No limit was reported, so there is no share to draw. See the module doc.
         windows: Vec::new(),
@@ -182,7 +190,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Moonshot console → API keys, on whichever region your account is on.",
     options: &[OptionSchema {
         name: REGION,

--- a/crates/tidemark-core/src/providers/keyed/nanogpt.rs
+++ b/crates/tidemark-core/src/providers/keyed/nanogpt.rs
@@ -62,18 +62,31 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(NanoGpt::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(NanoGpt::new_for_account(account, credential)?))
 }
 
 pub struct NanoGpt {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
 
 impl NanoGpt {
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -107,7 +120,12 @@ impl NanoGpt {
             super::request(PROVIDER_ID, &self.client, subscription_request),
             super::request(PROVIDER_ID, &self.client, balance_request),
         );
-        parse(&subscription?, &balance?, Timestamp::now())
+        parse_for_account(
+            &subscription?,
+            &balance?,
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 }
 
@@ -125,7 +143,7 @@ impl Provider for NanoGpt {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -288,10 +306,25 @@ fn window(
     })
 }
 
+#[cfg(test)]
 fn parse(
     subscription_body: &str,
     balance_body: &str,
     captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        subscription_body,
+        balance_body,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    subscription_body: &str,
+    balance_body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let usage: serde_json::Map<String, serde_json::Value> = serde_json::from_str(subscription_body)
         .map_err(|e| ProviderError::malformed(format!("unreadable subscription usage: {e}")))?;
@@ -357,7 +390,7 @@ fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![DetailSection {
@@ -384,7 +417,7 @@ fn parse(
 mod tests {
     use super::{NanoGpt, Options, SPEC, parse};
     use crate::providers::Credential;
-    use tidemark_types::{CredentialKind, DetailSection, Timestamp};
+    use tidemark_types::{AccountId, CredentialKind, DetailSection, Timestamp};
 
     /// A recorded `GET /api/subscription/v1/usage` response. This is the shape the live API
     /// actually returns: one object per metered pool, named for its period, with the pools
@@ -624,8 +657,12 @@ mod tests {
         assert_eq!(SPEC.credential, CredentialKind::Key);
         assert!(SPEC.options.is_empty());
 
-        let provider =
-            (SPEC.build)(Credential::new("not-a-real-key"), &Options::new()).expect("builds");
+        let provider = (SPEC.build)(
+            AccountId::default(),
+            Credential::new("not-a-real-key"),
+            &Options::new(),
+        )
+        .expect("builds");
         assert_eq!(provider.id().as_str(), "nanogpt");
     }
 

--- a/crates/tidemark-core/src/providers/keyed/neuralwatt.rs
+++ b/crates/tidemark-core/src/providers/keyed/neuralwatt.rs
@@ -240,6 +240,14 @@ fn day_of(at: Timestamp) -> String {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -414,7 +422,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -439,7 +447,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Neuralwatt portal → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/notion.rs
+++ b/crates/tidemark-core/src/providers/keyed/notion.rs
@@ -85,12 +85,17 @@ static OPTIONS: &[OptionSchema] = &[
     },
 ];
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Notion::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Notion::new_for_account(account, options)?))
 }
 
 /// One Notion account, authenticated by one explicitly chosen browser profile.
 pub struct Notion {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -102,7 +107,12 @@ pub struct Notion {
 
 impl Notion {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -125,6 +135,7 @@ impl Notion {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -194,11 +205,12 @@ impl Notion {
             self.request(&self.status_url(), &session.header, body)?,
         )
         .await?;
-        parse(
+        parse_for_account(
             &spaces,
             &status,
             self.workspace.as_deref(),
             Timestamp::now(),
+            &self.tidemark_account,
         )
     }
 
@@ -242,7 +254,7 @@ impl Provider for Notion {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -306,6 +318,22 @@ pub fn parse(
     status_body: &str,
     preferred: Option<&str>,
     captured_at: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    parse_for_account(
+        spaces_body,
+        status_body,
+        preferred,
+        captured_at,
+        &AccountId::default(),
+    )
+}
+
+fn parse_for_account(
+    spaces_body: &str,
+    status_body: &str,
+    preferred: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let account = parse_spaces(spaces_body)?;
     let workspace = resolve_workspace(&account, preferred)?;
@@ -427,7 +455,7 @@ pub fn parse(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/ollama.rs
+++ b/crates/tidemark-core/src/providers/keyed/ollama.rs
@@ -55,12 +55,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Ollama::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Ollama::new_for_account(account, options)?))
 }
 
 /// One Ollama account, authenticated by one explicitly chosen browser profile.
 pub struct Ollama {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -71,7 +76,12 @@ pub struct Ollama {
 
 impl Ollama {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -88,6 +98,7 @@ impl Ollama {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -152,7 +163,7 @@ impl Ollama {
         if is_signin_redirect(&landed_on, &self.site_host()) {
             return Err(ProviderError::Credential { status: 401 });
         }
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -205,7 +216,7 @@ impl Provider for Ollama {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -240,6 +251,14 @@ fn is_signin_redirect(url: &reqwest::Url, site_host: &str) -> bool {
 /// The page's meters as a snapshot: the session (or hourly) window, the weekly window,
 /// and the plan and account rows the page happens to carry.
 pub fn parse(html: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(html, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    html: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     if looks_signed_out(html) {
         // The page the site serves a signed-out visitor: the session is gone, not broken.
         return Err(ProviderError::Credential { status: 401 });
@@ -276,7 +295,7 @@ pub fn parse(html: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
     }
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/openai-api.rs
+++ b/crates/tidemark-core/src/providers/keyed/openai-api.rs
@@ -133,13 +133,20 @@ pub static SPEC: HandSpec = HandSpec {
 
 /// Builds a pollable client from the stored key and the account's settings. The project
 /// filter is resolved here so a changed one takes effect on the next build.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(OpenAiApi::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(OpenAiApi::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One OpenAI account: the Admin key, the project it is scoped to, and the three
 /// endpoints the card can come from.
 pub struct OpenAiApi {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     /// Trimmed and quote-stripped, exactly as CodexBar's `cleaned` reads it; `None` for
@@ -153,7 +160,16 @@ impl OpenAiApi {
     /// Builds a client. The project and the fallback gate are settings, resolved once
     /// here.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             project: cleaned(options.get(PROJECT)),
@@ -238,7 +254,11 @@ impl OpenAiApi {
     async fn balance(&self, now: Timestamp) -> Result<Snapshot, ProviderError> {
         let body = super::request(PROVIDER_ID, &self.client, self.credit_request()?).await?;
         let grants = parse_credit_grants(&body, now)?;
-        Ok(balance_snapshot(&grants, now))
+        Ok(balance_snapshot_for_account(
+            &grants,
+            now,
+            &self.tidemark_account,
+        ))
     }
 
     /// Walks both endpoints over the whole history window.
@@ -250,7 +270,7 @@ impl OpenAiApi {
         let completions = self
             .pages(COMPLETIONS_URL, "model", &ranges, parse_completions_page)
             .await?;
-        snapshot(&costs, &completions, now)
+        snapshot_for_account(&costs, &completions, now, &self.tidemark_account)
     }
 
     /// Every page of one endpoint: each 31-day range in turn, each following its cursor
@@ -308,7 +328,7 @@ impl Provider for OpenAiApi {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -650,10 +670,20 @@ fn daily_ranges(now: Timestamp, days: i64) -> Vec<DayRange> {
 /// No window, ever: the Admin usage endpoints report spend with no limit to draw a bar
 /// against, and the shape for that is details only — the card renders empty, which is
 /// accepted.
+#[cfg(test)]
 fn snapshot(
     costs: &[CostBucket],
     completions: &[UsageBucket],
     now: Timestamp,
+) -> Result<Snapshot, ProviderError> {
+    snapshot_for_account(costs, completions, now, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    costs: &[CostBucket],
+    completions: &[UsageBucket],
+    now: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let days = summarise(costs, completions, now)?;
     let totals = days.iter().fold(
@@ -719,7 +749,7 @@ fn snapshot(
     }
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: Vec::new(),
         details,
@@ -805,7 +835,16 @@ fn summarise(
 /// The credit-grants fallback as a card: one fixed balance — spend against the grant —
 /// keyed `balance` because a grant budget has no length to key on, resetless or reset at
 /// the next grant's expiry.
+#[cfg(test)]
 fn balance_snapshot(grants: &CreditGrants, now: Timestamp) -> Snapshot {
+    balance_snapshot_for_account(grants, now, &AccountId::default())
+}
+
+fn balance_snapshot_for_account(
+    grants: &CreditGrants,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     // The plugin's own degenerate cases: no grant to measure against means 0% when
     // something is still available and 100% when nothing is.
     let used_percent = if grants.total_granted > 0.0 {
@@ -817,7 +856,7 @@ fn balance_snapshot(grants: &CreditGrants, now: Timestamp) -> Snapshot {
     };
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: vec![Window {
             key: WindowKey::named("balance"),
@@ -1630,7 +1669,14 @@ mod tests {
         assert_eq!(SPEC.title, "OpenAI");
         assert_eq!(SPEC.options.len(), 2);
         assert!(SPEC.options.iter().all(|option| !option.required));
-        assert!(build(Credential::new("sk-test"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("sk-test"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/opencode.rs
+++ b/crates/tidemark-core/src/providers/keyed/opencode.rs
@@ -63,12 +63,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(OpenCode::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(OpenCode::new_for_account(account, options)?))
 }
 
 /// One OpenCode account, authenticated by one explicitly chosen browser profile.
 pub struct OpenCode {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -79,7 +84,12 @@ pub struct OpenCode {
 
 impl OpenCode {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -96,6 +106,7 @@ impl OpenCode {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -192,7 +203,9 @@ impl OpenCode {
         // A null answer is a workspace without a subscription: the POST spelling answers
         // those with a 500, so it is not worth trying.
         if !is_null_payload(&text) {
-            if let Some(snapshot) = parse_subscription(&text, now) {
+            if let Some(snapshot) =
+                parse_subscription_for_account(&text, now, &self.tidemark_account)
+            {
                 return Ok(snapshot);
             }
             // The GET spelling sometimes answers a shell; the POST carries the data.
@@ -203,7 +216,8 @@ impl OpenCode {
                 return Err(ProviderError::Credential { status: 401 });
             }
             if !is_null_payload(&fallback)
-                && let Some(snapshot) = parse_subscription(&fallback, now)
+                && let Some(snapshot) =
+                    parse_subscription_for_account(&fallback, now, &self.tidemark_account)
             {
                 return Ok(snapshot);
             }
@@ -235,7 +249,11 @@ impl OpenCode {
             // honest reading.
             return Ok(None);
         }
-        Ok(Some(payg_snapshot(billing, now)))
+        Ok(Some(payg_snapshot_for_account(
+            billing,
+            now,
+            &self.tidemark_account,
+        )))
     }
 
     async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {
@@ -306,7 +324,7 @@ impl Provider for OpenCode {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -516,7 +534,16 @@ fn seeded_number(text: &str, label: &str, field: &str) -> Option<f64> {
 /// The subscription answer as a snapshot: JSON first — the same shapes and rules the
 /// Zen reader already pins — then the seeded script's numbers. `None` when neither
 /// dialect carries the two windows.
+#[cfg(test)]
 fn parse_subscription(text: &str, now: Timestamp) -> Option<Snapshot> {
+    parse_subscription_for_account(text, now, &AccountId::default())
+}
+
+fn parse_subscription_for_account(
+    text: &str,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Option<Snapshot> {
     if let Ok(mut snapshot) = super::opencodego::parse(text, now) {
         snapshot.provider = ProviderId::new(PROVIDER_ID);
         return Some(snapshot);
@@ -539,7 +566,7 @@ fn parse_subscription(text: &str, now: Timestamp) -> Option<Snapshot> {
     ];
     Some(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows,
         details: Vec::new(),
@@ -660,7 +687,11 @@ fn field_value<'a>(text: &'a str, field: &str) -> Option<&'a str> {
 
 /// The pay-as-you-go month as a snapshot: a window when a limit is configured, and the
 /// balance rows the payload carries.
-fn payg_snapshot(billing: Billing, captured_at: Timestamp) -> Snapshot {
+fn payg_snapshot_for_account(
+    billing: Billing,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let mut windows = Vec::new();
     if let Some(limit) = billing.monthly_limit.filter(|limit| *limit > 0.0) {
         windows.push(window(
@@ -688,7 +719,7 @@ fn payg_snapshot(billing: Billing, captured_at: Timestamp) -> Snapshot {
     }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![DetailSection {

--- a/crates/tidemark-core/src/providers/keyed/opencodego.rs
+++ b/crates/tidemark-core/src/providers/keyed/opencodego.rs
@@ -242,6 +242,14 @@ fn window_of(
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let root: Value = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     let root = root
@@ -286,7 +294,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -314,7 +322,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "opencode.ai → Zen → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/openrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/openrouter.rs
@@ -86,12 +86,19 @@ pub static SPEC: HandSpec = HandSpec {
 
 /// Builds a pollable client from the stored key and the account's settings. The URLs
 /// are resolved here, so a changed base URL takes effect on the next build.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(OpenRouter::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(OpenRouter::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One OpenRouter account: the key, and the two endpoints it unlocks.
 pub struct OpenRouter {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     credits_url: String,
@@ -102,8 +109,17 @@ impl OpenRouter {
     /// Builds a client. The base URL is resolved once, here, because a setting that
     /// changed the host would otherwise take effect only on the next daemon restart.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let base = base_url(options, BASE_URL, DEFAULT_BASE_URL)?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             credits_url: format!("{base}/credits"),
@@ -149,7 +165,12 @@ impl OpenRouter {
             &super::request(PROVIDER_ID, &self.client, self.credits_request()?).await?,
         )?;
         let key = self.key_state().await;
-        Ok(snapshot(&credits, &key, now))
+        Ok(snapshot_for_account(
+            &credits,
+            &key,
+            now,
+            &self.tidemark_account,
+        ))
     }
 
     /// The optional `/key` request. It never fails the fetch: a failure — transport,
@@ -188,7 +209,7 @@ impl Provider for OpenRouter {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -393,7 +414,17 @@ fn used_for_quota(data: &KeyData, limit: f64) -> Option<Option<f64>> {
 }
 
 /// Assembles the snapshot. Pure, so every recorded key body is reachable from a test.
+#[cfg(test)]
 fn snapshot(credits: &Credits, key: &KeyState, captured_at: Timestamp) -> Snapshot {
+    snapshot_for_account(credits, key, captured_at, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    credits: &Credits,
+    key: &KeyState,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     let budget = match key {
         KeyState::Data(data) => Budget::of(data),
         KeyState::Degraded(_) => None,
@@ -406,7 +437,7 @@ fn snapshot(credits: &Credits, key: &KeyState, captured_at: Timestamp) -> Snapsh
     }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![credits_details(credits), key_details(key, budget.as_ref())],
@@ -813,7 +844,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "OpenRouter");
         assert_eq!(SPEC.options.len(), 1);
-        assert!(build(Credential::new("sk-or"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("sk-or"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/perplexity.rs
+++ b/crates/tidemark-core/src/providers/keyed/perplexity.rs
@@ -43,12 +43,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Perplexity::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Perplexity::new_for_account(account, options)?))
 }
 
 /// One Perplexity account, authenticated by one explicitly chosen browser profile.
 pub struct Perplexity {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -59,7 +64,12 @@ pub struct Perplexity {
 
 impl Perplexity {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -76,6 +86,7 @@ impl Perplexity {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -124,7 +135,7 @@ impl Perplexity {
             self.request(&self.credits_url(), &session.header)?,
         )
         .await?;
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -167,7 +178,7 @@ impl Provider for Perplexity {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -203,6 +214,14 @@ struct Grant {
 
 /// Turns Perplexity's credits response into its billing-cycle and promotional windows.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let credits: Credits = serde_json::from_str(body)
         .map_err(|error| ProviderError::malformed(format!("not Perplexity credits: {error}")))?;
     let cents = [
@@ -296,7 +315,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: vec![DetailSection {

--- a/crates/tidemark-core/src/providers/keyed/poe.rs
+++ b/crates/tidemark-core/src/providers/keyed/poe.rs
@@ -69,12 +69,17 @@ pub static SPEC: HandSpec = HandSpec {
 };
 
 /// Builds a pollable client from the stored key. Poe has nothing to configure.
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Poe::new(credential)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Poe::new_for_account(account, credential)?))
 }
 
 /// One Poe account: the key, and the two endpoints it unlocks.
 pub struct Poe {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
 }
@@ -83,7 +88,15 @@ impl Poe {
     /// Builds a client. Poe has one host, so the URLs are constants and there is nothing
     /// to resolve at build time.
     pub fn new(credential: Credential) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+    ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
         })
@@ -120,7 +133,12 @@ impl Poe {
         let body = super::request(PROVIDER_ID, &self.client, self.balance_request()?).await?;
         let balance = parse_balance(&body)?;
         let history = self.history(now).await;
-        Ok(snapshot(balance, &history, now))
+        Ok(snapshot_for_account(
+            balance,
+            &history,
+            now,
+            &self.tidemark_account,
+        ))
     }
 
     /// Walks the history pages, keeping what lands inside the cutoff. Any failure —
@@ -185,7 +203,7 @@ impl Provider for Poe {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -394,10 +412,20 @@ fn epoch(value: f64) -> Option<Timestamp> {
 ///
 /// No window, ever: a points balance has no limit to draw a bar against, and the task's
 /// shape for that is details only — the card renders empty, which is accepted.
+#[cfg(test)]
 fn snapshot(balance: Option<f64>, history: &History, now: Timestamp) -> Snapshot {
+    snapshot_for_account(balance, history, now, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    balance: Option<f64>,
+    history: &History,
+    now: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at: now,
         windows: Vec::new(),
         details: points_details(balance, history, now),
@@ -808,7 +836,14 @@ mod tests {
         assert_eq!(SPEC.id, PROVIDER_ID);
         assert_eq!(SPEC.title, "Poe");
         assert!(SPEC.options.is_empty(), "Poe has nothing to choose");
-        assert!(build(Credential::new("poe-key"), &Options::new()).is_ok());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("poe-key"),
+                &Options::new()
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/qoder.rs
+++ b/crates/tidemark-core/src/providers/keyed/qoder.rs
@@ -36,12 +36,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Qoder::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Qoder::new_for_account(account, options)?))
 }
 
 /// One Qoder account, authenticated by one explicitly chosen browser profile.
 pub struct Qoder {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -52,7 +57,12 @@ pub struct Qoder {
 
 impl Qoder {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -70,6 +80,7 @@ impl Qoder {
         china: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -149,7 +160,7 @@ impl Qoder {
             Err(ProviderError::NoCredential) => self.fetch_china().await?,
             Err(error) => return Err(error),
         };
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 
     async fn fetch_china(&self) -> Result<String, ProviderError> {
@@ -277,7 +288,7 @@ impl Provider for Qoder {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -295,6 +306,14 @@ fn cookie_query() -> browser::Query {
 
 /// Turns Qoder's recorded dashboard response into distinct total and shared credit pools.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let root: Value = serde_json::from_str(body)
         .map_err(|error| ProviderError::malformed(format!("not Qoder usage: {error}")))?;
     let object = root
@@ -311,7 +330,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
     }
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details: Vec::new(),

--- a/crates/tidemark-core/src/providers/keyed/sakana.rs
+++ b/crates/tidemark-core/src/providers/keyed/sakana.rs
@@ -45,13 +45,18 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Sakana::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Sakana::new_for_account(account, options)?))
 }
 
 /// One Sakana account, authenticated by one explicitly chosen browser profile. The gate
 /// is the whole jar: the console's session cookie has no name worth pinning.
 pub struct Sakana {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -62,7 +67,12 @@ pub struct Sakana {
 
 impl Sakana {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -79,6 +89,7 @@ impl Sakana {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -151,7 +162,12 @@ impl Sakana {
         )
         .await
         .ok();
-        parse(&body, payg.as_deref(), Timestamp::now())
+        parse_for_account(
+            &body,
+            payg.as_deref(),
+            Timestamp::now(),
+            &self.tidemark_account,
+        )
     }
 
     async fn validate_header(&self, header: &str) -> crate::browser::auth::Validation {
@@ -204,7 +220,7 @@ impl Provider for Sakana {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -272,6 +288,15 @@ pub fn parse(
     payg_html: Option<&str>,
     captured_at: Timestamp,
 ) -> Result<Snapshot, ProviderError> {
+    parse_for_account(html, payg_html, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    html: &str,
+    payg_html: Option<&str>,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let billing = parse_billing(html)?;
     let payg = payg_html.and_then(parse_payg);
 
@@ -316,7 +341,7 @@ pub fn parse(
     }
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/stepfun.rs
+++ b/crates/tidemark-core/src/providers/keyed/stepfun.rs
@@ -61,8 +61,15 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(credential: Credential, _options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(StepFun::new(credential.expose())?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    _options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(StepFun::new_for_account(
+        account,
+        credential.expose(),
+    )?))
 }
 
 /// The token a pasted value holds: trimmed, and a pasted cookie header reduced to its
@@ -99,6 +106,7 @@ fn device_id(token: &str) -> Option<String> {
 
 /// One Oasis-Token, bound to the device the token's own payload names.
 pub struct StepFun {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     /// The platform host, kept as a field so a test can point it at a loopback.
     base: String,
@@ -107,17 +115,21 @@ pub struct StepFun {
 }
 
 impl StepFun {
-    /// Builds the account against the real platform.
+    /// Builds the default account against the real platform.
     pub fn new(raw: &str) -> Result<Self, ProviderError> {
-        Self::with_base(BASE, raw)
+        Self::new_for_account(AccountId::default(), raw)
+    }
+
+    fn new_for_account(account_id: AccountId, raw: &str) -> Result<Self, ProviderError> {
+        Self::with_base(account_id, BASE, raw)
     }
 
     #[cfg(test)]
     fn for_test(base: &str, raw: &str) -> Result<Self, ProviderError> {
-        Self::with_base(base, raw)
+        Self::with_base(AccountId::default(), base, raw)
     }
 
-    fn with_base(base: &str, raw: &str) -> Result<Self, ProviderError> {
+    fn with_base(account_id: AccountId, base: &str, raw: &str) -> Result<Self, ProviderError> {
         let token = normalize_token(raw);
         if token.is_empty() {
             return Err(ProviderError::Local(
@@ -134,6 +146,7 @@ impl StepFun {
             ));
         };
         Ok(Self {
+            tidemark_account: account_id,
             client: super::http::client()?,
             base: base.trim_end_matches('/').to_owned(),
             token,
@@ -185,7 +198,7 @@ impl StepFun {
 
         Ok(Snapshot {
             provider: ProviderId::new(PROVIDER_ID),
-            account: AccountId::default(),
+            account: self.tidemark_account.clone(),
             captured_at: Timestamp::now(),
             windows,
             details,
@@ -207,7 +220,7 @@ impl Provider for StepFun {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -759,19 +772,28 @@ mod tests {
 
     #[test]
     fn a_token_whose_jwt_names_a_device_builds_and_one_without_is_refused() {
-        let error = (SPEC.build)(Credential::new("not a jwt at all"), &Options::new())
-            .expect_err("no device claim to bind");
+        let error = (SPEC.build)(
+            AccountId::default(),
+            Credential::new("not a jwt at all"),
+            &Options::new(),
+        )
+        .expect_err("no device claim to bind");
         assert!(
             matches!(error, ProviderError::Local(ref message) if message.contains("device_id")),
             "{error:?}"
         );
 
-        let error = (SPEC.build)(Credential::new("   "), &Options::new())
-            .expect_err("an empty paste is not a token");
+        let error = (SPEC.build)(
+            AccountId::default(),
+            Credential::new("   "),
+            &Options::new(),
+        )
+        .expect_err("an empty paste is not a token");
         assert!(matches!(error, ProviderError::Local(_)), "{error:?}");
 
         assert!(
             (SPEC.build)(
+                AccountId::default(),
                 Credential::new(jwt_with_device("device-7")),
                 &Options::new()
             )

--- a/crates/tidemark-core/src/providers/keyed/sub2api.rs
+++ b/crates/tidemark-core/src/providers/keyed/sub2api.rs
@@ -251,6 +251,14 @@ fn day_of(at: Timestamp) -> String {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let data: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -473,7 +481,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,
@@ -513,12 +521,19 @@ pub static SPEC: HandSpec = HandSpec {
 /// URL is required — sub2api has no default host — and resolved here, so a changed one
 /// takes effect on the next build and a value the shared reader refuses is a
 /// [`ProviderError::Local`] naming the setting, not a panic mid-fetch.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Sub2Api::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Sub2Api::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One sub2api deployment: the key, and the `/v1/usage` URL it is polled at.
 pub struct Sub2Api {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     url: String,
@@ -528,12 +543,21 @@ impl Sub2Api {
     /// Builds a client. The URL is resolved once, here, because a setting that changed
     /// the host would otherwise take effect only on the next daemon restart.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         // `required` proved a value exists and `base_url` the HTTPS-or-loopback rule on
         // it, the same two checks a catalogued spec's build makes; both name the setting
         // when they refuse.
         let raw = required(options, BASE_URL, "Base URL")?;
         let base = base_url(&Options::from([(BASE_URL.to_owned(), raw)]), BASE_URL, "")?;
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             url: usage_url(&base),
@@ -561,7 +585,7 @@ impl Sub2Api {
             return Err(ProviderError::Credential { status: 401 });
         }
         let body = super::request(PROVIDER_ID, &self.client, self.usage_request()?).await?;
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 }
 
@@ -582,7 +606,7 @@ impl Provider for Sub2Api {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -1084,7 +1108,11 @@ mod tests {
         // state. The daemon's factory calls this same `build`, so proving it here is
         // proving the daemon cannot panic on these inputs.
         for bad in ["http://remote.host", "myproxy.example.com"] {
-            let Err(error) = build(Credential::new("sk-test"), &options(bad)) else {
+            let Err(error) = build(
+                AccountId::default(),
+                Credential::new("sk-test"),
+                &options(bad),
+            ) else {
                 panic!("{bad} must refuse the build, not panic");
             };
             assert!(
@@ -1103,7 +1131,11 @@ mod tests {
     fn an_unset_base_url_names_itself_rather_than_malforming_the_url() {
         // Without this refusal the user would see "Unreachable: relative URL without a
         // base" on every poll, with nothing pointing at the settings field that fixes it.
-        let Err(error) = build(Credential::new("sk-test"), &Options::new()) else {
+        let Err(error) = build(
+            AccountId::default(),
+            Credential::new("sk-test"),
+            &Options::new(),
+        ) else {
             panic!("the required option is unset, so the build must refuse")
         };
         assert!(
@@ -1111,7 +1143,11 @@ mod tests {
                 if message == "Base URL is not set for this account"),
             "{error}"
         );
-        let Err(blank) = build(Credential::new("sk-test"), &options("  ")) else {
+        let Err(blank) = build(
+            AccountId::default(),
+            Credential::new("sk-test"),
+            &options("  "),
+        ) else {
             panic!("a blank value is an unset value, so the build must refuse")
         };
         assert!(

--- a/crates/tidemark-core/src/providers/keyed/synthetic.rs
+++ b/crates/tidemark-core/src/providers/keyed/synthetic.rs
@@ -179,6 +179,14 @@ const CONTAINER_KEYS: &[&str] = &[
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let json: Value = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     // An array root is a quotas list with the wrapper omitted.
@@ -334,7 +342,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -705,7 +713,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Synthetic dashboard → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/t3chat.rs
+++ b/crates/tidemark-core/src/providers/keyed/t3chat.rs
@@ -54,13 +54,18 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(T3Chat::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(T3Chat::new_for_account(account, options)?))
 }
 
 /// One T3 Chat account, authenticated by one explicitly chosen browser profile. The gate
 /// is the whole jar: the site's session cookie has no name worth pinning.
 pub struct T3Chat {
+    tidemark_account: AccountId,
     client: wreq::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -71,11 +76,16 @@ pub struct T3Chat {
 
 impl T3Chat {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         let selection = session::selection(options);
         let browser = selection
             .as_ref()
             .map_or("chrome", |selection| selection.browser.as_str());
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: Self::browser_client(browser)?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -92,6 +102,7 @@ impl T3Chat {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: Self::browser_client("firefox")?,
             home: Some(home.to_path_buf()),
             storage,
@@ -167,7 +178,7 @@ impl T3Chat {
         .ok_or(ProviderError::NoCredential)?;
         let request = self.data_request(&self.url(API_URL), &session.header)?;
         let body = self.send_inspected(request).await?;
-        parse(&body, Timestamp::now())
+        parse_for_account(&body, Timestamp::now(), &self.tidemark_account)
     }
 
     /// [`super::request_inspected`] on the emulating stack: the same `Retry-After` read,
@@ -289,7 +300,7 @@ impl Provider for T3Chat {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -367,6 +378,14 @@ struct CustomerData {
 /// and the plan row. A meter the response did not state stays away rather than reading
 /// zero; a response that states none of them is not an answer.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     for line in body.lines() {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
@@ -374,7 +393,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
         let Some(customer) = find_customer_data(&value) else {
             continue;
         };
-        return snapshot(customer, captured_at);
+        return snapshot_for_account(customer, captured_at, account_id);
     }
     Err(ProviderError::malformed(
         "the T3 Chat response named no customer data",
@@ -400,9 +419,10 @@ fn find_customer_data(value: &serde_json::Value) -> Option<&serde_json::Value> {
     }
 }
 
-fn snapshot(
+fn snapshot_for_account(
     customer: &serde_json::Value,
     captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Result<Snapshot, ProviderError> {
     let data: CustomerData = serde_json::from_value(customer.clone()).map_err(|error| {
         ProviderError::malformed(format!("the T3 Chat customer data did not decode: {error}"))
@@ -468,7 +488,7 @@ fn snapshot(
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,

--- a/crates/tidemark-core/src/providers/keyed/venice.rs
+++ b/crates/tidemark-core/src/providers/keyed/venice.rs
@@ -117,6 +117,14 @@ fn balance_window(used_percent: f64, subtitle: String) -> Window {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -189,7 +197,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details,
@@ -204,7 +212,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Venice dashboard → API keys.",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/warp.rs
+++ b/crates/tidemark-core/src/providers/keyed/warp.rs
@@ -165,6 +165,14 @@ struct Bonus {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let root: Value = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     let Some(json) = root.as_object() else {
@@ -277,7 +285,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows,
         details: Vec::new(),
@@ -401,7 +409,7 @@ pub static SPEC: Spec = Spec {
         // Pinned: CodexBar sends the running OS version, and no recorded body pins one.
         ("x-warp-os-version", "14.0"),
     ],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Warp settings → API key (docs.warp.dev/reference/cli/api-keys).",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/wayfinder.rs
+++ b/crates/tidemark-core/src/providers/keyed/wayfinder.rs
@@ -110,12 +110,17 @@ pub static SPEC: HandSpec = HandSpec {
 /// Builds a pollable client from the account's settings. The credential is blank and
 /// unused; the gateway URL is resolved here so a value the shared reader refuses is a
 /// [`ProviderError::Local`] naming the setting rather than a malformed request later.
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Wayfinder::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Wayfinder::new_for_account(account, options)?))
 }
 
 /// One Wayfinder account, which is one gateway.
 pub struct Wayfinder {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     base: String,
 }
@@ -124,7 +129,12 @@ impl Wayfinder {
     /// Builds a client. The URL is resolved once, here, because a setting that changed the
     /// gateway would otherwise take effect only on the next daemon restart.
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: client()?,
             base: base_url(options, BASE_URL, DEFAULT_BASE_URL)?,
         })
@@ -152,7 +162,13 @@ impl Wayfinder {
         let health: Health = parse(&self.get(&health_url(&self.base)).await?, "/healthz")?;
         let models: Models = parse(&self.get(&models_url(&self.base)).await?, "/router/models")?;
         let savings: Savings = parse(&self.get(&savings_url(&self.base)).await?, "/v1/savings")?;
-        Ok(snapshot(&health, &models, &savings, Timestamp::now()))
+        Ok(snapshot_for_account(
+            &health,
+            &models,
+            &savings,
+            Timestamp::now(),
+            &self.tidemark_account,
+        ))
     }
 }
 
@@ -174,7 +190,7 @@ impl Provider for Wayfinder {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -380,11 +396,22 @@ fn saved_summary(savings: &Savings) -> Option<String> {
 }
 
 /// The card.
+#[cfg(test)]
 fn snapshot(
     health: &Health,
     models: &Models,
     savings: &Savings,
     captured_at: Timestamp,
+) -> Snapshot {
+    snapshot_for_account(health, models, savings, captured_at, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    health: &Health,
+    models: &Models,
+    savings: &Savings,
+    captured_at: Timestamp,
+    account_id: &AccountId,
 ) -> Snapshot {
     let mut rows = vec![DetailRow {
         label: "Gateway".to_owned(),
@@ -405,7 +432,7 @@ fn snapshot(
 
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         // A gateway has no quota. See the module doc.
         windows: Vec::new(),
@@ -790,6 +817,13 @@ mod tests {
         assert_eq!(SPEC.options[0].name, BASE_URL);
         // The blank credential the registry hands the builder is ignored, which is the
         // whole of what a keyless provider means.
-        assert!((SPEC.build)(Credential::new(String::new()), &options(&[])).is_ok());
+        assert!(
+            (SPEC.build)(
+                AccountId::default(),
+                Credential::new(String::new()),
+                &options(&[])
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/tidemark-core/src/providers/keyed/xai.rs
+++ b/crates/tidemark-core/src/providers/keyed/xai.rs
@@ -78,13 +78,20 @@ pub static SPEC: HandSpec = HandSpec {
 /// Builds a pollable client from the stored key and the account's settings. The team ID
 /// is read and validated here, so a missing or invalid one is named on the card rather
 /// than reaching the wire as a malformed URL.
-fn build(credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(Xai::new(credential, options)?))
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Xai::new_for_account(
+        account, credential, options,
+    )?))
 }
 
 /// One xAI account: the management key, the team it bills, and the two endpoints that
 /// come from both.
 pub struct Xai {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     credential: Credential,
     balance_url: String,
@@ -94,6 +101,14 @@ pub struct Xai {
 impl Xai {
     /// Builds a client. The team ID is part of both paths, so it is resolved once, here.
     pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    fn new_for_account(
+        account_id: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
         let team = required(options, TEAM, "Team ID")?;
         if team.contains('/') || team == "." || team == ".." {
             return Err(ProviderError::Local(format!(
@@ -102,6 +117,7 @@ impl Xai {
         }
         let root = format!("{BASE_URL}/{}", encode_team(&team));
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             credential,
             balance_url: format!("{root}/prepaid/balance"),
@@ -161,7 +177,12 @@ impl Xai {
             }
             Err(_) => History::Unavailable,
         };
-        Ok(snapshot(balance, history, now))
+        Ok(snapshot_for_account(
+            balance,
+            history,
+            now,
+            &self.tidemark_account,
+        ))
     }
 
     async fn history(&self, now: Timestamp) -> Result<History, ProviderError> {
@@ -187,7 +208,7 @@ impl Provider for Xai {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -357,10 +378,20 @@ fn encode_team(team: &str) -> String {
 /// No window, ever: prepaid credits have no limit to draw a bar against, and the shape
 /// for that is details only — the card renders the rows and nothing else, which is
 /// accepted.
+#[cfg(test)]
 fn snapshot(balance: f64, history: History, captured_at: Timestamp) -> Snapshot {
+    snapshot_for_account(balance, history, captured_at, &AccountId::default())
+}
+
+fn snapshot_for_account(
+    balance: f64,
+    history: History,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Snapshot {
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows: Vec::new(),
         details: vec![billing_details(balance, &history)],
@@ -710,8 +741,22 @@ mod tests {
         );
         assert_eq!(SPEC.options.len(), 1);
         assert!(SPEC.options[0].required);
-        assert!(build(Credential::new("key"), &options("team-1234")).is_ok());
-        assert!(build(Credential::new("key"), &Options::new()).is_err());
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("key"),
+                &options("team-1234")
+            )
+            .is_ok()
+        );
+        assert!(
+            build(
+                AccountId::default(),
+                Credential::new("key"),
+                &Options::new()
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/zai.rs
+++ b/crates/tidemark-core/src/providers/keyed/zai.rs
@@ -96,7 +96,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[],
-    parse,
+    parse: parse_for_account,
     credential_hint: "Z.ai dashboard → API keys, on whichever region your account is on.",
     options: &[OptionSchema {
         name: REGION,
@@ -115,6 +115,14 @@ pub static SPEC: Spec = Spec {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+pub fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
 
@@ -149,7 +157,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account.clone(),
         captured_at,
         windows: limits.iter().map(Parsed::window).collect(),
         details: details(&limits, data.level.as_deref()),

--- a/crates/tidemark-core/src/providers/keyed/zenmux.rs
+++ b/crates/tidemark-core/src/providers/keyed/zenmux.rs
@@ -91,6 +91,14 @@ struct Quota {
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, ProviderError> {
     let envelope: Envelope = serde_json::from_str(body)
         .map_err(|e| ProviderError::malformed(format!("not the expected envelope: {e}")))?;
     if !envelope.success {
@@ -139,7 +147,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderErr
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows,
         details,
@@ -197,7 +205,7 @@ pub static SPEC: Spec = Spec {
     method: Method::Get,
     auth: Auth::Bearer,
     headers: &[("Accept", "application/json")],
-    parse,
+    parse: parse_for_account,
     credential_hint: "ZenMux platform → Management API key (an inference key will not do).",
     options: &[],
 };

--- a/crates/tidemark-core/src/providers/keyed/zoommate.rs
+++ b/crates/tidemark-core/src/providers/keyed/zoommate.rs
@@ -36,12 +36,17 @@ pub static SPEC: HandSpec = HandSpec {
     build,
 };
 
-fn build(_credential: Credential, options: &Options) -> Result<Arc<dyn Provider>, ProviderError> {
-    Ok(Arc::new(ZoomMate::new(options)?))
+fn build(
+    account: AccountId,
+    _credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(ZoomMate::new_for_account(account, options)?))
 }
 
 /// One ZoomMate account, authenticated by its chosen browser profile.
 pub struct ZoomMate {
+    tidemark_account: AccountId,
     client: reqwest::Client,
     home: Option<PathBuf>,
     storage: Arc<dyn SafeStorage>,
@@ -54,7 +59,12 @@ pub struct ZoomMate {
 
 impl ZoomMate {
     pub fn new(options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), options)
+    }
+
+    fn new_for_account(account_id: AccountId, options: &Options) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: account_id.clone(),
             client: http::client()?,
             home: std::env::var_os("HOME").map(PathBuf::from),
             storage: Arc::new(Keyring),
@@ -73,6 +83,7 @@ impl ZoomMate {
         base_url: &str,
     ) -> Result<Self, ProviderError> {
         Ok(Self {
+            tidemark_account: AccountId::default(),
             client: http::client()?,
             home: Some(home.to_path_buf()),
             storage,
@@ -182,7 +193,7 @@ impl ZoomMate {
             &login.nak,
         )?;
         let body = super::request(PROVIDER_ID, &self.client, request).await?;
-        let mut snapshot = parse(&body, Timestamp::now())?;
+        let mut snapshot = parse_for_account(&body, Timestamp::now(), &self.tidemark_account)?;
         if let Some(email) = login.email {
             snapshot.details.push(DetailSection {
                 title: "Account".to_owned(),
@@ -242,7 +253,7 @@ impl Provider for ZoomMate {
     }
 
     fn account(&self) -> AccountId {
-        AccountId::default()
+        self.tidemark_account.clone()
     }
 
     fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
@@ -323,6 +334,14 @@ fn parse_login(body: &str) -> Result<Login, super::ProviderError> {
 
 /// Turns ZoomMate's reported credit cycle into one quota window.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, super::ProviderError> {
+    parse_for_account(body, captured_at, &AccountId::default())
+}
+
+fn parse_for_account(
+    body: &str,
+    captured_at: Timestamp,
+    account_id: &AccountId,
+) -> Result<Snapshot, super::ProviderError> {
     let envelope: CreditsEnvelope = serde_json::from_str(body).map_err(|error| {
         super::ProviderError::malformed(format!("unreadable ZoomMate credits status: {error}"))
     })?;
@@ -359,7 +378,7 @@ pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, super::Prov
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
-        account: AccountId::default(),
+        account: account_id.clone(),
         captured_at,
         windows: vec![Window {
             key: length

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -50,9 +50,14 @@ pub trait Provider: fmt::Debug + Send + Sync {
     /// The stable slug this provider's history is filed under.
     fn id(&self) -> ProviderId;
 
-    /// Which set of credentials this instance speaks for. v1 has one per provider.
+    /// Which set of credentials this instance speaks for, when it has more than one.
     fn account(&self) -> AccountId {
         AccountId::default()
+    }
+
+    /// The source selected for this account, when the provider owns source selection.
+    fn source(&self) -> Option<Source> {
+        None
     }
 
     /// Fetch current quota.

--- a/crates/tidemark-core/src/storage/mod.rs
+++ b/crates/tidemark-core/src/storage/mod.rs
@@ -443,6 +443,30 @@ impl History {
         };
         self.points(provider, account, window, segment)
     }
+    /// Moves every stored row for one provider/account pair to another account id.
+    ///
+    /// Account promotion and account rename must not leave history split across two ids.
+    /// The updates run in one transaction so a failure in any table leaves all four tables
+    /// unchanged.
+    pub fn rekey_account(
+        &mut self,
+        provider: &str,
+        old: &str,
+        new: &str,
+    ) -> Result<(), StorageError> {
+        let transaction = self.connection.transaction()?;
+        for table in ["window_state", "segment", "point", "notice"] {
+            transaction.execute(
+                &format!(
+                    "UPDATE {table} SET account = ?1
+                     WHERE provider = ?2 AND account = ?3"
+                ),
+                params![new, provider, old],
+            )?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
 
     /// Total points stored, across everything. Diagnostics and tests.
     pub fn point_count(&self) -> Result<i64, StorageError> {
@@ -887,6 +911,105 @@ mod tests {
                 .current_segment("test", "two", &key())
                 .expect("looked up"),
             Some(1)
+        );
+    }
+    #[test]
+    fn rekeying_moves_all_history_rows_to_the_new_account() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested");
+        history
+            .record_notice("test", "default", &key(), 1, "threshold-70", at(0))
+            .expect("recorded");
+
+        history
+            .rekey_account("test", "default", "work")
+            .expect("rekeyed");
+
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("old state read"),
+            None
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "work", &key())
+                .expect("new state read"),
+            Some(1)
+        );
+        assert!(
+            history
+                .points("test", "default", &key(), 1)
+                .expect("old points read")
+                .is_empty()
+        );
+        assert_eq!(
+            history
+                .points("test", "work", &key(), 1)
+                .expect("new points read")
+                .len(),
+            1
+        );
+        assert!(
+            !history
+                .notice_sent("test", "default", &key(), 1, "threshold-70")
+                .expect("old notice read")
+        );
+        assert!(
+            history
+                .notice_sent("test", "work", &key(), 1, "threshold-70")
+                .expect("new notice read")
+        );
+    }
+
+    #[test]
+    fn a_failed_rekey_keeps_rows_under_the_old_account() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested");
+        history
+            .record_notice("test", "default", &key(), 1, "threshold-70", at(0))
+            .expect("recorded");
+        history
+            .connection
+            .execute_batch(
+                "CREATE TRIGGER pinned_segment BEFORE UPDATE OF account ON segment
+                 WHEN NEW.account = 'work'
+                 BEGIN SELECT RAISE(FAIL, 'segments are pinned'); END;",
+            )
+            .expect("trigger installed");
+
+        assert!(
+            history.rekey_account("test", "default", "work").is_err(),
+            "a pinned segment refuses the rekey"
+        );
+
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("old state read"),
+            Some(1)
+        );
+        assert!(
+            history
+                .current_segment("test", "work", &key())
+                .expect("new state read")
+                .is_none()
+        );
+        assert_eq!(
+            history
+                .points("test", "default", &key(), 1)
+                .expect("old points read")
+                .len(),
+            1
+        );
+        assert!(
+            history
+                .notice_sent("test", "default", &key(), 1, "threshold-70")
+                .expect("old notice read")
         );
     }
 

--- a/crates/tidemark-core/src/storage/mod.rs
+++ b/crates/tidemark-core/src/storage/mod.rs
@@ -28,6 +28,14 @@ pub enum StorageError {
     /// The database itself refused.
     #[error("history database: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    /// Rekeying would overwrite rows already owned by the destination account.
+    #[error("history account rekey destination is not empty: {provider}/{account}")]
+    AccountRekeyCollision {
+        /// Provider whose account rows would collide.
+        provider: String,
+        /// Destination account id containing existing rows.
+        account: String,
+    },
     /// The directory holding the database could not be created.
     #[error("could not create {}: {source}", .path.display())]
     Directory {
@@ -443,6 +451,40 @@ impl History {
         };
         self.points(provider, account, window, segment)
     }
+    /// Checks that moving rows to `new` cannot overwrite another account's history.
+    ///
+    /// History has no merge semantics: a destination with any row is rejected so a
+    /// promotion cannot silently discard windows, points, or notifications.
+    pub fn can_rekey_account(
+        &self,
+        provider: &str,
+        old: &str,
+        new: &str,
+    ) -> Result<(), StorageError> {
+        if old == new {
+            return Ok(());
+        }
+        for table in ["window_state", "segment", "point", "notice"] {
+            let occupied: i64 = self.connection.query_row(
+                &format!(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM {table}
+                        WHERE provider = ?1 AND account = ?2
+                    )"
+                ),
+                params![provider, new],
+                |row| row.get(0),
+            )?;
+            if occupied != 0 {
+                return Err(StorageError::AccountRekeyCollision {
+                    provider: provider.to_owned(),
+                    account: new.to_owned(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Moves every stored row for one provider/account pair to another account id.
     ///
     /// Account promotion and account rename must not leave history split across two ids.
@@ -454,6 +496,7 @@ impl History {
         old: &str,
         new: &str,
     ) -> Result<(), StorageError> {
+        self.can_rekey_account(provider, old, new)?;
         let transaction = self.connection.transaction()?;
         for table in ["window_state", "segment", "point", "notice"] {
             transaction.execute(
@@ -961,6 +1004,51 @@ mod tests {
             history
                 .notice_sent("test", "work", &key(), 1, "threshold-70")
                 .expect("new notice read")
+        );
+    }
+
+    #[test]
+    fn a_rekey_rejects_a_nonempty_destination_without_merging_rows() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested old account");
+        let mut destination = snapshot(POLL, 7.0, Some(5 * HOUR));
+        destination.account = AccountId::new("work");
+        history
+            .ingest(&destination)
+            .expect("ingested destination account");
+
+        assert!(matches!(
+            history.rekey_account("test", "default", "work"),
+            Err(StorageError::AccountRekeyCollision { provider, account })
+                if provider == "test" && account == "work"
+        ));
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("old state read"),
+            Some(1)
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "work", &key())
+                .expect("destination state read"),
+            Some(1)
+        );
+        assert_eq!(
+            history
+                .points("test", "default", &key(), 1)
+                .expect("old points read")
+                .len(),
+            1
+        );
+        assert_eq!(
+            history
+                .points("test", "work", &key(), 1)
+                .expect("destination points read")
+                .len(),
+            1
         );
     }
 

--- a/crates/tidemark-core/src/storage/mod.rs
+++ b/crates/tidemark-core/src/storage/mod.rs
@@ -485,11 +485,16 @@ impl History {
         Ok(())
     }
 
-    /// Moves every stored row for one provider/account pair to another account id.
+    /// Moves every stored row for one provider/account pair to another account id,
+    /// refusing when the destination already holds anything.
     ///
-    /// Account promotion and account rename must not leave history split across two ids.
-    /// The updates run in one transaction so a failure in any table leaves all four tables
-    /// unchanged.
+    /// History has no merge semantics and this is the caller that must not clobber: a
+    /// destination with any row is rejected up front by [`Self::can_rekey_account`] so a
+    /// move cannot silently discard windows, points, or notifications. The updates run
+    /// in one transaction so a failure in any table leaves all four tables unchanged.
+    /// Account rename and promotion do not land here: their destination ids are
+    /// unconfigured or retired by construction, so they use
+    /// [`Self::rekey_account_discarding_destination`] instead.
     pub fn rekey_account(
         &mut self,
         provider: &str,
@@ -497,8 +502,49 @@ impl History {
         new: &str,
     ) -> Result<(), StorageError> {
         self.can_rekey_account(provider, old, new)?;
-        let transaction = self.connection.transaction()?;
+        Self::move_account_rows(self.connection.transaction()?, provider, old, new, false)
+    }
+
+    /// Moves every stored row for one provider/account pair to another account id,
+    /// discarding whatever the destination still holds in the same transaction.
+    ///
+    /// The destination of an account rename or a promotion was validated unconfigured, or
+    /// is the id of an account the very same flow removes, so any row already under it
+    /// belongs to an id nothing will answer for: keeping it would attribute a
+    /// predecessor's usage to the account that inherits the id, which is the cross-account
+    /// pollution this storage exists to prevent. Clearing and moving in one transaction
+    /// leaves either all of the old id's rows in place and the destination cleared, or
+    /// neither.
+    pub fn rekey_account_discarding_destination(
+        &mut self,
+        provider: &str,
+        old: &str,
+        new: &str,
+    ) -> Result<(), StorageError> {
+        if old == new {
+            // Clearing the destination would clear the source with it; there is no move
+            // to make.
+            return Ok(());
+        }
+        Self::move_account_rows(self.connection.transaction()?, provider, old, new, true)
+    }
+
+    /// The statements behind both rekey variants, run inside one transaction so the
+    /// destination clearing and the move commit or roll back together.
+    fn move_account_rows(
+        transaction: rusqlite::Transaction<'_>,
+        provider: &str,
+        old: &str,
+        new: &str,
+        clear_destination: bool,
+    ) -> Result<(), StorageError> {
         for table in ["window_state", "segment", "point", "notice"] {
+            if clear_destination {
+                transaction.execute(
+                    &format!("DELETE FROM {table} WHERE provider = ?1 AND account = ?2"),
+                    params![provider, new],
+                )?;
+            }
             transaction.execute(
                 &format!(
                     "UPDATE {table} SET account = ?1
@@ -1049,6 +1095,113 @@ mod tests {
                 .expect("destination points read")
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn a_discarding_rekey_clears_the_stale_destination_rows_and_moves_its_own_in() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested the migrating account");
+        let mut stale = snapshot(POLL, 7.0, Some(5 * HOUR));
+        stale.account = AccountId::new("work");
+        history
+            .ingest(&stale)
+            .expect("ingested the stale destination");
+
+        history
+            .rekey_account_discarding_destination("test", "default", "work")
+            .expect("rekeyed");
+
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("old state read"),
+            None
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "work", &key())
+                .expect("new state read"),
+            Some(1)
+        );
+        let points = history
+            .points("test", "work", &key(), 1)
+            .expect("new points read");
+        assert_eq!(points.len(), 1);
+        assert_eq!(
+            points[0].used_percent, 42.0,
+            "the account that inherited the id owns the rows under it, not the id's \n             predecessor"
+        );
+    }
+
+    #[test]
+    fn a_discarding_rekey_of_an_id_onto_itself_keeps_every_row() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested");
+
+        history
+            .rekey_account_discarding_destination("test", "default", "default")
+            .expect("rekeyed");
+
+        assert_eq!(
+            history
+                .current_segment("test", "default", &key())
+                .expect("state read"),
+            Some(1)
+        );
+        assert_eq!(
+            history
+                .points("test", "default", &key(), 1)
+                .expect("points read")
+                .len(),
+            1,
+            "clearing the destination of a no-op move must not clear the source with it"
+        );
+    }
+
+    #[test]
+    fn a_failed_discarding_rekey_leaves_the_destination_rows_in_place() {
+        let mut history = history();
+        history
+            .ingest(&snapshot(0, 42.0, Some(5 * HOUR)))
+            .expect("ingested the migrating account");
+        let mut stale = snapshot(POLL, 7.0, Some(5 * HOUR));
+        stale.account = AccountId::new("work");
+        history
+            .ingest(&stale)
+            .expect("ingested the stale destination");
+        history
+            .connection
+            .execute_batch(
+                "CREATE TRIGGER pinned_segment BEFORE UPDATE OF account ON segment
+                 WHEN NEW.account = 'work'
+                 BEGIN SELECT RAISE(FAIL, 'segments are pinned'); END;",
+            )
+            .expect("trigger installed");
+
+        assert!(
+            history
+                .rekey_account_discarding_destination("test", "default", "work")
+                .is_err(),
+            "a pinned segment refuses the rekey"
+        );
+        assert_eq!(
+            history
+                .current_segment("test", "work", &key())
+                .expect("destination state read"),
+            Some(1)
+        );
+        assert_eq!(
+            history
+                .points("test", "work", &key(), 1)
+                .expect("destination points read")
+                .len(),
+            1,
+            "the stale rows come back with the transaction that failed to move the rest"
         );
     }
 

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -23,7 +23,8 @@ pub use window::{DANGER_AT, WARNING_AT, Window, WindowKey, WindowLength};
 pub use wire::{
     AuthCandidate, AuthCandidateState, AuthMode, AuthSelection, AuthSelector, CredentialKind,
     DataInfo, ExternalLogin, HistoryPoint, OptionChoice, Preferences, ProviderDefinition,
-    ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus,
+    ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus, account_slug_suggestion,
+    valid_account_slug,
 };
 
 /// Identity constants. Changing any of these is a breaking change for installed units,

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -723,6 +723,45 @@ impl ProviderStatus {
     }
 }
 
+/// Whether a string can serve as an account id in `config.toml`, the Secret Service and
+/// the history: lowercase letters, digits and hyphens, non-empty, and not starting or
+/// ending with a hyphen.
+///
+/// Wire vocabulary because both halves of the bus speak it: the daemon refuses an id the
+/// config cannot hold, and a client typing a new account's name wants to disable its own
+/// confirm button for the same ids rather than learn each refusal by round trip.
+pub fn valid_account_slug(account: &str) -> bool {
+    !account.is_empty()
+        && !account.starts_with('-')
+        && !account.ends_with('-')
+        && account
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+/// The account id a display name suggests: lowercased, everything the config cannot hold
+/// becomes a hyphen, a run of those becomes one, and the edges are trimmed away.
+///
+/// This is the live preview while a name is typed. It never suggests an id
+/// [`valid_account_slug`] refuses — only the empty string, which is a name that has not
+/// been typed yet.
+pub fn account_slug_suggestion(name: &str) -> String {
+    let mut suggestion = String::new();
+    let mut hyphen_pending = false;
+    for character in name.chars() {
+        if character.is_ascii_alphanumeric() {
+            if hyphen_pending && !suggestion.is_empty() {
+                suggestion.push('-');
+            }
+            hyphen_pending = false;
+            suggestion.push(character.to_ascii_lowercase());
+        } else {
+            hyphen_pending = true;
+        }
+    }
+    suggestion
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -929,6 +968,55 @@ mod tests {
             "an absent account label must stay absent: {:?}",
             dict.keys().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn an_account_slug_is_lowercase_letters_digits_and_inner_hyphens() {
+        for slug in ["work", "w", "work-2", "w-o-r-k"] {
+            assert!(
+                valid_account_slug(slug),
+                "{slug:?} is an id the config can hold"
+            );
+        }
+        // The refusals the daemon answered with before the rule moved here; kept beside
+        // the rule so the two cannot drift apart again.
+        for slug in ["", "Work", "work-", "-work", "two words", "work_1", "wörk"] {
+            assert!(
+                !valid_account_slug(slug),
+                "{slug:?} is not an id the config can hold"
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_suggests_the_slug_the_config_holds() {
+        assert_eq!(account_slug_suggestion("My Work"), "my-work");
+        // Leading, trailing and repeated separators all collapse to one inner hyphen.
+        assert_eq!(account_slug_suggestion("  Team   Lead  "), "team-lead");
+        assert_eq!(account_slug_suggestion("-My--Work-"), "my-work");
+        assert_eq!(account_slug_suggestion("work_1"), "work-1");
+        // What the config cannot hold becomes a hyphen rather than being dropped, so a
+        // name never suggests an id silently different from what was typed.
+        assert_eq!(account_slug_suggestion("wörk"), "w-rk");
+        assert_eq!(account_slug_suggestion("Team (QA)"), "team-qa");
+    }
+
+    #[test]
+    fn a_name_with_nothing_the_config_holds_suggests_nothing() {
+        assert_eq!(account_slug_suggestion(""), "");
+        assert_eq!(account_slug_suggestion("   "), "");
+        assert_eq!(account_slug_suggestion("—😀"), "");
+    }
+
+    #[test]
+    fn a_suggestion_is_always_a_slug_the_config_holds_or_empty() {
+        for name in ["", "My Work", "Q&A Team", "Ünternehmen", "—", "😀"] {
+            let suggested = account_slug_suggestion(name);
+            assert!(
+                suggested.is_empty() || valid_account_slug(&suggested),
+                "{name:?} suggested {suggested:?}, which the config cannot hold"
+            );
+        }
     }
 
     #[test]

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -575,6 +575,9 @@ pub struct ProviderStatus {
     pub provider: String,
     /// Account slug.
     pub account: String,
+    /// A human-readable label for this account. Absent for the default account and when
+    /// speaking to an older daemon.
+    pub account_label: Option<String>,
     /// A [`ProviderState`] as a string.
     pub state: String,
     /// Human-readable detail for a state that is not `ok`. Absent when there is nothing
@@ -635,6 +638,7 @@ impl ProviderStatus {
         Self {
             provider: provider.to_string(),
             account: account.to_string(),
+            account_label: None,
             state: ProviderState::Pending.as_wire().to_owned(),
             message: None,
             captured_at: None,
@@ -902,6 +906,45 @@ mod tests {
         let (decoded, _): (ProviderStatus, _) =
             encode(&original).deserialize().expect("decodes again");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn a_status_with_an_account_label_survives_the_bus() {
+        let mut original = status();
+        original.account_label = Some("Work".into());
+        let (decoded, _): (ProviderStatus, _) =
+            encode(&original).deserialize().expect("decodes again");
+        assert_eq!(decoded.account_label, original.account_label);
+    }
+
+    #[test]
+    fn a_status_without_an_account_label_has_no_label_key() {
+        let original = status();
+        assert_eq!(original.account_label, None);
+        let (dict, _): (HashMap<String, OwnedValue>, _) = encode(&original)
+            .deserialize()
+            .expect("decodes as a dictionary");
+        assert!(
+            !dict.contains_key("account_label"),
+            "an absent account label must stay absent: {:?}",
+            dict.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn an_older_status_without_an_account_label_decodes_to_none() {
+        let mut current = status();
+        current.account_label = Some("Work".into());
+        let encoded = encode(&current);
+        let (mut old_dict, _): (HashMap<String, OwnedValue>, _) =
+            encoded.deserialize().expect("decodes as a dictionary");
+        assert!(old_dict.remove("account_label").is_some());
+        let old_encoded =
+            to_bytes(Context::new_dbus(LE, 0), &old_dict).expect("the old dictionary encodes");
+        let (decoded, _): (ProviderStatus, _) = old_encoded
+            .deserialize()
+            .expect("decodes without the new key");
+        assert_eq!(decoded.account_label, None);
     }
 
     #[test]

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -50,6 +50,12 @@ pub trait Daemon {
     /// Removes one configured account.
     fn remove_provider(&self, provider: &str, account: &str) -> zbus::Result<()>;
 
+    /// Adds one more account to a provider the config already has.
+    fn add_account(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Renames one configured account, carrying its credential and history to the new id.
+    fn rename_account(&self, provider: &str, account: &str, new: &str) -> zbus::Result<()>;
+
     /// Every account the daemon watches.
     fn get_status(&self) -> zbus::Result<Vec<ProviderStatus>>;
 
@@ -135,6 +141,9 @@ pub trait Daemon {
 
     /// Puts the configured providers in the order the user arranged the cards in.
     fn set_order(&self, providers: &[String]) -> zbus::Result<()>;
+
+    /// Puts one provider's accounts in the order the user arranged them in.
+    fn set_account_order(&self, provider: &str, accounts: Vec<String>) -> zbus::Result<()>;
 
     /// What the daemon on the other end is.
     #[zbus(property(emits_changed_signal = "false"))]

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -93,16 +93,19 @@ struct Shown {
     secondary: Vec<QuotaBar>,
 }
 
+/// The native account-group control shown on a provider's main card.
+pub(crate) struct CardExpansion {
+    pub(crate) extra_accounts: usize,
+    pub(crate) expanded: bool,
+    pub(crate) on_toggled: Rc<dyn Fn(bool)>,
+}
+
 /// A provider card.
 #[derive(Debug)]
 pub struct Card {
-    slot: adw::Bin,
+    slot: gtk::Overlay,
     mark: gtk::Image,
     name: gtk::Label,
-    /// The provider's name as the catalog spells it, resolved once at construction: slugs
-    /// never change and neither do the titles this build ships, so a status update has
-    /// nothing to re-resolve.
-    provider_name: String,
     plan: gtk::Label,
     chip: gtk::Label,
     reading: gtk::Box,
@@ -122,8 +125,9 @@ impl Card {
     pub fn new(
         status: &ProviderStatus,
         now: Timestamp,
-        provider_name: String,
+        title: String,
         on_activate: Rc<dyn Fn(String, String)>,
+        expansion: Option<CardExpansion>,
     ) -> Self {
         // All three ellipsize. None of them is expected to: a provider's name, its plan and
         // a state chip all fit the row this build ships. They ellipsize because the three
@@ -170,6 +174,19 @@ impl Card {
         title_row.append(&chip);
         plan.set_margin_start(TITLE_GAP - MARK_GAP);
 
+        let expansion = expansion.map(|expansion| {
+            let content = gtk::Label::builder()
+                .label(format!("+{}", expansion.extra_accounts))
+                .build();
+            let toggle = gtk::ToggleButton::builder()
+                .active(expansion.expanded)
+                .child(&content)
+                .css_classes(["flat", "circular", "quota-account-toggle"])
+                .tooltip_text("Show other accounts")
+                .build();
+            toggle.connect_toggled(move |toggle| (expansion.on_toggled)(toggle.is_active()));
+            toggle
+        });
         align_to_baseline(&name, &mark, &plan);
 
         let headline = gtk::Label::builder()
@@ -252,17 +269,21 @@ impl Card {
             .css_classes(["caption", "quota-footer"])
             .build();
 
-        let root = gtk::Box::builder()
+        let body = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
             .spacing(12)
+            .build();
+        body.append(&title_row);
+        body.append(&reading);
+        body.append(&blank);
+        body.append(&rows);
+        body.append(&footer);
+        let root = gtk::Overlay::builder()
+            .child(&body)
             .width_request(MIN_WIDTH)
             .css_classes(["card", "quota-card", "activatable"])
             .build();
-        root.append(&title_row);
-        root.append(&reading);
-        root.append(&blank);
-        root.append(&rows);
-        root.append(&footer);
+        root.set_overflow(gtk::Overflow::Visible);
 
         // The card owns the widget the grid allocates rather than letting the grid wrap it,
         // so that a reorder moves slots around a vector instead of taking widgets out of
@@ -274,11 +295,17 @@ impl Card {
         // is still for is the hover: `style.rs` matches `:hover` here and moves the card
         // inside, because a CSS transform moves what GTK picks and a card that lifted
         // itself out from under the pointer would flicker.
-        let slot = adw::Bin::builder()
+        let slot = gtk::Overlay::builder()
             .child(&root)
             .focusable(true)
             .css_classes([crate::grid::SLOT_CLASS])
             .build();
+        slot.set_overflow(gtk::Overflow::Visible);
+        if let Some(expansion) = expansion {
+            expansion.set_halign(gtk::Align::End);
+            expansion.set_valign(gtk::Align::Start);
+            slot.add_overlay(&expansion);
+        }
         slot.set_cursor_from_name(Some("pointer"));
         let identity = CardIdentity::from(status);
         let invoke: Rc<dyn Fn()> = Rc::new({
@@ -312,7 +339,6 @@ impl Card {
             slot,
             mark,
             name,
-            provider_name,
             plan,
             chip,
             reading,
@@ -329,6 +355,7 @@ impl Card {
                 secondary: Vec::new(),
             }),
         };
+        card.set_title(&title);
         card.apply(status, now);
         card
     }
@@ -343,10 +370,14 @@ impl Card {
         self.shown.borrow().status.clone()
     }
 
+    /// Replaces the title resolved by the window for this account.
+    pub fn set_title(&self, title: &str) {
+        self.name.set_label(title);
+    }
+
     /// Shows a new status for the same account.
     pub fn apply(&self, status: &ProviderStatus, now: Timestamp) {
         mark::set(&self.mark, &status.provider);
-        self.name.set_label(&self.provider_name);
 
         match status.plan() {
             Some(plan) => {

--- a/crates/tidemark/src/grid.rs
+++ b/crates/tidemark/src/grid.rs
@@ -48,6 +48,8 @@ const MAX_COLUMNS: usize = 3;
 const REORDER_MS: u32 = 250;
 /// How long a released card takes to settle into its slot.
 const SETTLE_MS: u32 = 200;
+/// How long account cards take to enter or leave an expanded provider group.
+const GROUP_TRANSITION_MS: u32 = 180;
 /// How close to the edge of the scrolled view the pointer has to get before the view
 /// follows it. Roughly a finger's width: near enough to be deliberate, far enough that it
 /// engages before the pointer is jammed against the edge.
@@ -195,6 +197,36 @@ fn paint_order(motion: &[bool], carried: Option<usize>) -> Vec<usize> {
     order
 }
 
+/// The child order for cards that must travel beneath the preceding visible card.
+///
+/// Provider account cards are contiguous. Moving each entering or leaving account before
+/// the visible card before it means that card paints over the account for only the
+/// transition, then [`CardGrid::reset_child_order`] restores the ordinary slot order.
+fn paint_order_beneath_preceding(count: usize, lower: &[usize]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..count).collect();
+    for &index in lower {
+        let Some(anchor) = (0..index)
+            .rev()
+            .find(|candidate| !lower.contains(candidate))
+        else {
+            continue;
+        };
+        let Some(current) = order.iter().position(|candidate| *candidate == index) else {
+            continue;
+        };
+        let Some(before) = order.iter().position(|candidate| *candidate == anchor) else {
+            continue;
+        };
+        let lowered = order.remove(current);
+        let before = order
+            .iter()
+            .position(|candidate| *candidate == anchor)
+            .unwrap_or(before);
+        order.insert(before, lowered);
+    }
+    order
+}
+
 /// How fast the scrolled view should follow a pointer this far into its edge, in pixels per
 /// second. Positive scrolls down. Zero everywhere but the two edge bands.
 fn autoscroll_rate(pointer: f64, height: f64) -> f64 {
@@ -275,6 +307,9 @@ mod imp {
         /// allocation cannot come to different conclusions about where a slot is.
         pub(super) columns: Cell<usize>,
         pub(super) cell: Cell<(f64, f64)>,
+        /// The in-flight account-card transition, if any.
+        pub(super) group_transition: RefCell<Option<adw::TimedAnimation>>,
+        pub(super) transition_id: Cell<u64>,
     }
 
     // By hand because the reorder callback is a closure. What is worth printing is the
@@ -462,6 +497,197 @@ impl CardGrid {
             animation: RefCell::new(None),
         });
         self.queue_resize();
+    }
+
+    /// Replaces the visible cards, moving existing cards instead of teleporting them.
+    pub(crate) fn replace(&self, cards: Vec<gtk::Widget>) {
+        let existing: Vec<gtk::Widget> = self
+            .imp()
+            .slots
+            .borrow()
+            .iter()
+            .map(|slot| slot.child.clone())
+            .collect();
+        let disappearing: Vec<gtk::Widget> = existing
+            .iter()
+            .filter(|child| !cards.contains(child))
+            .cloned()
+            .collect();
+        let entering: Vec<gtk::Widget> = cards
+            .iter()
+            .filter(|card| !existing.contains(card))
+            .cloned()
+            .collect();
+
+        if disappearing.is_empty() {
+            if entering.is_empty() {
+                self.set_order(&cards);
+            } else {
+                self.expand(cards, existing, entering);
+            }
+            return;
+        }
+
+        self.collapse(cards, existing, disappearing);
+    }
+
+    fn expand(
+        &self,
+        cards: Vec<gtk::Widget>,
+        existing: Vec<gtk::Widget>,
+        entering: Vec<gtk::Widget>,
+    ) {
+        let id = self.imp().transition_id.get().wrapping_add(1);
+        self.imp().transition_id.set(id);
+        if let Some(animation) = self.imp().group_transition.borrow_mut().take() {
+            animation.pause();
+        }
+        self.replace_now(cards.clone());
+        let starts = {
+            let slots = self.imp().slots.borrow();
+            slots
+                .iter()
+                .enumerate()
+                .map(|(index, held)| {
+                    let origin = existing
+                        .iter()
+                        .position(|child| *child == held.child)
+                        .or_else(|| {
+                            cards[..index]
+                                .iter()
+                                .rev()
+                                .find_map(|card| existing.iter().position(|child| *child == *card))
+                        })
+                        .unwrap_or(index);
+                    let offset = origin as f64 - index as f64;
+                    held.offset.set(offset);
+                    held.target.set(0.0);
+                    offset
+                })
+                .collect::<Vec<_>>()
+        };
+        self.lower_cards_beneath_preceding(&entering);
+        self.add_css_class(REORDERING_CLASS);
+        let target = adw::CallbackAnimationTarget::new({
+            let grid = self.downgrade();
+            move |value| {
+                let Some(grid) = grid.upgrade() else {
+                    return;
+                };
+                for (slot, start) in grid.imp().slots.borrow().iter().zip(&starts) {
+                    slot.offset.set((1.0 - value) * start);
+                }
+                grid.queue_allocate();
+            }
+        });
+        let animation = adw::TimedAnimation::new(self, 0.0, 1.0, GROUP_TRANSITION_MS, target);
+        animation.set_easing(adw::Easing::EaseOutCubic);
+        animation.connect_done({
+            let grid = self.downgrade();
+            move |_| {
+                let Some(grid) = grid.upgrade() else {
+                    return;
+                };
+                if grid.imp().transition_id.get() != id {
+                    return;
+                }
+                grid.imp().group_transition.borrow_mut().take();
+                grid.reset_child_order();
+                grid.remove_css_class(REORDERING_CLASS);
+                grid.queue_allocate();
+            }
+        });
+        *self.imp().group_transition.borrow_mut() = Some(animation.clone());
+        animation.play();
+    }
+
+    fn collapse(
+        &self,
+        cards: Vec<gtk::Widget>,
+        existing: Vec<gtk::Widget>,
+        disappearing: Vec<gtk::Widget>,
+    ) {
+        let id = self.imp().transition_id.get().wrapping_add(1);
+        self.imp().transition_id.set(id);
+        if let Some(animation) = self.imp().group_transition.borrow_mut().take() {
+            animation.pause();
+        }
+        let shifts: Vec<(gtk::Widget, f64)> = existing
+            .iter()
+            .enumerate()
+            .map(|(index, child)| {
+                let target = cards
+                    .iter()
+                    .position(|card| *card == *child)
+                    .unwrap_or_else(|| {
+                        existing[..index]
+                            .iter()
+                            .rposition(|card| cards.contains(card))
+                            .unwrap_or(0)
+                    });
+                (child.clone(), target as f64 - index as f64)
+            })
+            .collect();
+        let target = adw::CallbackAnimationTarget::new({
+            let shifts = shifts.clone();
+            let grid = self.downgrade();
+            move |value| {
+                if let Some(grid) = grid.upgrade() {
+                    let slots = grid.imp().slots.borrow();
+                    for (child, shift) in &shifts {
+                        if let Some(slot) = slots.iter().find(|slot| slot.child == *child) {
+                            slot.offset.set(value * shift);
+                        }
+                    }
+                    grid.queue_allocate();
+                }
+            }
+        });
+        self.lower_cards_beneath_preceding(&disappearing);
+        self.add_css_class(REORDERING_CLASS);
+        let animation = adw::TimedAnimation::new(self, 0.0, 1.0, GROUP_TRANSITION_MS, target);
+        animation.set_easing(adw::Easing::EaseOutCubic);
+        animation.connect_done({
+            let grid = self.downgrade();
+            move |_| {
+                let Some(grid) = grid.upgrade() else {
+                    return;
+                };
+                if grid.imp().transition_id.get() != id {
+                    return;
+                }
+                grid.imp().group_transition.borrow_mut().take();
+                grid.replace_now(cards.clone());
+            }
+        });
+        *self.imp().group_transition.borrow_mut() = Some(animation.clone());
+        animation.play();
+    }
+
+    fn replace_now(&self, cards: Vec<gtk::Widget>) {
+        self.clear();
+        for card in cards {
+            self.append(&card);
+        }
+    }
+
+    /// Draws group-transition cards below their preceding provider card.
+    fn lower_cards_beneath_preceding(&self, lowered: &[gtk::Widget]) {
+        let slots = self.imp().slots.borrow();
+        let lowered: Vec<usize> = slots
+            .iter()
+            .enumerate()
+            .filter_map(|(index, slot)| lowered.contains(&slot.child).then_some(index))
+            .collect();
+        let children: Vec<gtk::Widget> = slots.iter().map(|slot| slot.child.clone()).collect();
+        drop(slots);
+
+        let mut previous: Option<gtk::Widget> = None;
+        for index in paint_order_beneath_preceding(children.len(), &lowered) {
+            let child = children[index].clone();
+            child.insert_after(self, previous.as_ref());
+            previous = Some(child);
+        }
     }
 
     /// Removes one card, leaving the order of the rest alone.
@@ -1086,6 +1312,15 @@ mod tests {
     #[test]
     fn nothing_moving_leaves_the_cards_in_slot_order() {
         assert_eq!(paint_order(&[false; 4], None), [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn entering_accounts_are_painted_below_their_provider_card() {
+        assert_eq!(
+            paint_order_beneath_preceding(4, &[1, 2]),
+            [1, 2, 0, 3],
+            "the provider card remains above its newly entering accounts"
+        );
     }
 
     #[test]

--- a/crates/tidemark/src/model.rs
+++ b/crates/tidemark/src/model.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use tidemark_types::{ProviderDefinition, Snapshot, Window, WindowLength};
+use tidemark_types::{ProviderDefinition, ProviderStatus, Snapshot, Window, WindowLength};
 
 /// The catalog's spelling of each provider's name, by slug.
 pub type Titles = BTreeMap<String, String>;
@@ -30,6 +30,91 @@ pub fn name(titles: &Titles, slug: &str) -> String {
         .get(slug)
         .cloned()
         .unwrap_or_else(|| tidemark_types::provider_label(slug))
+}
+
+/// Keeps one provider's accounts adjacent while preserving first-seen provider order.
+pub fn provider_groups(statuses: &[ProviderStatus]) -> Vec<Vec<&ProviderStatus>> {
+    let mut groups: Vec<Vec<&ProviderStatus>> = Vec::new();
+    for status in statuses {
+        if let Some(group) = groups.iter_mut().find(|group| {
+            group
+                .first()
+                .is_some_and(|first| first.provider == status.provider)
+        }) {
+            group.push(status);
+        } else {
+            groups.push(vec![status]);
+        }
+    }
+    groups
+}
+
+/// The daemon operation a completed card drag represents.
+#[derive(Debug, Eq, PartialEq)]
+pub enum CardReorder {
+    /// Moves a whole provider group among the configured providers.
+    Providers(Vec<String>),
+    /// Moves one extra account within its provider, retaining the default account first.
+    Accounts {
+        provider: String,
+        accounts: Vec<String>,
+    },
+}
+
+/// Classifies a grid move without allowing an extra account to leave its provider group.
+pub fn card_reorder(
+    statuses: &[ProviderStatus],
+    visible: &[ProviderStatus],
+    from: usize,
+    to: usize,
+) -> Option<CardReorder> {
+    if from == to {
+        return None;
+    }
+    let source = visible.get(from)?;
+    let target = visible.get(to)?;
+    let groups = provider_groups(statuses);
+
+    if source.provider == target.provider {
+        if source.account == "default" || target.account == "default" {
+            return None;
+        }
+        let mut accounts: Vec<String> = groups
+            .iter()
+            .find(|group| group[0].provider == source.provider)?
+            .iter()
+            .map(|status| status.account.clone())
+            .collect();
+        let source_index = accounts
+            .iter()
+            .position(|account| *account == source.account)?;
+        let target_index = accounts
+            .iter()
+            .position(|account| *account == target.account)?;
+        let moved = accounts.remove(source_index);
+        accounts.insert(target_index, moved);
+        Some(CardReorder::Accounts {
+            provider: source.provider.clone(),
+            accounts,
+        })
+    } else {
+        if source.account != "default" {
+            return None;
+        }
+        let mut providers: Vec<String> = groups
+            .iter()
+            .map(|group| group[0].provider.clone())
+            .collect();
+        let source = providers
+            .iter()
+            .position(|provider| *provider == source.provider)?;
+        let target = providers
+            .iter()
+            .position(|provider| *provider == target.provider)?;
+        let moved = providers.remove(source);
+        providers.insert(target, moved);
+        Some(CardReorder::Providers(providers))
+    }
 }
 
 /// The windows of a reading, in the order the card draws them.
@@ -78,7 +163,7 @@ pub fn arrangement(slugs: &[String], order: &[String]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidemark_types::{AccountId, ProviderId, Timestamp, WindowKey};
+    use tidemark_types::{AccountId, ProviderId, ProviderStatus, Timestamp, WindowKey};
 
     fn window(length: Option<u64>, used: f64) -> Window {
         Window {
@@ -110,6 +195,10 @@ mod tests {
             resets_at: None,
             length: length.and_then(WindowLength::from_secs),
         }
+    }
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
     }
 
     #[test]
@@ -203,5 +292,75 @@ mod tests {
         let held = ["kimi".to_owned(), "zai".to_owned()];
         assert_eq!(arrangement(&held, &[]), [0, 1]);
         assert!(arrangement(&[], &["zai".to_owned()]).is_empty());
+    }
+
+    #[test]
+    fn statuses_of_one_provider_stay_together_in_first_seen_order() {
+        let statuses = [
+            status("zai", "default"),
+            status("claude", "default"),
+            status("zai", "work"),
+        ];
+        let groups = provider_groups(&statuses);
+
+        let identities: Vec<Vec<(&str, &str)>> = groups
+            .iter()
+            .map(|group| {
+                group
+                    .iter()
+                    .map(|status| (status.provider.as_str(), status.account.as_str()))
+                    .collect()
+            })
+            .collect();
+        assert_eq!(
+            identities,
+            vec![
+                vec![("zai", "default"), ("zai", "work")],
+                vec![("claude", "default")],
+            ]
+        );
+    }
+
+    #[test]
+    fn dragging_an_extra_account_within_its_group_only_reorders_that_group() {
+        let statuses = [
+            status("zai", "default"),
+            status("zai", "work"),
+            status("zai", "team"),
+            status("claude", "default"),
+        ];
+
+        assert_eq!(
+            card_reorder(&statuses, &statuses, 1, 2),
+            Some(CardReorder::Accounts {
+                provider: "zai".into(),
+                accounts: vec!["default".into(), "team".into(), "work".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn dragging_a_main_card_across_groups_reorders_providers() {
+        let statuses = [
+            status("zai", "default"),
+            status("zai", "work"),
+            status("claude", "default"),
+        ];
+
+        assert_eq!(
+            card_reorder(&statuses, &statuses, 0, 2),
+            Some(CardReorder::Providers(vec!["claude".into(), "zai".into()]))
+        );
+    }
+
+    #[test]
+    fn dragging_an_extra_account_across_a_group_boundary_is_refused() {
+        let statuses = [
+            status("zai", "default"),
+            status("zai", "work"),
+            status("claude", "default"),
+        ];
+
+        assert_eq!(card_reorder(&statuses, &statuses, 1, 2), None);
     }
 }

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -11,7 +11,7 @@ use tidemark_types::{
 
 use super::browser_auth::BrowserAuth;
 use super::model::AuthSource;
-use super::{model, reason};
+use super::{DEFAULT_ACCOUNT, model, name_dialog, reason};
 use crate::bus::DaemonProxy;
 use crate::{format, mark};
 
@@ -313,6 +313,16 @@ impl ProviderDetail {
         let image = mark::image_at(72);
         mark::set(&image, &definition.provider);
         let title = adw::WindowTitle::new(&definition.title, "");
+        // The account's own name under the provider's, when this page is not the default
+        // account's: a page a second account lands on must say which account it is.
+        if status.account != DEFAULT_ACCOUNT {
+            title.set_subtitle(
+                status
+                    .account_label
+                    .as_deref()
+                    .unwrap_or(status.account.as_str()),
+            );
+        }
         let heading = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
             .spacing(6)
@@ -363,6 +373,7 @@ impl ProviderDetail {
         });
         detail.build_authentication();
         detail.build_options(&options);
+        detail.wire_rename();
         let initial_status = detail.status.borrow().clone();
         detail.apply(&initial_status);
         detail
@@ -370,6 +381,62 @@ impl ProviderDetail {
 
     pub(super) fn page(&self) -> &adw::NavigationPage {
         &self.page
+    }
+
+    /// The label pen, on the header of an account that is not the provider's default.
+    ///
+    /// The default account is the provider's structural first one; the daemon will not
+    /// move it, so the pen stays off its page. A confirmed rename retires this page — it
+    /// is keyed by an identity the rename just replaced — and the dialog returns to the
+    /// list when the daemon announces the old id's removal. Nothing here chases the new
+    /// id: the user is where the list is, and the new account's row is one click away.
+    fn wire_rename(self: &Rc<Self>) {
+        let status = self.status.borrow();
+        if status.account == DEFAULT_ACCOUNT {
+            return;
+        }
+        let provider = status.provider.clone();
+        let account = status.account.clone();
+        let label = status
+            .account_label
+            .clone()
+            .unwrap_or_else(|| account.clone());
+        drop(status);
+
+        let rename = gtk::Button::builder()
+            .icon_name("document-edit-symbolic")
+            .tooltip_text("Rename account")
+            .valign(gtk::Align::Center)
+            .build();
+        rename.connect_clicked({
+            let weak = Rc::downgrade(self);
+            let label = label.clone();
+            move |_| {
+                let Some(detail) = weak.upgrade() else {
+                    return;
+                };
+                let dialog = detail.dialog.clone();
+                let proxy = detail.proxy.clone();
+                let provider = provider.clone();
+                let account = account.clone();
+                let label = label.clone();
+                glib::spawn_future_local(async move {
+                    let Some(slug) =
+                        name_dialog(&dialog, "Rename account", &label, "Rename", Some(&account))
+                            .await
+                    else {
+                        return;
+                    };
+                    // Success needs no action here: the daemon publishes the old id's
+                    // removal and the new id's arrival, and the page keyed by the old id
+                    // is retired by that, not by anything it does to itself.
+                    if let Err(error) = proxy.rename_account(&provider, &account, &slug).await {
+                        detail.toast(&reason(&error));
+                    }
+                });
+            }
+        });
+        self.header.pack_end(&rename);
     }
 
     pub(super) fn matches(&self, provider: &str, account: &str) -> bool {

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -313,6 +313,15 @@ fn account_row(
         .margin_start(24)
         .use_markup(false)
         .build();
+    // A dimmed corner tying the row to the provider above it — the margin alone read as
+    // a stray indent rather than as nesting. Pango falls back to a font that draws the
+    // glyph when the interface font has none of its own.
+    let corner = gtk::Label::builder()
+        .label("⌞")
+        .valign(gtk::Align::Center)
+        .css_classes(["dim-label"])
+        .build();
+    row.add_prefix(&corner);
     row.add_prefix(&image);
 
     let edit = gtk::Button::builder()
@@ -403,6 +412,12 @@ fn update_account_row(
         status,
         is_waiting(&status.provider, &status.account),
     ));
+    // The same editability rule the provider's own row applies. For every provider that
+    // can hold a second account it is true by construction (its credential is key or
+    // oauth), but a missing definition draws no pen here either, exactly as above.
+    let editable = definition.is_some_and(opens_detail_after_add);
+    row.edit.set_visible(editable);
+    row.edit.set_sensitive(editable);
     mark::set(&row.image, &status.provider);
 }
 
@@ -552,7 +567,7 @@ impl Picker {
 mod tests {
     use tidemark_types::{AccountId, ProviderId, ProviderStatus};
 
-    use super::{ProviderGroup, group};
+    use super::{ProviderGroup, group, structure};
 
     fn status(provider: &str, account: &str) -> ProviderStatus {
         ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
@@ -602,6 +617,29 @@ mod tests {
         assert_eq!(
             keys(&groups),
             vec![("kimi", vec!["team", "default", "work"])]
+        );
+    }
+
+    #[test]
+    fn a_group_draws_one_provider_key_then_one_key_per_account_beyond_the_first() {
+        // The shape key apply() diffs held rows against: None is the provider's own row,
+        // and each account after the first is Some(...) in configured order. A provider
+        // with one account contributes its single None key and nothing else.
+        let groups = group(&[
+            status("kimi", "default"),
+            status("kimi", "work"),
+            status("kimi", "team"),
+            status("zai", "default"),
+        ]);
+
+        assert_eq!(
+            structure(&groups),
+            [
+                ("kimi", None),
+                ("kimi", Some("work")),
+                ("kimi", Some("team")),
+                ("zai", None),
+            ]
         );
     }
 

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -4,10 +4,59 @@ use std::rc::Rc;
 use adw::prelude::*;
 use tidemark_types::{ProviderDefinition, ProviderStatus, provider_label};
 
-use super::{model, opens_detail_after_add};
+use super::{model, multi_account_capable, opens_detail_after_add};
 use crate::mark;
 
 type IdentityCallback = Rc<dyn Fn(String, String)>;
+type ProviderCallback = Rc<dyn Fn(String)>;
+
+/// A provider and its accounts, in the order the list draws them.
+#[derive(Debug, PartialEq)]
+struct ProviderGroup {
+    /// The provider slug, keying the provider's own row.
+    provider: String,
+    /// The provider's accounts in configured order. The first is drawn on the provider's
+    /// own row — a provider with one account looks exactly as it always has — and the
+    /// rest are nested rows under it.
+    accounts: Vec<ProviderStatus>,
+}
+
+/// Groups a flat status list into providers: one entry per provider, in the order the
+/// provider first appears, with that provider's accounts in the order they appear.
+fn group(statuses: &[ProviderStatus]) -> Vec<ProviderGroup> {
+    let mut groups: Vec<ProviderGroup> = Vec::new();
+    for status in statuses {
+        if let Some(group) = groups
+            .iter_mut()
+            .find(|group| group.provider == status.provider)
+        {
+            group.accounts.push(status.clone());
+        } else {
+            groups.push(ProviderGroup {
+                provider: status.provider.clone(),
+                accounts: vec![status.clone()],
+            });
+        }
+    }
+    groups
+}
+
+/// The identity sequence the list draws: one provider key per provider, then one account
+/// key per account beyond the first. Held rows are compared against it to decide whether
+/// the picture changed only in words — updated in place, so a click never lands on a row
+/// replaced under it — or in shape, which is drawn fresh.
+fn structure(groups: &[ProviderGroup]) -> Vec<(&str, Option<&str>)> {
+    groups
+        .iter()
+        .flat_map(|group| {
+            std::iter::once((group.provider.as_str(), None)).chain(
+                group.accounts[1..]
+                    .iter()
+                    .map(|status| (group.provider.as_str(), Some(status.account.as_str()))),
+            )
+        })
+        .collect()
+}
 
 /// The configured rows on the dialog's main page.
 #[derive(Debug)]
@@ -17,13 +66,23 @@ pub(super) struct ConfiguredList {
     rows: RefCell<Vec<ConfiguredRow>>,
 }
 
+/// One drawn row of the configured list: a provider's own row, or one of the accounts
+/// nested under it.
 #[derive(Debug)]
 struct ConfiguredRow {
+    /// The provider every identity below belongs to.
     provider: String,
-    account: String,
+    /// The account the row is, or `None` for the provider's own row — which is the
+    /// provider's first account's row in everything but name.
+    account: Option<String>,
     row: adw::ActionRow,
     image: gtk::Image,
+    /// The pen: the provider row's opens the provider's first account, a nested row's
+    /// opens that account.
     edit: gtk::Button,
+    /// The "+", on the provider row alone. `None` on nested rows, which are the accounts
+    /// the "+" exists to create.
+    add: Option<gtk::Button>,
 }
 
 impl ConfiguredList {
@@ -59,53 +118,124 @@ impl ConfiguredList {
         is_waiting: &dyn Fn(&str, &str) -> bool,
         on_edit: IdentityCallback,
         on_remove: IdentityCallback,
+        on_add_account: ProviderCallback,
+    ) {
+        let groups = group(statuses);
+        let shape_held = {
+            let rows = self.rows.borrow();
+            rows.len()
+                == groups
+                    .iter()
+                    .map(|group| group.accounts.len())
+                    .sum::<usize>()
+                && rows
+                    .iter()
+                    .zip(structure(&groups))
+                    .all(|(row, key)| row.provider == key.0 && row.account.as_deref() == key.1)
+        };
+        if shape_held {
+            self.update(&groups, definitions, is_waiting);
+        } else {
+            self.rebuild(
+                &groups,
+                definitions,
+                is_waiting,
+                &on_edit,
+                &on_remove,
+                &on_add_account,
+            );
+        }
+        self.empty.set_visible(groups.is_empty());
+    }
+
+    /// Draws the whole list fresh. Only reached when the shape changed — an account or a
+    /// provider appearing or disappearing — because the rows carry no text of their own
+    /// to lose, and a list redrawn on every poll would take the click with it.
+    fn rebuild(
+        &self,
+        groups: &[ProviderGroup],
+        definitions: &[ProviderDefinition],
+        is_waiting: &dyn Fn(&str, &str) -> bool,
+        on_edit: &IdentityCallback,
+        on_remove: &IdentityCallback,
+        on_add_account: &ProviderCallback,
     ) {
         let mut rows = self.rows.borrow_mut();
-        let (kept, removed): (Vec<_>, Vec<_>) =
-            std::mem::take(&mut *rows).into_iter().partition(|row| {
-                statuses
-                    .iter()
-                    .any(|status| status.provider == row.provider && status.account == row.account)
-            });
-        *rows = kept;
-        for removed in removed {
-            self.group.remove(&removed.row);
+        for row in std::mem::take(&mut *rows) {
+            self.group.remove(&row.row);
         }
-
-        for status in statuses {
+        for group in groups {
             let definition = definitions
                 .iter()
-                .find(|definition| definition.provider == status.provider);
-            if let Some(existing) = rows
-                .iter()
-                .find(|row| row.provider == status.provider && row.account == status.account)
-            {
-                update_row(existing, definition, status, is_waiting);
-                continue;
-            }
-
-            let built = configured_row(
+                .find(|definition| definition.provider == group.provider);
+            let built = provider_row(
                 definition,
-                status,
+                group,
                 is_waiting,
-                Rc::clone(&on_edit),
-                Rc::clone(&on_remove),
+                Rc::clone(on_edit),
+                Rc::clone(on_remove),
+                Rc::clone(on_add_account),
             );
             self.group.add(&built.row);
             rows.push(built);
+            for status in &group.accounts[1..] {
+                let built = account_row(
+                    definition,
+                    status,
+                    is_waiting,
+                    Rc::clone(on_edit),
+                    Rc::clone(on_remove),
+                );
+                self.group.add(&built.row);
+                rows.push(built);
+            }
         }
+    }
 
-        self.empty.set_visible(rows.is_empty());
+    /// Refreshes the words on rows whose shape did not change.
+    fn update(
+        &self,
+        groups: &[ProviderGroup],
+        definitions: &[ProviderDefinition],
+        is_waiting: &dyn Fn(&str, &str) -> bool,
+    ) {
+        let rows = self.rows.borrow();
+        for row in rows.iter() {
+            let Some(group) = groups.iter().find(|group| group.provider == row.provider) else {
+                continue;
+            };
+            let definition = definitions
+                .iter()
+                .find(|definition| definition.provider == group.provider);
+            match row.account.as_deref() {
+                None => update_provider_row(row, definition, group, is_waiting),
+                Some(account) => {
+                    if let Some(status) = group
+                        .accounts
+                        .iter()
+                        .find(|status| status.account == account)
+                    {
+                        update_account_row(row, definition, status, is_waiting);
+                    }
+                }
+            }
+        }
     }
 }
 
-fn configured_row(
+/// The provider's own row: its mark, its name, and the state of its first account — which
+/// is the account the pen opens, and the only account a provider with just the one has
+/// ever shown. The "+" beside the pen adds another, for providers whose credential a
+/// second account can hold its own copy of.
+fn provider_row(
     definition: Option<&ProviderDefinition>,
-    status: &ProviderStatus,
+    group: &ProviderGroup,
     is_waiting: &dyn Fn(&str, &str) -> bool,
     on_edit: IdentityCallback,
     on_remove: IdentityCallback,
+    on_add_account: ProviderCallback,
 ) -> ConfiguredRow {
+    let status = &group.accounts[0];
     let image = mark::image();
     mark::set(&image, &status.provider);
     let row = adw::ActionRow::new();
@@ -114,6 +244,17 @@ fn configured_row(
     row.set_use_markup(false);
     row.add_prefix(&image);
 
+    let add = gtk::Button::builder()
+        .icon_name("list-add-symbolic")
+        .tooltip_text("Add account")
+        .valign(gtk::Align::Center)
+        .build();
+    add.connect_clicked({
+        let on_add_account = Rc::clone(&on_add_account);
+        let provider = group.provider.clone();
+        move |_| on_add_account(provider.clone())
+    });
+
     let edit = gtk::Button::builder()
         .icon_name("document-edit-symbolic")
         .tooltip_text("Edit provider")
@@ -121,6 +262,7 @@ fn configured_row(
         .sensitive(definition.is_some())
         .build();
     edit.connect_clicked({
+        let on_edit = Rc::clone(&on_edit);
         let provider = status.provider.clone();
         let account = status.account.clone();
         move |_| on_edit(provider.clone(), account.clone())
@@ -133,6 +275,66 @@ fn configured_row(
         .css_classes(["destructive-action"])
         .build();
     remove.connect_clicked({
+        let on_remove = Rc::clone(&on_remove);
+        let provider = status.provider.clone();
+        let account = status.account.clone();
+        move |_| on_remove(provider.clone(), account.clone())
+    });
+
+    // Suffixes stack left to right in the order they are added, which is what puts the
+    // "+" left of the pen and the trash outside both.
+    row.add_suffix(&add);
+    row.add_suffix(&edit);
+    row.add_suffix(&remove);
+
+    let built = ConfiguredRow {
+        provider: status.provider.clone(),
+        account: None,
+        row,
+        image,
+        edit,
+        add: Some(add),
+    };
+    update_provider_row(&built, definition, group, is_waiting);
+    built
+}
+
+/// One account nested under its provider, indented to say which row it belongs to.
+fn account_row(
+    definition: Option<&ProviderDefinition>,
+    status: &ProviderStatus,
+    is_waiting: &dyn Fn(&str, &str) -> bool,
+    on_edit: IdentityCallback,
+    on_remove: IdentityCallback,
+) -> ConfiguredRow {
+    let image = mark::image();
+    mark::set(&image, &status.provider);
+    let row = adw::ActionRow::builder()
+        .margin_start(24)
+        .use_markup(false)
+        .build();
+    row.add_prefix(&image);
+
+    let edit = gtk::Button::builder()
+        .icon_name("document-edit-symbolic")
+        .tooltip_text("Edit account")
+        .valign(gtk::Align::Center)
+        .build();
+    edit.connect_clicked({
+        let on_edit = Rc::clone(&on_edit);
+        let provider = status.provider.clone();
+        let account = status.account.clone();
+        move |_| on_edit(provider.clone(), account.clone())
+    });
+
+    let remove = gtk::Button::builder()
+        .icon_name("user-trash-symbolic")
+        .tooltip_text("Remove account")
+        .valign(gtk::Align::Center)
+        .css_classes(["destructive-action"])
+        .build();
+    remove.connect_clicked({
+        let on_remove = Rc::clone(&on_remove);
         let provider = status.provider.clone();
         let account = status.account.clone();
         move |_| on_remove(provider.clone(), account.clone())
@@ -143,26 +345,74 @@ fn configured_row(
 
     let built = ConfiguredRow {
         provider: status.provider.clone(),
-        account: status.account.clone(),
+        account: Some(status.account.clone()),
         row,
         image,
         edit,
+        add: None,
     };
-    update_row(&built, definition, status, is_waiting);
+    update_account_row(&built, definition, status, is_waiting);
     built
 }
 
-fn update_row(
+fn update_provider_row(
+    row: &ConfiguredRow,
+    definition: Option<&ProviderDefinition>,
+    group: &ProviderGroup,
+    is_waiting: &dyn Fn(&str, &str) -> bool,
+) {
+    let status = &group.accounts[0];
+    let title = definition
+        .map(|definition| definition.title.clone())
+        .unwrap_or_else(|| provider_label(&status.provider));
+    row.row.set_title(&title);
+    row.row.set_subtitle(&status_text(
+        definition,
+        status,
+        is_waiting(&status.provider, &status.account),
+    ));
+    // A provider with a source selector to pick at counts as editable however it logs in:
+    // which local login to read is configuration, not something polling works out.
+    let editable = definition.is_some_and(opens_detail_after_add);
+    row.edit.set_visible(editable);
+    row.edit.set_sensitive(editable);
+    if let Some(add) = &row.add {
+        let capable = definition.is_some_and(multi_account_capable);
+        add.set_visible(capable);
+        add.set_sensitive(capable);
+    }
+    mark::set(&row.image, &status.provider);
+}
+
+fn update_account_row(
     row: &ConfiguredRow,
     definition: Option<&ProviderDefinition>,
     status: &ProviderStatus,
     is_waiting: &dyn Fn(&str, &str) -> bool,
 ) {
-    let title = definition
-        .map(|definition| definition.title.clone())
-        .unwrap_or_else(|| provider_label(&status.provider));
-    row.row.set_title(&title);
-    let subtitle = if is_waiting(&status.provider, &status.account) {
+    // The account's own name: the daemon publishes the label, and derives it from the id
+    // until a rename says otherwise.
+    row.row.set_title(
+        status
+            .account_label
+            .as_deref()
+            .unwrap_or(status.account.as_str()),
+    );
+    row.row.set_subtitle(&status_text(
+        definition,
+        status,
+        is_waiting(&status.provider, &status.account),
+    ));
+    mark::set(&row.image, &status.provider);
+}
+
+/// The one line of state under a row's name.
+fn status_text(
+    definition: Option<&ProviderDefinition>,
+    status: &ProviderStatus,
+    waiting: bool,
+) -> String {
+    if waiting {
         "Waiting for your browser…".into()
     } else if let Some(definition) = definition {
         model::connection_text(definition, status)
@@ -171,14 +421,7 @@ fn update_row(
             .message
             .clone()
             .unwrap_or_else(|| status.state.clone())
-    };
-    row.row.set_subtitle(&subtitle);
-    // A provider with a source selector to pick at counts as editable however it logs in:
-    // which local login to read is configuration, not something polling works out.
-    let editable = definition.is_some_and(opens_detail_after_add);
-    row.edit.set_visible(editable);
-    row.edit.set_sensitive(editable);
-    mark::set(&row.image, &status.provider);
+    }
 }
 
 /// Searchable catalog page pushed from the main provider list.
@@ -302,5 +545,68 @@ impl Picker {
             self.group.add(&row);
             rows.push(row);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tidemark_types::{AccountId, ProviderId, ProviderStatus};
+
+    use super::{ProviderGroup, group};
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
+    }
+
+    fn keys(groups: &[ProviderGroup]) -> Vec<(&str, Vec<&str>)> {
+        groups
+            .iter()
+            .map(|group| {
+                (
+                    group.provider.as_str(),
+                    group
+                        .accounts
+                        .iter()
+                        .map(|status| status.account.as_str())
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn statuses_of_one_provider_are_gathered_under_it_in_first_seen_order() {
+        // A status for a second account can arrive after another provider's, from a
+        // locally added pending row as much as from the daemon; the provider it belongs
+        // to is where it lands.
+        let groups = group(&[
+            status("kimi", "default"),
+            status("zai", "default"),
+            status("kimi", "work"),
+        ]);
+
+        assert_eq!(
+            keys(&groups),
+            vec![("kimi", vec!["default", "work"]), ("zai", vec!["default"])]
+        );
+    }
+
+    #[test]
+    fn accounts_keep_the_order_they_arrived_in() {
+        let groups = group(&[
+            status("kimi", "team"),
+            status("kimi", "default"),
+            status("kimi", "work"),
+        ]);
+
+        assert_eq!(
+            keys(&groups),
+            vec![("kimi", vec!["team", "default", "work"])]
+        );
+    }
+
+    #[test]
+    fn no_statuses_means_no_rows() {
+        assert!(group(&[]).is_empty());
     }
 }

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -63,26 +63,95 @@ fn structure(groups: &[ProviderGroup]) -> Vec<(&str, Option<&str>)> {
 pub(super) struct ConfiguredList {
     pub(super) group: adw::PreferencesGroup,
     empty: adw::StatusPage,
-    rows: RefCell<Vec<ConfiguredRow>>,
+    rows: RefCell<Vec<ProviderRow>>,
 }
 
-/// One drawn row of the configured list: a provider's own row, or one of the accounts
-/// nested under it.
+/// A provider row and its accounts. `AdwExpanderRow` owns the nested rows, which gives
+/// accounts libadwaita's standard tree indentation instead of imitating it with a glyph.
 #[derive(Debug)]
-struct ConfiguredRow {
-    /// The provider every identity below belongs to.
+struct ProviderRow {
     provider: String,
-    /// The account the row is, or `None` for the provider's own row — which is the
-    /// provider's first account's row in everything but name.
-    account: Option<String>,
+    row: ProviderWidget,
+    image: gtk::Image,
+    edit: gtk::Button,
+    add: gtk::Button,
+    accounts: Vec<AccountRow>,
+}
+
+/// The native row selected from the provider's account count.
+#[derive(Debug)]
+enum ProviderWidget {
+    Plain(adw::ActionRow),
+    Nested(adw::ExpanderRow),
+}
+
+/// The semantic row kind before GTK widgets are built.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderRowKind {
+    Plain,
+    Nested,
+}
+
+/// Only a provider with a second account needs an expansion affordance.
+fn provider_row_kind(group: &ProviderGroup) -> ProviderRowKind {
+    if group.accounts.len() > 1 {
+        ProviderRowKind::Nested
+    } else {
+        ProviderRowKind::Plain
+    }
+}
+
+impl ProviderWidget {
+    fn add_prefix(&self, widget: &impl IsA<gtk::Widget>) {
+        match self {
+            Self::Plain(row) => row.add_prefix(widget),
+            Self::Nested(row) => row.add_prefix(widget),
+        }
+    }
+
+    fn add_suffix(&self, widget: &impl IsA<gtk::Widget>) {
+        match self {
+            Self::Plain(row) => row.add_suffix(widget),
+            Self::Nested(row) => row.add_suffix(widget),
+        }
+    }
+
+    fn set_subtitle(&self, subtitle: &str) {
+        match self {
+            Self::Plain(row) => row.set_subtitle(subtitle),
+            Self::Nested(row) => row.set_subtitle(subtitle),
+        }
+    }
+
+    fn set_title(&self, title: &str) {
+        match self {
+            Self::Plain(row) => row.set_title(title),
+            Self::Nested(row) => row.set_title(title),
+        }
+    }
+
+    fn set_use_markup(&self, use_markup: bool) {
+        match self {
+            Self::Plain(row) => row.set_use_markup(use_markup),
+            Self::Nested(row) => row.set_use_markup(use_markup),
+        }
+    }
+
+    fn widget(&self) -> &gtk::Widget {
+        match self {
+            Self::Plain(row) => row.upcast_ref(),
+            Self::Nested(row) => row.upcast_ref(),
+        }
+    }
+}
+
+/// One account displayed beneath its provider.
+#[derive(Debug)]
+struct AccountRow {
+    account: String,
     row: adw::ActionRow,
     image: gtk::Image,
-    /// The pen: the provider row's opens the provider's first account, a nested row's
-    /// opens that account.
     edit: gtk::Button,
-    /// The "+", on the provider row alone. `None` on nested rows, which are the accounts
-    /// the "+" exists to create.
-    add: Option<gtk::Button>,
 }
 
 impl ConfiguredList {
@@ -123,15 +192,17 @@ impl ConfiguredList {
         let groups = group(statuses);
         let shape_held = {
             let rows = self.rows.borrow();
-            rows.len()
-                == groups
-                    .iter()
-                    .map(|group| group.accounts.len())
-                    .sum::<usize>()
-                && rows
-                    .iter()
-                    .zip(structure(&groups))
-                    .all(|(row, key)| row.provider == key.0 && row.account.as_deref() == key.1)
+            let held = rows
+                .iter()
+                .flat_map(|row| {
+                    std::iter::once((row.provider.as_str(), None)).chain(
+                        row.accounts
+                            .iter()
+                            .map(|account| (row.provider.as_str(), Some(account.account.as_str()))),
+                    )
+                })
+                .collect::<Vec<_>>();
+            held == structure(&groups)
         };
         if shape_held {
             self.update(&groups, definitions, is_waiting);
@@ -162,13 +233,13 @@ impl ConfiguredList {
     ) {
         let mut rows = self.rows.borrow_mut();
         for row in std::mem::take(&mut *rows) {
-            self.group.remove(&row.row);
+            self.group.remove(row.row.widget());
         }
         for group in groups {
             let definition = definitions
                 .iter()
                 .find(|definition| definition.provider == group.provider);
-            let built = provider_row(
+            let mut built = provider_row(
                 definition,
                 group,
                 is_waiting,
@@ -176,19 +247,24 @@ impl ConfiguredList {
                 Rc::clone(on_remove),
                 Rc::clone(on_add_account),
             );
-            self.group.add(&built.row);
-            rows.push(built);
-            for status in &group.accounts[1..] {
-                let built = account_row(
-                    definition,
-                    status,
-                    is_waiting,
-                    Rc::clone(on_edit),
-                    Rc::clone(on_remove),
-                );
-                self.group.add(&built.row);
-                rows.push(built);
+            match &built.row {
+                ProviderWidget::Plain(_) => {}
+                ProviderWidget::Nested(row) => {
+                    for status in &group.accounts[1..] {
+                        let account = account_row(
+                            definition,
+                            status,
+                            is_waiting,
+                            Rc::clone(on_edit),
+                            Rc::clone(on_remove),
+                        );
+                        row.add_row(&account.row);
+                        built.accounts.push(account);
+                    }
+                }
             }
+            self.group.add(built.row.widget());
+            rows.push(built);
         }
     }
 
@@ -207,16 +283,14 @@ impl ConfiguredList {
             let definition = definitions
                 .iter()
                 .find(|definition| definition.provider == group.provider);
-            match row.account.as_deref() {
-                None => update_provider_row(row, definition, group, is_waiting),
-                Some(account) => {
-                    if let Some(status) = group
-                        .accounts
-                        .iter()
-                        .find(|status| status.account == account)
-                    {
-                        update_account_row(row, definition, status, is_waiting);
-                    }
+            update_provider_row(row, definition, group, is_waiting);
+            for account in &row.accounts {
+                if let Some(status) = group
+                    .accounts
+                    .iter()
+                    .find(|status| status.account == account.account)
+                {
+                    update_account_row(account, definition, status, is_waiting);
                 }
             }
         }
@@ -234,11 +308,16 @@ fn provider_row(
     on_edit: IdentityCallback,
     on_remove: IdentityCallback,
     on_add_account: ProviderCallback,
-) -> ConfiguredRow {
+) -> ProviderRow {
     let status = &group.accounts[0];
     let image = mark::image();
     mark::set(&image, &status.provider);
-    let row = adw::ActionRow::new();
+    let row = match provider_row_kind(group) {
+        ProviderRowKind::Plain => ProviderWidget::Plain(adw::ActionRow::new()),
+        ProviderRowKind::Nested => {
+            ProviderWidget::Nested(adw::ExpanderRow::builder().expanded(true).build())
+        }
+    };
     // The picker's stay-off-markup rule again: the title and the subtitle both carry
     // the daemon's own words, which are data, never markup.
     row.set_use_markup(false);
@@ -287,41 +366,29 @@ fn provider_row(
     row.add_suffix(&edit);
     row.add_suffix(&remove);
 
-    let built = ConfiguredRow {
+    let built = ProviderRow {
         provider: status.provider.clone(),
-        account: None,
         row,
         image,
         edit,
-        add: Some(add),
+        add,
+        accounts: Vec::new(),
     };
     update_provider_row(&built, definition, group, is_waiting);
     built
 }
 
-/// One account nested under its provider, indented to say which row it belongs to.
+/// One account nested under its provider by `AdwExpanderRow`.
 fn account_row(
     definition: Option<&ProviderDefinition>,
     status: &ProviderStatus,
     is_waiting: &dyn Fn(&str, &str) -> bool,
     on_edit: IdentityCallback,
     on_remove: IdentityCallback,
-) -> ConfiguredRow {
+) -> AccountRow {
     let image = mark::image();
     mark::set(&image, &status.provider);
-    let row = adw::ActionRow::builder()
-        .margin_start(24)
-        .use_markup(false)
-        .build();
-    // A dimmed corner tying the row to the provider above it — the margin alone read as
-    // a stray indent rather than as nesting. Pango falls back to a font that draws the
-    // glyph when the interface font has none of its own.
-    let corner = gtk::Label::builder()
-        .label("⌞")
-        .valign(gtk::Align::Center)
-        .css_classes(["dim-label"])
-        .build();
-    row.add_prefix(&corner);
+    let row = adw::ActionRow::builder().use_markup(false).build();
     row.add_prefix(&image);
 
     let edit = gtk::Button::builder()
@@ -352,20 +419,18 @@ fn account_row(
     row.add_suffix(&edit);
     row.add_suffix(&remove);
 
-    let built = ConfiguredRow {
-        provider: status.provider.clone(),
-        account: Some(status.account.clone()),
+    let built = AccountRow {
+        account: status.account.clone(),
         row,
         image,
         edit,
-        add: None,
     };
     update_account_row(&built, definition, status, is_waiting);
     built
 }
 
 fn update_provider_row(
-    row: &ConfiguredRow,
+    row: &ProviderRow,
     definition: Option<&ProviderDefinition>,
     group: &ProviderGroup,
     is_waiting: &dyn Fn(&str, &str) -> bool,
@@ -385,16 +450,14 @@ fn update_provider_row(
     let editable = definition.is_some_and(opens_detail_after_add);
     row.edit.set_visible(editable);
     row.edit.set_sensitive(editable);
-    if let Some(add) = &row.add {
-        let capable = definition.is_some_and(multi_account_capable);
-        add.set_visible(capable);
-        add.set_sensitive(capable);
-    }
+    let capable = definition.is_some_and(multi_account_capable);
+    row.add.set_visible(capable);
+    row.add.set_sensitive(capable);
     mark::set(&row.image, &status.provider);
 }
 
 fn update_account_row(
-    row: &ConfiguredRow,
+    row: &AccountRow,
     definition: Option<&ProviderDefinition>,
     status: &ProviderStatus,
     is_waiting: &dyn Fn(&str, &str) -> bool,
@@ -567,7 +630,7 @@ impl Picker {
 mod tests {
     use tidemark_types::{AccountId, ProviderId, ProviderStatus};
 
-    use super::{ProviderGroup, group, structure};
+    use super::{ProviderGroup, ProviderRowKind, group, provider_row_kind, structure};
 
     fn status(provider: &str, account: &str) -> ProviderStatus {
         ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
@@ -641,6 +704,15 @@ mod tests {
                 ("zai", None),
             ]
         );
+    }
+
+    #[test]
+    fn a_provider_with_one_account_uses_a_plain_row_but_multiple_accounts_expand() {
+        let single = group(&[status("kimi", "default")]);
+        let multiple = group(&[status("kimi", "default"), status("kimi", "work")]);
+
+        assert_eq!(provider_row_kind(&single[0]), ProviderRowKind::Plain);
+        assert_eq!(provider_row_kind(&multiple[0]), ProviderRowKind::Nested);
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/mod.rs
+++ b/crates/tidemark/src/provider_settings/mod.rs
@@ -11,11 +11,18 @@ use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
 use gtk::glib;
-use tidemark_types::{AccountId, CredentialKind, ProviderDefinition, ProviderId, ProviderStatus};
+use tidemark_types::{
+    AccountId, CredentialKind, ProviderDefinition, ProviderId, ProviderStatus,
+    account_slug_suggestion, valid_account_slug,
+};
 
 use self::detail::ProviderDetail;
 use self::list::{ConfiguredList, Picker};
 use crate::bus::DaemonProxy;
+
+/// The account a provider's structural first add holds. The daemon will not rename it,
+/// so the label pen stays off its page.
+pub(super) const DEFAULT_ACCOUNT: &str = "default";
 
 /// OAuth attempts which the open dialog is responsible for cancelling on close.
 #[derive(Debug, Default)]
@@ -144,12 +151,12 @@ impl ActiveDetail {
 
 fn remove_local_provider<T>(
     statuses: &mut Vec<ProviderStatus>,
-    local_added: &mut HashSet<String>,
+    local_added: &mut HashSet<(String, String)>,
     details: &mut DetailCache<T>,
     provider: &str,
     account: &str,
 ) {
-    local_added.remove(provider);
+    local_added.remove(&(provider.into(), account.into()));
     statuses.retain(|status| status.provider != provider || status.account != account);
     details.remove(provider, account);
 }
@@ -161,7 +168,7 @@ pub struct ProviderSettings {
     proxy: DaemonProxy<'static>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     statuses: RefCell<Vec<ProviderStatus>>,
-    local_added: RefCell<HashSet<String>>,
+    local_added: RefCell<HashSet<(String, String)>>,
     configured: ConfiguredList,
     picker: Rc<Picker>,
     details: RefCell<DetailCache<Rc<ProviderDetail>>>,
@@ -244,9 +251,11 @@ impl ProviderSettings {
             &self.statuses.borrow(),
             &self.local_added.borrow(),
         );
-        self.local_added
-            .borrow_mut()
-            .retain(|provider| !statuses.iter().any(|status| status.provider == *provider));
+        self.local_added.borrow_mut().retain(|(provider, account)| {
+            !statuses
+                .iter()
+                .any(|status| &status.provider == provider && &status.account == account)
+        });
         let return_to_list = self.active_detail.borrow_mut().take_if_missing(&merged);
         *self.statuses.borrow_mut() = merged;
         self.details.borrow_mut().retain(|provider, account| {
@@ -280,6 +289,7 @@ impl ProviderSettings {
             &|provider, account| self.pending.contains(provider, account),
             self.identity_callback(Self::open_detail),
             self.identity_callback(Self::confirm_removal),
+            self.provider_callback(Self::add_account),
         );
         self.picker.apply(&definitions, &statuses);
     }
@@ -292,6 +302,15 @@ impl ProviderSettings {
         Rc::new(move |provider, account| {
             if let Some(settings) = weak.upgrade() {
                 action(&settings, provider, account);
+            }
+        })
+    }
+
+    fn provider_callback(&self, action: fn(&Rc<Self>, String)) -> Rc<dyn Fn(String)> {
+        let weak = self.self_weak.borrow().clone();
+        Rc::new(move |provider| {
+            if let Some(settings) = weak.upgrade() {
+                action(&settings, provider);
             }
         })
     }
@@ -323,19 +342,74 @@ impl ProviderSettings {
                 .statuses
                 .borrow()
                 .iter()
-                .any(|status| status.provider == provider)
+                .any(|status| status.provider == provider && status.account == DEFAULT_ACCOUNT)
             {
-                settings.local_added.borrow_mut().insert(provider.clone());
+                settings
+                    .local_added
+                    .borrow_mut()
+                    .insert((provider.clone(), DEFAULT_ACCOUNT.to_owned()));
                 settings
                     .statuses
                     .borrow_mut()
-                    .push(pending_status(&definition));
+                    .push(pending_status(&definition, DEFAULT_ACCOUNT));
             }
             settings.refresh_views();
             settings.dialog.pop_subpage();
             if opens_detail_after_add(&definition) {
                 settings.open_detail(provider, AccountId::default().to_string());
             }
+        });
+    }
+
+    /// The provider row's "+": asks for a name, has the daemon add the account it
+    /// suggests, and lands on that account's page to give it a credential.
+    fn add_account(self: &Rc<Self>, provider: String) {
+        let definition = self
+            .definitions
+            .borrow()
+            .iter()
+            .find(|definition| definition.provider == provider)
+            .cloned();
+        let Some(definition) = definition else {
+            return;
+        };
+        let settings = Rc::clone(self);
+        glib::spawn_future_local(async move {
+            let Some(slug) = name_dialog(
+                &settings.dialog,
+                &format!("New {} account", definition.title),
+                "",
+                "Add",
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+            if let Err(error) = settings.proxy.add_account(&provider, &slug).await {
+                settings.toast(&reason(&error));
+                return;
+            }
+            // The daemon persists the account before it answers, and publishes its first
+            // status from its own task; until that lands, the account exists only as this
+            // pending row, kept alive by the same machinery an added provider's is.
+            if !settings
+                .statuses
+                .borrow()
+                .iter()
+                .any(|status| status.provider == provider && status.account == slug)
+            {
+                settings
+                    .local_added
+                    .borrow_mut()
+                    .insert((provider.clone(), slug.clone()));
+                settings
+                    .statuses
+                    .borrow_mut()
+                    .push(pending_status(&definition, &slug));
+            }
+            settings.refresh_views();
+            settings.open_detail(provider, slug);
         });
     }
 
@@ -456,10 +530,10 @@ impl ProviderSettings {
     }
 }
 
-fn pending_status(definition: &ProviderDefinition) -> ProviderStatus {
+fn pending_status(definition: &ProviderDefinition, account: &str) -> ProviderStatus {
     let mut status = ProviderStatus::pending(
         &ProviderId::new(&definition.provider),
-        &AccountId::default(),
+        &AccountId::new(account),
     );
     status.credential = Some(definition.credential.clone());
     status.credential_hint = Some(definition.credential_hint.clone());
@@ -480,6 +554,83 @@ pub(super) fn opens_detail_after_add(definition: &ProviderDefinition) -> bool {
         || !definition.options.is_empty()
 }
 
+/// Whether a user can give this provider another account: a key or a browser login is
+/// something a second account can hold its own copy of, while an external or
+/// credential-free provider reads whatever one thing this machine already has.
+pub(super) fn multi_account_capable(definition: &ProviderDefinition) -> bool {
+    matches!(
+        definition.credential_kind(),
+        Some(CredentialKind::Key | CredentialKind::OAuth)
+    )
+}
+
+/// Whether a typed name can be confirmed: it must suggest an id the config can hold, and
+/// a rename must suggest one the account does not already have.
+pub(super) fn name_suggests_usable(name: &str, current: Option<&str>) -> bool {
+    let slug = account_slug_suggestion(name);
+    valid_account_slug(&slug) && current.is_none_or(|held| held != slug)
+}
+
+/// The name-to-id entry dialog the provider row's "+" and the account label's pen share.
+///
+/// The id, not the name, is what gets stored — so the id the name suggests is previewed
+/// live under the entry, and confirm stays disabled until the name suggests an id the
+/// config can hold (and, for a rename, one the account does not already have). Returns
+/// the suggested id, or `None` when the dialog was dismissed.
+pub(super) async fn name_dialog(
+    parent: &impl IsA<gtk::Widget>,
+    heading: &str,
+    prefill: &str,
+    confirm: &str,
+    current: Option<&str>,
+) -> Option<String> {
+    let entry = gtk::Entry::builder()
+        .placeholder_text("Account name")
+        .text(prefill)
+        .activates_default(true)
+        .build();
+    // Owned rather than borrowed: the entry keeps validating after this returns, and the
+    // id a rename may not re-suggest has to live as long as the preview does.
+    let current = current.map(str::to_owned);
+    let preview = gtk::Label::builder()
+        .xalign(0.0)
+        .css_classes(["caption", "dim-label"])
+        .build();
+    let dialog = adw::AlertDialog::builder().heading(heading).build();
+    dialog.add_responses(&[("cancel", "Cancel"), ("accept", confirm)]);
+    dialog.set_default_response(Some("accept"));
+    dialog.set_close_response("cancel");
+    dialog.set_response_appearance("accept", adw::ResponseAppearance::Suggested);
+
+    let refresh_preview = {
+        let entry = entry.clone();
+        let preview = preview.clone();
+        let dialog = dialog.clone();
+        move || {
+            let name = entry.text().to_string();
+            let slug = account_slug_suggestion(&name);
+            preview.set_text(&format!("Account id: {slug}"));
+            dialog.set_response_enabled("accept", name_suggests_usable(&name, current.as_deref()));
+        }
+    };
+    entry.connect_changed({
+        let refresh_preview = refresh_preview.clone();
+        move |_| refresh_preview()
+    });
+    refresh_preview();
+
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(6)
+        .build();
+    content.append(&entry);
+    content.append(&preview);
+    dialog.set_extra_child(Some(&content));
+
+    (dialog.choose_future(Some(parent)).await == "accept")
+        .then(|| account_slug_suggestion(&entry.text()))
+}
+
 /// A D-Bus error as one sentence for a toast.
 pub(super) fn reason(error: &zbus::Error) -> String {
     match error {
@@ -492,11 +643,15 @@ pub(super) fn reason(error: &zbus::Error) -> String {
 mod tests {
     use std::collections::HashSet;
 
-    use tidemark_types::{AuthMode, AuthSelector, CredentialKind, ProviderDefinition};
+    use tidemark_types::{
+        AccountId, AuthMode, AuthSelector, CredentialKind, ProviderDefinition, ProviderId,
+        ProviderStatus,
+    };
 
     use super::detail::{AfterBeginAction, after_begin_action};
     use super::{
-        ActiveDetail, DetailCache, PendingLogins, opens_detail_after_add, remove_local_provider,
+        ActiveDetail, DEFAULT_ACCOUNT, DetailCache, PendingLogins, multi_account_capable,
+        name_suggests_usable, opens_detail_after_add, remove_local_provider,
     };
 
     fn definition(credential: CredentialKind) -> ProviderDefinition {
@@ -559,6 +714,36 @@ mod tests {
     }
 
     #[test]
+    fn key_and_oauth_providers_can_hold_more_than_one_account() {
+        // A key or a browser login is something a second account can hold its own copy
+        // of; those are the providers the "+" is drawn on.
+        assert!(multi_account_capable(&definition(CredentialKind::Key)));
+        assert!(multi_account_capable(&definition(CredentialKind::OAuth)));
+    }
+
+    #[test]
+    fn external_and_credential_free_providers_cannot_hold_a_second_account() {
+        assert!(!multi_account_capable(&definition(
+            CredentialKind::External
+        )));
+        assert!(!multi_account_capable(&definition(CredentialKind::None)));
+        let mut unknown = definition(CredentialKind::None);
+        unknown.credential = "future-kind".into();
+        assert!(!multi_account_capable(&unknown));
+    }
+
+    #[test]
+    fn a_name_can_only_be_confirmed_when_it_suggests_a_fresh_id() {
+        assert!(!name_suggests_usable("", None));
+        assert!(!name_suggests_usable("   ", None));
+        assert!(name_suggests_usable("My Work", None));
+        // A rename to the id the account already has is the daemon's no-op refusal, and
+        // the confirm button is where the user should hear that from.
+        assert!(!name_suggests_usable("My Work", Some("my-work")));
+        assert!(name_suggests_usable("My Team", Some("my-work")));
+    }
+
+    #[test]
     fn pending_logins_are_taken_once_for_cancellation() {
         let pending = PendingLogins::default();
         pending.insert("antigravity", "default");
@@ -609,7 +794,7 @@ mod tests {
     fn remove_then_readd_uses_a_fresh_detail_value() {
         let mut details = DetailCache::default();
         let mut statuses = Vec::new();
-        let mut local_added = HashSet::from(["zai".to_owned()]);
+        let mut local_added = HashSet::from([("zai".to_owned(), DEFAULT_ACCOUNT.to_owned())]);
         details.insert("zai", "default", "old credential page");
 
         remove_local_provider(
@@ -623,7 +808,7 @@ mod tests {
 
         assert_eq!(details.get("zai", "default"), Some(&"fresh pending page"));
         assert_eq!(details.values().count(), 1);
-        assert!(!local_added.contains("zai"));
+        assert!(!local_added.contains(&("zai".to_owned(), DEFAULT_ACCOUNT.to_owned())));
     }
 
     #[test]
@@ -632,6 +817,21 @@ mod tests {
         active.show("zai", "default");
 
         assert!(active.take_if_missing(&[]));
+        assert_eq!(active.identity(), None);
+    }
+
+    #[test]
+    fn a_renamed_active_detail_is_retired_when_only_its_successor_remains() {
+        // A rename announces the old id's removal and the new id's arrival; the page keyed
+        // by the old id must return to the list rather than pretend to be its successor.
+        let mut active = ActiveDetail::default();
+        active.show("kimi", "work");
+        let successor = vec![ProviderStatus::pending(
+            &ProviderId::new("kimi"),
+            &AccountId::new("team"),
+        )];
+
+        assert!(active.take_if_missing(&successor));
         assert_eq!(active.identity(), None);
     }
 }

--- a/crates/tidemark/src/provider_settings/model.rs
+++ b/crates/tidemark/src/provider_settings/model.rs
@@ -194,22 +194,26 @@ pub fn notification_rows(status: &ProviderStatus) -> Vec<NotificationRow> {
         .collect()
 }
 
-/// Keeps successful local additions visible until the daemon publishes their first status.
+/// Keeps successful local additions visible until the daemon publishes their first
+/// status, keyed by the identity the addition will hold. Provider-level enough for a
+/// provider's default account, account-level enough for the "+" beside it: a provider
+/// whose other accounts already poll must not swallow the pending row a just-added
+/// account is waiting on.
 pub fn merge_local_additions(
     incoming: &[ProviderStatus],
     current: &[ProviderStatus],
-    local_additions: &HashSet<String>,
+    local_additions: &HashSet<(String, String)>,
 ) -> Vec<ProviderStatus> {
     let mut merged = incoming.to_vec();
     for status in current {
-        let still_local = local_additions.contains(&status.provider)
-            && !incoming
-                .iter()
-                .any(|incoming| incoming.provider == status.provider);
-        let already_present = merged
+        let is = |other: &ProviderStatus| {
+            other.provider == status.provider && other.account == status.account
+        };
+        let still_local = local_additions
             .iter()
-            .any(|merged| merged.provider == status.provider && merged.account == status.account);
-        if still_local && !already_present {
+            .any(|(provider, account)| provider == &status.provider && account == &status.account)
+            && !incoming.iter().any(is);
+        if still_local && !merged.iter().any(is) {
             merged.push(status.clone());
         }
     }
@@ -291,6 +295,13 @@ mod tests {
             ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new("default"));
         status.set_state(state, None);
         status.has_credential = has_credential;
+        status
+    }
+
+    fn account_status(provider: &str, account: &str, state: ProviderState) -> ProviderStatus {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account));
+        status.set_state(state, None);
         status
     }
 
@@ -417,7 +428,7 @@ mod tests {
     fn an_unacknowledged_local_add_survives_an_unrelated_status_update() {
         let current = vec![status("codex", ProviderState::Pending, Some(false))];
         let incoming = vec![status("claude", ProviderState::Ok, Some(false))];
-        let local = HashSet::from(["codex".to_owned()]);
+        let local = HashSet::from([("codex".to_owned(), "default".to_owned())]);
 
         let merged = merge_local_additions(&incoming, &current, &local);
 
@@ -428,6 +439,39 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["claude", "codex"]
         );
+    }
+
+    #[test]
+    fn an_unacknowledged_local_account_survives_while_its_provider_has_other_accounts() {
+        // The provider's own status arriving is not the new account arriving: the "+"
+        // lands on a provider that already polls, and the pending row it added must not
+        // vanish the first time a sibling reports in.
+        let current = vec![
+            status("kimi", ProviderState::Ok, Some(true)),
+            account_status("kimi", "work", ProviderState::Pending),
+        ];
+        let incoming = vec![status("kimi", ProviderState::Ok, Some(true))];
+        let local = HashSet::from([("kimi".to_owned(), "work".to_owned())]);
+
+        let merged = merge_local_additions(&incoming, &current, &local);
+
+        let identities: Vec<(&str, &str)> = merged
+            .iter()
+            .map(|status| (status.provider.as_str(), status.account.as_str()))
+            .collect();
+        assert_eq!(identities, [("kimi", "default"), ("kimi", "work")]);
+    }
+
+    #[test]
+    fn a_locally_added_account_the_daemon_publishes_is_not_duplicated() {
+        let current = vec![account_status("kimi", "work", ProviderState::Pending)];
+        let incoming = vec![account_status("kimi", "work", ProviderState::Ok)];
+        let local = HashSet::from([("kimi".to_owned(), "work".to_owned())]);
+
+        let merged = merge_local_additions(&incoming, &current, &local);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].state, ProviderState::Ok.as_wire());
     }
 
     fn windowed(keys: &[(&str, &str)], notify: &[&str]) -> ProviderStatus {

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -105,6 +105,27 @@ pub(crate) const STYLE: &str = "
     font-weight: bold;
 }
 
+/* A notification-style account counter: it overlays the card corner and is deliberately
+   outside the title row, whose provider, plan and state labels can all grow independently. */
+.quota-account-toggle {
+    min-width: 28px;
+    min-height: 28px;
+    padding: 0;
+    background-color: @accent_bg_color;
+    color: @accent_fg_color;
+    font-size: 0.75em;
+    font-weight: bold;
+    transform: translate(10px, -10px);
+    transition: transform 150ms ease-out;
+    box-shadow: 0 1px 3px 0 alpha(black, 0.3);
+}
+
+/* The badge lives in the slot, outside the card surface, so it repeats the card's hover
+   lift rather than looking detached from the surface it labels. */
+.quota-grid > .quota-slot:hover:not(.dragging) > .quota-account-toggle {
+    transform: translate(10px, -12px);
+}
+
 /* The plan is the same pill without a tone: it says what the account is, not what is wrong
    with it. `alpha(currentColor, …)` is what makes one rule serve both styles — the
    foreground is dark on a light card and light on a dark one, so the pill comes out a step

--- a/crates/tidemark/src/tray.rs
+++ b/crates/tidemark/src/tray.rs
@@ -108,8 +108,9 @@ pub fn needs_attention(statuses: &[ProviderStatus]) -> bool {
 }
 
 /// The provider's name, with the account after it only when it is needed to tell two rows
-/// apart. One account per provider is the ordinary case and `Claude (default)` would be a
-/// word of noise on every line of the menu.
+/// apart — preferring the account's label, falling back to its id. One account per provider
+/// is the ordinary case and `Claude (default)` would be a word of noise on every line of the
+/// menu.
 fn label(all: &[ProviderStatus], status: &ProviderStatus, titles: &model::Titles) -> String {
     let name = model::name(titles, &status.provider);
     let shared = all
@@ -118,7 +119,8 @@ fn label(all: &[ProviderStatus], status: &ProviderStatus, titles: &model::Titles
         .count()
         > 1;
     if shared {
-        format!("{name} ({})", status.account)
+        let account = status.account_label.as_deref().unwrap_or(&status.account);
+        format!("{name} ({account})")
     } else {
         name
     }
@@ -449,6 +451,29 @@ mod tests {
             "the grid's order is the user's, and the panel does not have an opinion"
         );
         assert_eq!(rows[1].line(), "Z.ai — 90%");
+    }
+
+    #[test]
+    fn a_shared_provider_says_which_account_each_row_is() {
+        let statuses = [
+            reading("claude", "default", vec![window(18_000, 10.0)]),
+            reading("claude", "work", vec![window(18_000, 20.0)]),
+        ];
+        let rows = entries(&statuses, &model::Titles::new());
+        assert_eq!(rows[0].line(), "Claude (default) — 10%");
+        assert_eq!(rows[1].line(), "Claude (work) — 20%");
+    }
+
+    #[test]
+    fn a_shared_provider_prefers_the_account_label_to_its_id() {
+        let mut second = reading("claude", "work", vec![window(18_000, 20.0)]);
+        second.account_label = Some("Work Laptop".to_string());
+        let statuses = [
+            reading("claude", "default", vec![window(18_000, 10.0)]),
+            second,
+        ];
+        let rows = entries(&statuses, &model::Titles::new());
+        assert_eq!(rows[1].line(), "Claude (Work Laptop) — 20%");
     }
 
     #[test]

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -12,6 +12,7 @@
 //! changes.
 
 use std::cell::{Cell, RefCell};
+use std::collections::BTreeSet;
 use std::rc::{Rc, Weak};
 
 use adw::prelude::*;
@@ -22,7 +23,7 @@ use tidemark_types::{
 
 use crate::about;
 use crate::bus::{self, DaemonProxy, Update};
-use crate::card::Card;
+use crate::card::{Card, CardExpansion};
 use crate::detail::DetailDialog;
 use crate::grid::CardGrid;
 use crate::model;
@@ -93,9 +94,11 @@ pub struct MainWindow {
     release: gtk::Button,
     providers: gtk::Button,
     preferences_action: gio::SimpleAction,
-    /// The cards in the order they are on screen. The one order this process has: the tray
-    /// menu and the settings list are both drawn from it, and it is what a drag permutes.
+    /// Every account card, ordered by provider and then account. Collapsed account cards stay
+    /// here for the tray and provider settings even while the grid omits them.
     cards: RefCell<Vec<Rc<Card>>>,
+    /// Provider groups expanded in this window. It deliberately resets on the next launch.
+    expanded: RefCell<BTreeSet<String>>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     daemon: RefCell<Option<DaemonProxy<'static>>>,
     /// What the daemon last said its version was, for the About dialog's troubleshooting
@@ -224,6 +227,7 @@ impl MainWindow {
                 release_check_available: false,
             }),
             minimize_on_close: Cell::new(true),
+            expanded: RefCell::new(BTreeSet::new()),
             provider_settings: DialogSlot::default(),
             preferences_dialog: DialogSlot::default(),
             detail_dialog: DialogSlot::default(),
@@ -354,6 +358,7 @@ impl MainWindow {
             // Connected, and there is genuinely nothing to draw. Distinguished from a
             // missing daemon on purpose: one of them is fixed by configuring an account
             // and the other by starting a service.
+            self.expanded.borrow_mut().clear();
             self.show_message(
                 "view-grid-symbolic",
                 "Welcome to Tidemark",
@@ -366,26 +371,51 @@ impl MainWindow {
             return;
         }
 
-        let now = Timestamp::now();
-        let cards: Vec<Rc<Card>> = statuses
-            .iter()
-            .map(|status| self.make_card(status, now))
-            .collect();
+        self.expanded
+            .borrow_mut()
+            .retain(|provider| statuses.iter().any(|status| status.provider == *provider));
 
-        self.grid.clear();
-        *self.cards.borrow_mut() = cards.clone();
-        for card in &cards {
-            // Appended in the sequence the daemon published, which is the sequence the user
-            // arranged: there is nothing left to sort afterwards.
-            self.grid.append(card.widget());
+        let now = Timestamp::now();
+        let mut cards = Vec::new();
+        for group in model::provider_groups(&statuses) {
+            let provider = &group[0].provider;
+            let provider_name = model::name(&self.titles(), provider);
+            let expanded = self.expanded.borrow().contains(provider);
+            let extra_accounts = group.len() - 1;
+            for (index, status) in group.iter().enumerate() {
+                let title = if index == 0 {
+                    provider_name.clone()
+                } else {
+                    status
+                        .account_label
+                        .clone()
+                        .unwrap_or_else(|| status.account.clone())
+                };
+                let expansion = (index == 0 && extra_accounts > 0).then(|| {
+                    let weak = Rc::downgrade(self);
+                    let provider = provider.clone();
+                    CardExpansion {
+                        extra_accounts,
+                        expanded,
+                        on_toggled: Rc::new(move |expanded| {
+                            if let Some(main) = weak.upgrade() {
+                                main.set_group_expanded(&provider, expanded);
+                            }
+                        }),
+                    }
+                });
+                cards.push(self.make_card(status, now, title, expansion));
+            }
         }
+        *self.cards.borrow_mut() = cards;
+        self.redraw_cards();
         self.stack.set_visible_child_name(PAGE_GRID);
         self.update_provider_settings();
         self.update_detail_from_statuses(&statuses);
     }
 
     /// Removes one account's card after the daemon confirms it is no longer configured.
-    fn show_removed(&self, provider: &str, account: &str) {
+    fn show_removed(self: &Rc<Self>, provider: &str, account: &str) {
         if let Some(dialog) = self.detail_dialog.get()
             && dialog.matches(provider, account)
         {
@@ -397,16 +427,8 @@ impl MainWindow {
             return;
         };
 
-        let card = self.cards.borrow_mut().remove(index);
-        self.grid.remove(card.widget());
-        if self.cards.borrow().is_empty() {
-            self.show_message(
-                "view-grid-symbolic",
-                "Welcome to Tidemark",
-                "Add a provider to start tracking your quota.",
-            );
-        }
-        self.update_provider_settings();
+        self.cards.borrow_mut().remove(index);
+        self.show_all(self.statuses());
     }
 
     /// Applies one account's update, adding a card for an account seen for the first time.
@@ -420,12 +442,15 @@ impl MainWindow {
         match existing {
             Some(index) => {
                 let card = Rc::clone(&self.cards.borrow()[index]);
+                card.set_title(&self.card_title(&status, status.account == "default"));
                 card.apply(&status, now);
             }
             None => {
-                let card = self.make_card(&status, now);
-                self.cards.borrow_mut().push(Rc::clone(&card));
-                self.grid.append(card.widget());
+                self.expanded.borrow_mut().insert(status.provider.clone());
+                let mut statuses = self.statuses();
+                statuses.push(status);
+                self.show_all(statuses);
+                return;
             }
         }
         self.stack.set_visible_child_name(PAGE_GRID);
@@ -453,19 +478,78 @@ impl MainWindow {
         }
     }
 
+    /// Replaces the visible subset of account cards without affecting the tray's full list.
+    fn redraw_cards(&self) {
+        self.grid.replace(
+            self.visible_cards()
+                .into_iter()
+                .map(|card| card.widget().clone())
+                .collect(),
+        );
+    }
+
+    /// The cards the grid currently owns: main cards always, extra cards only when expanded.
+    fn visible_cards(&self) -> Vec<Rc<Card>> {
+        let cards = self.cards.borrow();
+        let mut visible = Vec::new();
+        let mut first = 0;
+        while first < cards.len() {
+            let provider = cards[first].status().provider;
+            let expanded = self.expanded.borrow().contains(&provider);
+            let mut next = first + 1;
+            while next < cards.len() && cards[next].status().provider == provider {
+                next += 1;
+            }
+            visible.push(Rc::clone(&cards[first]));
+            if expanded {
+                visible.extend(cards[first + 1..next].iter().cloned());
+            }
+            first = next;
+        }
+        visible
+    }
+
+    /// Stores an in-memory expansion choice and redraws just the grid representation.
+    fn set_group_expanded(&self, provider: &str, expanded: bool) {
+        if expanded {
+            self.expanded.borrow_mut().insert(provider.into());
+        } else {
+            self.expanded.borrow_mut().remove(provider);
+        }
+        self.redraw_cards();
+    }
+
+    /// The title a card shows: provider title for the main account, account label otherwise.
+    fn card_title(&self, status: &ProviderStatus, main: bool) -> String {
+        if main {
+            model::name(&self.titles(), &status.provider)
+        } else {
+            status
+                .account_label
+                .clone()
+                .unwrap_or_else(|| status.account.clone())
+        }
+    }
+
     /// Builds a card whose activation is owned by this window, not by the card itself.
-    fn make_card(self: &Rc<Self>, status: &ProviderStatus, now: Timestamp) -> Rc<Card> {
+    fn make_card(
+        self: &Rc<Self>,
+        status: &ProviderStatus,
+        now: Timestamp,
+        title: String,
+        expansion: Option<CardExpansion>,
+    ) -> Rc<Card> {
         let weak = Rc::downgrade(self);
-        let provider_name = model::name(&self.titles(), &status.provider);
         Rc::new(Card::new(
             status,
             now,
-            provider_name,
+            title,
             Rc::new(move |provider, account| {
                 if let Some(main) = weak.upgrade() {
                     main.open_detail(&provider, &account);
                 }
             }),
+            expansion,
         ))
     }
 
@@ -628,53 +712,58 @@ impl MainWindow {
             let Some(main) = weak.upgrade() else {
                 return;
             };
-            {
-                let mut cards = main.cards.borrow_mut();
-                if from >= cards.len() || to >= cards.len() {
-                    return;
-                }
-                let moved = cards.remove(from);
-                cards.insert(to, moved);
-            }
-            main.update_provider_settings();
-            main.update_tray();
-
-            let Some(proxy) = main.daemon.borrow().clone() else {
+            let statuses = main.statuses();
+            let visible: Vec<ProviderStatus> = main
+                .visible_cards()
+                .iter()
+                .map(|card| card.status())
+                .collect();
+            let Some(reorder) = model::card_reorder(&statuses, &visible, from, to) else {
+                main.redraw_cards();
                 return;
             };
-            let order: Vec<String> = main
-                .cards
-                .borrow()
-                .iter()
-                .map(|card| card.status().provider)
-                .collect();
-            let weak = Rc::downgrade(&main);
-            glib::spawn_future_local(async move {
-                if let Err(error) = proxy.set_order(&order).await {
-                    tracing::warn!(%error, "the daemon refused the new card order");
-                    let Some(main) = weak.upgrade() else {
-                        return;
-                    };
-                    match proxy.get_status().await {
-                        Ok(statuses) => main.show_order(
-                            &statuses
-                                .iter()
-                                .map(|status| status.provider.clone())
-                                .collect::<Vec<String>>(),
-                        ),
-                        Err(error) => {
-                            tracing::warn!(%error, "and did not say what the order actually is")
+            let Some(proxy) = main.daemon.borrow().clone() else {
+                main.redraw_cards();
+                return;
+            };
+            match reorder {
+                model::CardReorder::Providers(order) => {
+                    main.show_order(&order);
+                    let weak = Rc::downgrade(&main);
+                    glib::spawn_future_local(async move {
+                        if let Err(error) = proxy.set_order(&order).await {
+                            tracing::warn!(%error, "the daemon refused the new provider order");
+                            MainWindow::restore_order_after_refusal(weak, proxy).await;
                         }
-                    }
+                    });
                 }
-            });
+                model::CardReorder::Accounts { provider, accounts } => {
+                    main.show_account_order(&provider, &accounts);
+                    let weak = Rc::downgrade(&main);
+                    glib::spawn_future_local(async move {
+                        if let Err(error) = proxy.set_account_order(&provider, accounts).await {
+                            tracing::warn!(%error, "the daemon refused the new account order");
+                            MainWindow::restore_order_after_refusal(weak, proxy).await;
+                        }
+                    });
+                }
+            }
         });
     }
 
+    /// Restores the full daemon order after an optimistic drag was rejected.
+    async fn restore_order_after_refusal(weak: Weak<Self>, proxy: DaemonProxy<'static>) {
+        match proxy.get_status().await {
+            Ok(statuses) => {
+                if let Some(main) = weak.upgrade() {
+                    main.show_all(statuses);
+                }
+            }
+            Err(error) => tracing::warn!(%error, "and did not say what the order actually is"),
+        }
+    }
+
     /// Puts the cards in the order the daemon published.
-    ///
-    /// Ordering by provider slug, because that is the identity `config.toml` has: two
-    /// accounts of one provider — which v1 does not create — keep their relative places.
     fn show_order(&self, providers: &[String]) {
         let slugs: Vec<String> = self
             .cards
@@ -695,13 +784,34 @@ impl MainWindow {
                 }
             }
         }
-        let order: Vec<gtk::Widget> = self
-            .cards
-            .borrow()
+        self.redraw_cards();
+        self.update_provider_settings();
+        self.update_tray();
+    }
+
+    /// Reorders one provider's contiguous account group without moving any other provider.
+    fn show_account_order(&self, provider: &str, accounts: &[String]) {
+        let mut cards = self.cards.borrow_mut();
+        let Some(first) = cards
             .iter()
-            .map(|card| card.widget().clone())
-            .collect();
-        self.grid.set_order(&order);
+            .position(|card| card.status().provider == provider)
+        else {
+            return;
+        };
+        let last = cards[first..]
+            .iter()
+            .position(|card| card.status().provider != provider)
+            .map_or(cards.len(), |offset| first + offset);
+        let mut group: Vec<Rc<Card>> = cards.drain(first..last).collect();
+        group.sort_by_key(|card| {
+            accounts
+                .iter()
+                .position(|account| *account == card.status().account)
+                .unwrap_or(accounts.len())
+        });
+        cards.splice(first..first, group);
+        drop(cards);
+        self.redraw_cards();
         self.update_provider_settings();
         self.update_tray();
     }

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -259,16 +259,12 @@ pub struct Account {
 }
 
 /// Whether a string can serve as an account id in `config.toml`, the Secret Service and
-/// the history: lowercase, non-empty, and not starting or ending with a hyphen.
-/// Shared by the engine and the D-Bus service so a call rejected here is rejected for the
-/// same reason there.
+/// the history. The rule itself lives in `tidemark-types`, where the client typing a new
+/// account's name reads it too; this is the daemon-side spelling of it, shared by the
+/// engine and the D-Bus service so a call rejected here is rejected for the same reason
+/// there.
 pub(crate) fn valid_account_slug(account: &str) -> bool {
-    !account.is_empty()
-        && !account.starts_with('-')
-        && !account.ends_with('-')
-        && account
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    tidemark_types::valid_account_slug(account)
 }
 
 /// Everything about an account that is fixed at registration, kept together so both

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use tidemark_core::config::Config;
 use tidemark_core::providers::http::{self, Proxy};
 use tidemark_core::providers::keyed::session;
-use tidemark_core::providers::{Credential, Provider, ProviderError};
+use tidemark_core::providers::{Credential, Provider, ProviderError, Source};
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_core::storage::{History, IngestReport};
 use tidemark_types::{
@@ -209,6 +209,7 @@ pub struct Account {
     factory: Option<Factory>,
     rebuild: Option<Rebuild>,
     client: Option<Arc<dyn Provider>>,
+    source: Source,
     status: ProviderStatus,
     failures: u32,
     retry_after: Option<Duration>,
@@ -244,6 +245,7 @@ impl Account {
             status,
             provider,
             account,
+            source: Source::Auto,
             factory: Some(factory),
             rebuild: None,
             client: None,
@@ -258,13 +260,18 @@ impl Account {
     /// This is the shape for providers that own credential discovery themselves, such as
     /// Claude's CLI file and Antigravity's future `agy` session.
     pub fn with_client(client: Arc<dyn Provider>) -> Self {
-        let (provider, account) = (client.id(), client.account());
+        let (provider, account, source) = (
+            client.id(),
+            client.account(),
+            client.source().unwrap_or_default(),
+        );
         let mut status = ProviderStatus::pending(&provider, &account);
         describe(&mut status, CredentialKind::External);
         Self {
             status,
             provider,
             account,
+            source,
             factory: None,
             rebuild: None,
             client: Some(client),
@@ -289,6 +296,7 @@ impl Account {
             status,
             provider,
             account,
+            source: Source::Auto,
             factory: None,
             rebuild: Some(rebuild),
             client: None,
@@ -304,6 +312,11 @@ impl Account {
     /// rebuilt from its stored key whenever the engine drops it.
     pub fn with_rebuild(mut self, rebuild: Rebuild) -> Self {
         self.rebuild = Some(rebuild);
+        self
+    }
+    /// Records the source selected for this account's next poll.
+    pub(crate) fn with_source(mut self, source: Source) -> Self {
+        self.source = source;
         self
     }
 
@@ -552,6 +565,9 @@ impl Engine {
             .set_option(provider, name, value)
             .map_err(|error| error.to_string())?;
         self.accounts[index].status.options = crate::registry::options(provider, &config);
+        let account_id = self.accounts[index].account.clone();
+        self.accounts[index].source =
+            crate::registry::source_for_account(provider, &account_id, &config);
         if self.accounts[index].rebuildable() {
             self.accounts[index].client = None;
         }
@@ -1188,7 +1204,8 @@ impl Engine {
             }
             let provider = account.provider.as_str().to_owned();
             account.status.external_present = crate::registry::external_present(&provider);
-            account.status.auth_source = crate::registry::auth_source(&provider, &account.status);
+            account.status.auth_source =
+                crate::registry::auth_source(&provider, account.source, &account.status);
         }
     }
 
@@ -1216,6 +1233,11 @@ impl Engine {
                 account.status.options =
                     crate::registry::options(account.provider.as_str(), config);
                 account.status.notify = crate::registry::notify(account.provider.as_str(), config);
+                account.source = crate::registry::source_for_account(
+                    account.provider.as_str(),
+                    &account.account,
+                    config,
+                );
             }
             if account.rebuildable() {
                 account.client = None;
@@ -1247,6 +1269,7 @@ impl Engine {
                 continue;
             }
             let provider = account.provider.clone();
+            let source = account.source;
             let kind = account.status.credential_kind().and_then(stored_kind);
             let held = match kind {
                 Some(kind) => {
@@ -1267,8 +1290,11 @@ impl Engine {
             self.accounts[index].status.has_credential = held;
             self.accounts[index].status.external_present =
                 crate::registry::external_present(provider.as_str());
-            self.accounts[index].status.auth_source =
-                crate::registry::auth_source(provider.as_str(), &self.accounts[index].status);
+            self.accounts[index].status.auth_source = crate::registry::auth_source(
+                provider.as_str(),
+                source,
+                &self.accounts[index].status,
+            );
         }
     }
 

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -738,7 +738,19 @@ impl Engine {
         }
         self.probe_credentials(Some(provider)).await;
 
-        if promote_from.is_some() {
+        if let Some(old) = promote_from.as_ref() {
+            // The survivor's old id stops existing the moment it takes over `default`,
+            // and its published entry must leave with it — first, and never as a
+            // `Removed` for `default` itself: `upsert` and `remove` share the
+            // (provider, account) key, and the pairs here differ, so this retirement
+            // cannot collide with the survivor's fresh entry that follows it.
+            let _ = self
+                .updates
+                .send(Publication::Removed {
+                    provider: provider.to_owned(),
+                    account: old.clone(),
+                })
+                .await;
             let promoted = self
                 .accounts
                 .iter()
@@ -750,8 +762,7 @@ impl Engine {
                 .status
                 .clone();
             let _ = self.updates.send(Publication::Changed(promoted)).await;
-        }
-        if promote_from.is_none() {
+        } else {
             let _ = self
                 .updates
                 .send(Publication::Removed {
@@ -2541,7 +2552,70 @@ mod tests {
         assert!(saw_changed, "the promoted account must be republished");
         assert!(
             !saw_removed,
-            "the promoted account absorbs default; no Removed publication is needed"
+            "the promoted account absorbs default; no Removed for `default` is published — \
+             the survivor's old id gets one instead"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_promotion_retires_the_published_entry_of_the_survivors_old_id() {
+        let mut harness = Harness::configured("promote-ghost", &["kimi"]).await;
+        harness
+            .engine
+            .add_account("kimi", "work")
+            .await
+            .expect("account added");
+        harness.published();
+
+        // The published state a client already holds: both accounts of the provider.
+        let published = crate::service::Published::default();
+        for account in [0, 1] {
+            published
+                .upsert(harness.engine.accounts()[account].status.clone())
+                .await;
+        }
+
+        harness
+            .engine
+            .remove_provider("kimi", "default")
+            .await
+            .expect("default removed");
+
+        // The publisher applies these mechanically; driving the same shapes through the
+        // real `Published` is the set a `GetStatus` client ends up with.
+        let mut sequence = Vec::new();
+        while let Ok(publication) = harness.updates.try_recv() {
+            match publication {
+                Publication::Changed(status) => {
+                    sequence.push(("changed", status.account.clone()));
+                    published.upsert(status).await;
+                }
+                Publication::Removed { provider, account } => {
+                    sequence.push(("removed", account.clone()));
+                    published.remove(&provider, &account).await;
+                }
+                Publication::Reordered(_) => panic!("a promotion does not reorder"),
+            }
+        }
+        assert_eq!(
+            sequence,
+            vec![
+                ("removed", "work".to_owned()),
+                ("changed", "default".to_owned())
+            ],
+            "the survivor's old id is retired first — the ids differ, so that Removed \
+             cannot collide with the Changed that follows it"
+        );
+        let identities: Vec<(String, String)> = published
+            .all()
+            .await
+            .into_iter()
+            .map(|status| (status.provider, status.account))
+            .collect();
+        assert_eq!(
+            identities,
+            vec![("kimi".to_owned(), "default".to_owned())],
+            "GetStatus serves exactly the identities that exist; the old id is not a ghost"
         );
     }
 

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -351,6 +351,10 @@ impl Account {
     pub fn provider(&self) -> &ProviderId {
         &self.provider
     }
+    #[cfg_attr(not(test), expect(dead_code, reason = "read only by registry tests"))]
+    pub fn account(&self) -> &AccountId {
+        &self.account
+    }
 
     /// The settings as a plain map, which is what a [`Factory`] is handed.
     fn option_values(&self) -> BTreeMap<String, String> {
@@ -440,8 +444,9 @@ impl Engine {
             return Ok(());
         }
 
-        let Some(mut account) = crate::registry::account(provider, &self.secrets, &config)
-            .map_err(|error| error.to_string())?
+        let Some(mut account) =
+            crate::registry::account(provider, &AccountId::default(), &self.secrets, &config)
+                .map_err(|error| error.to_string())?
         else {
             return Err(format!(
                 "provider {provider} is not supported by this build"

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -96,8 +96,7 @@ pub enum Command {
         /// Completion sent after persistence and in-memory mutation finish.
         reply: oneshot::Sender<Result<(), String>>,
     },
-    // Constructed by the D-Bus service when Task 6 exposes this operation.
-    #[allow(dead_code)]
+    /// Add one account to a configured provider and report the persisted topology result.
     AddAccount {
         /// Stable provider slug.
         provider: String,
@@ -113,8 +112,10 @@ pub enum Command {
         provider: String,
         /// Stable account name.
         account: String,
-        /// Completion sent after persistence and in-memory mutation finish.
-        reply: oneshot::Sender<Result<(), String>>,
+        /// Completion with every surviving `(provider, account)` pair once persistence
+        /// and in-memory mutation finish. The reply carries the topology because the
+        /// caller's mirror of it is updated asynchronously and must not be guessed at.
+        reply: oneshot::Sender<Result<Vec<(String, String)>, String>>,
     },
     /// Validate and persist one provider setting in the same queue as topology writes.
     SetOption {
@@ -169,8 +170,7 @@ pub enum Command {
         /// Completion sent after persistence and in-memory state agree.
         reply: oneshot::Sender<Result<(), String>>,
     },
-    // Constructed by the D-Bus service when Task 6 exposes this operation.
-    #[allow(dead_code)]
+    /// Reorder one provider's accounts, in the same queue as topology writes.
     SetAccountOrder {
         /// Stable provider slug.
         provider: String,
@@ -244,10 +244,28 @@ pub struct Account {
     due: Instant,
 }
 
+/// Whether a string can serve as an account id in `config.toml`, the Secret Service and
+/// the history: lowercase, non-empty, and not starting or ending with a hyphen.
+/// Shared by the engine and the D-Bus service so a call rejected here is rejected for the
+/// same reason there.
+pub(crate) fn valid_account_slug(account: &str) -> bool {
+    !account.is_empty()
+        && !account.starts_with('-')
+        && !account.ends_with('-')
+        && account
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
 /// Everything about an account that is fixed at registration, kept together so both
 /// constructors fill it the same way.
-fn describe(status: &mut ProviderStatus, kind: CredentialKind) {
+fn describe(status: &mut ProviderStatus, kind: CredentialKind, account: &AccountId) {
     status.credential = Some(kind.as_wire().to_owned());
+    // The label is the account's own name until a rename says otherwise. The default
+    // account *is* the provider as far as a client is concerned, and stays unlabelled —
+    // the wire contract keeps the key absent rather than empty.
+    status.account_label =
+        (account.as_str() != AccountId::default().as_str()).then(|| account.to_string());
 }
 
 impl std::fmt::Debug for Account {
@@ -268,7 +286,7 @@ impl Account {
     /// An account whose client is built from a stored key the first time it is polled.
     pub fn new(provider: ProviderId, account: AccountId, factory: Factory) -> Self {
         let mut status = ProviderStatus::pending(&provider, &account);
-        describe(&mut status, CredentialKind::Key);
+        describe(&mut status, CredentialKind::Key, &account);
         Self {
             status,
             provider,
@@ -294,7 +312,7 @@ impl Account {
             client.source().unwrap_or_default(),
         );
         let mut status = ProviderStatus::pending(&provider, &account);
-        describe(&mut status, CredentialKind::External);
+        describe(&mut status, CredentialKind::External, &account);
         Self {
             status,
             provider,
@@ -319,7 +337,7 @@ impl Account {
     /// the rest of them.
     pub fn keyless(provider: ProviderId, account: AccountId, rebuild: Rebuild) -> Self {
         let mut status = ProviderStatus::pending(&provider, &account);
-        describe(&mut status, CredentialKind::None);
+        describe(&mut status, CredentialKind::None, &account);
         Self {
             status,
             provider,
@@ -511,13 +529,7 @@ impl Engine {
     }
     /// Adds one account to a configured provider without restarting the loop.
     pub async fn add_account(&mut self, provider: &str, account: &str) -> Result<(), String> {
-        if account.is_empty()
-            || account.starts_with('-')
-            || account.ends_with('-')
-            || !account
-                .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        {
+        if !valid_account_slug(account) {
             return Err(format!("account {account:?} is not a valid lowercase slug"));
         }
 
@@ -609,8 +621,12 @@ impl Engine {
     }
 
     /// Removes an exact account from future polling, promoting the first survivor when the
-    /// provider still has accounts left.
-    pub async fn remove_provider(&mut self, provider: &str, account: &str) -> Result<(), String> {
+    /// provider still has accounts left. The reply carries the surviving topology.
+    pub async fn remove_provider(
+        &mut self,
+        provider: &str,
+        account: &str,
+    ) -> Result<Vec<(String, String)>, String> {
         let Some(index) = self.accounts.iter().position(|configured| {
             configured.provider.as_str() == provider && configured.account.as_str() == account
         }) else {
@@ -673,6 +689,33 @@ impl Engine {
                 .map_err(|error| error.to_string())?;
         }
 
+        // The removal is durable, so the removed account's credentials can be cleared.
+        // A promotion has already moved the survivor's own kind into the `default` slot;
+        // the kinds the survivor does not use belonged to the removed account alone, and
+        // they sit under ids that are gone (`old`) or have changed hands (`default`).
+        // A keyring failure here is logged rather than returned: the topology has already
+        // been persisted, and a caller told the removal failed would be wrong about that.
+        if let Some(old) = promote_from.as_ref() {
+            let provider_id = ProviderId::new(provider);
+            for kind in [Kind::Key, Kind::Token] {
+                if Some(kind) == promoted_kind {
+                    continue;
+                }
+                for id in [old.as_str(), AccountId::default().as_str()] {
+                    if let Err(error) = self
+                        .secrets
+                        .delete(kind, &provider_id, &AccountId::new(id))
+                        .await
+                    {
+                        tracing::warn!(
+                            %error, provider, account = id,
+                            "could not clear a credential the promoted account does not use"
+                        );
+                    }
+                }
+            }
+        }
+
         let removed = self.accounts.remove(index);
         if promote_from.is_some() {
             let promoted_index = self
@@ -717,7 +760,16 @@ impl Engine {
                 })
                 .await;
         }
-        Ok(())
+        Ok(self
+            .accounts
+            .iter()
+            .map(|account| {
+                (
+                    account.provider.as_str().to_owned(),
+                    account.account.as_str().to_owned(),
+                )
+            })
+            .collect())
     }
 
     /// Puts one provider's configured accounts in the order the user selected.
@@ -1988,6 +2040,31 @@ mod tests {
                 secret.to_owned(),
             );
         }
+
+        /// Everything held, as `(kind, provider, account, secret)`, sorted for exact
+        /// comparison.
+        fn held(&self) -> Vec<(String, String, String, String)> {
+            let mut entries: Vec<_> = self
+                .0
+                .lock()
+                .expect("no test panics here")
+                .iter()
+                .map(|((kind, provider, account), secret)| {
+                    (
+                        match kind {
+                            Kind::Key => "key",
+                            Kind::Token => "token",
+                        }
+                        .to_owned(),
+                        provider.clone(),
+                        account.clone(),
+                        secret.clone(),
+                    )
+                })
+                .collect();
+            entries.sort();
+            entries
+        }
     }
 
     impl Secrets for StoredSecrets {
@@ -2466,6 +2543,102 @@ mod tests {
             !saw_removed,
             "the promoted account absorbs default; no Removed publication is needed"
         );
+    }
+
+    #[tokio::test]
+    async fn an_extra_account_publishes_its_slug_as_its_label() {
+        let mut harness = Harness::configured("account-label", &["kimi"]).await;
+        assert_eq!(
+            harness.engine.accounts()[0].status.account_label,
+            None,
+            "the default account is the provider itself and stays unlabelled"
+        );
+
+        harness
+            .engine
+            .add_account("kimi", "work")
+            .await
+            .expect("account added");
+
+        assert_eq!(
+            harness.engine.accounts()[1].status.account_label.as_deref(),
+            Some("work")
+        );
+        assert!(
+            matches!(
+                harness.updates.recv().await.expect("announced"),
+                Publication::Changed(status) if status.account_label.as_deref() == Some("work")
+            ),
+            "the label rides the publication, not only the engine's private state"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_promotion_moves_the_survivors_credential_and_clears_the_rest() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-promote-cleanup-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+        let mut config = Config::at(config_path.clone()).expect("empty config parses");
+        config.add_provider("kimi").expect("provider configured");
+        config
+            .set_accounts("kimi", &["default".into(), "work".into()])
+            .expect("accounts configured");
+
+        let secrets = Arc::new(StoredSecrets::default());
+        secrets.insert(Kind::Key, "kimi", "default", "default-key");
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        secrets.insert(Kind::Token, "kimi", "default", "stale-token");
+        secrets.insert(Kind::Token, "kimi", "work", "stale-token");
+        let secrets_dyn: Arc<dyn Secrets> = secrets.clone();
+        let accounts = crate::registry::accounts(&secrets_dyn, &config).expect("accounts built");
+        let (tx, rx) = mpsc::channel(64);
+        let notices = Arc::new(Recorder::default());
+        let mut harness = Harness {
+            engine: Engine::new(
+                accounts,
+                History::in_memory().expect("an in-memory database opens"),
+                secrets_dyn,
+                tx,
+                config_path.clone(),
+                scheduler::RefreshMode::Auto,
+                Arc::clone(&notices) as Arc<dyn Notifier>,
+            ),
+            updates: rx,
+            config_path: config_path.clone(),
+            notices,
+        };
+
+        let topology = harness
+            .engine
+            .remove_provider("kimi", "default")
+            .await
+            .expect("default removed");
+
+        assert_eq!(
+            topology,
+            vec![("kimi".to_owned(), "default".to_owned())],
+            "the reply carries the surviving topology, not just success"
+        );
+        assert_eq!(
+            harness.engine.accounts()[0].status.account_label,
+            None,
+            "the survivor takes the default identity and its unlabelled status with it"
+        );
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "kimi".to_owned(),
+                "default".to_owned(),
+                "work-key".to_owned()
+            )],
+            "the survivor's key moved into the default slot, and every credential of the \
+             removed account and the old id — including kinds the survivor does not use — \
+             is gone"
+        );
+        let _ = std::fs::remove_file(config_path);
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -96,6 +96,17 @@ pub enum Command {
         /// Completion sent after persistence and in-memory mutation finish.
         reply: oneshot::Sender<Result<(), String>>,
     },
+    // Constructed by the D-Bus service when Task 6 exposes this operation.
+    #[allow(dead_code)]
+    AddAccount {
+        /// Stable provider slug.
+        provider: String,
+        /// Lowercase account slug, unique within the provider.
+        account: String,
+        /// Completion sent after persistence and in-memory mutation finish.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+
     /// Remove one exact provider/account pair and report the persisted topology result.
     RemoveProvider {
         /// Stable provider slug.
@@ -158,6 +169,17 @@ pub enum Command {
         /// Completion sent after persistence and in-memory state agree.
         reply: oneshot::Sender<Result<(), String>>,
     },
+    // Constructed by the D-Bus service when Task 6 exposes this operation.
+    #[allow(dead_code)]
+    SetAccountOrder {
+        /// Stable provider slug.
+        provider: String,
+        /// Every configured account id, in the order the user selected.
+        accounts: Vec<String>,
+        /// Completion sent after persistence and in-memory state agree.
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+
     /// Reads the stored points in one account window's open segment.
     CurrentSegment {
         /// Stable provider slug.
@@ -481,8 +503,107 @@ impl Engine {
         let _ = self.updates.send(Publication::Changed(status)).await;
         Ok(())
     }
+    /// Adds one account to a configured provider without restarting the loop.
+    pub async fn add_account(&mut self, provider: &str, account: &str) -> Result<(), String> {
+        if account.is_empty()
+            || account.starts_with('-')
+            || account.ends_with('-')
+            || !account
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        {
+            return Err(format!("account {account:?} is not a valid lowercase slug"));
+        }
 
-    /// Removes an exact account from future polling without touching its history.
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        if !config
+            .providers()
+            .map_err(|error| error.to_string())?
+            .iter()
+            .any(|configured| configured == provider)
+        {
+            return Err(format!("provider {provider} is not configured"));
+        }
+        let mut accounts = config
+            .accounts(provider)
+            .map_err(|error| error.to_string())?;
+        if accounts.iter().any(|configured| configured == account)
+            || self.accounts.iter().any(|configured| {
+                configured.provider.as_str() == provider && configured.account.as_str() == account
+            })
+        {
+            return Err(format!(
+                "account {provider}/{account} is already configured"
+            ));
+        }
+
+        let Some(mut new_account) =
+            crate::registry::account(provider, &AccountId::new(account), &self.secrets, &config)
+                .map_err(|error| error.to_string())?
+        else {
+            return Err(format!(
+                "provider {provider} is not supported by this build"
+            ));
+        };
+        if matches!(
+            new_account.status.credential_kind(),
+            Some(CredentialKind::External | CredentialKind::None)
+        ) {
+            return Err(format!(
+                "provider {provider} does not support multiple accounts"
+            ));
+        }
+
+        accounts.push(account.to_owned());
+        config
+            .set_accounts(provider, &accounts)
+            .map_err(|error| error.to_string())?;
+
+        new_account.due = Instant::now();
+        let insert_at = self
+            .accounts
+            .iter()
+            .rposition(|configured| configured.provider.as_str() == provider)
+            .map(|index| index + 1)
+            .unwrap_or(self.accounts.len());
+        self.accounts.insert(insert_at, new_account);
+        self.probe_credentials(Some(provider)).await;
+        let status = self.accounts[insert_at].status.clone();
+        let _ = self.updates.send(Publication::Changed(status)).await;
+        Ok(())
+    }
+
+    /// Copies one stored credential to a promoted account id, deleting the old slot only after
+    /// the replacement has been accepted.
+    async fn rekey_secret(
+        secrets: Arc<dyn Secrets>,
+        kind: Kind,
+        provider: &str,
+        old: &str,
+        new: &str,
+    ) -> Result<(), String> {
+        let provider_id = ProviderId::new(provider);
+        let old_id = AccountId::new(old);
+        let new_id = AccountId::new(new);
+        let Some(secret) = secrets
+            .get(kind, &provider_id, &old_id)
+            .await
+            .map_err(|error| error.to_string())?
+        else {
+            return Ok(());
+        };
+        secrets
+            .set(kind, &provider_id, &new_id, &secret)
+            .await
+            .map_err(|error| error.to_string())?;
+        secrets
+            .delete(kind, &provider_id, &old_id)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    /// Removes an exact account from future polling, promoting the first survivor when the
+    /// provider still has accounts left.
     pub async fn remove_provider(&mut self, provider: &str, account: &str) -> Result<(), String> {
         let Some(index) = self.accounts.iter().position(|configured| {
             configured.provider.as_str() == provider && configured.account.as_str() == account
@@ -491,11 +612,96 @@ impl Engine {
         };
 
         let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
-        config
-            .remove_provider(provider)
+        let configured_accounts = config
+            .accounts(provider)
             .map_err(|error| error.to_string())?;
+        if !configured_accounts
+            .iter()
+            .any(|configured| configured == account)
+        {
+            return Err(format!("account {provider}/{account} is not configured"));
+        }
+
+        let promote_from = if account == "default" && configured_accounts.len() > 1 {
+            let mut survivors = configured_accounts.clone();
+            let removed = survivors
+                .iter()
+                .position(|configured| configured == account)
+                .expect("the configured account was just found");
+            survivors.remove(removed);
+            Some(survivors.remove(0))
+        } else {
+            None
+        };
+        let promoted_kind = promote_from.as_ref().and_then(|old| {
+            self.accounts
+                .iter()
+                .find(|configured| {
+                    configured.provider.as_str() == provider && configured.account.as_str() == old
+                })
+                .and_then(|account| account.status.credential_kind())
+                .and_then(stored_kind)
+        });
+        if let Some(old) = promote_from.as_ref() {
+            if !self.accounts.iter().any(|configured| {
+                configured.provider.as_str() == provider && configured.account.as_str() == old
+            }) {
+                return Err(format!("account {provider}/{old} is not configured"));
+            }
+            if let Some(kind) = promoted_kind {
+                Self::rekey_secret(Arc::clone(&self.secrets), kind, provider, old, "default")
+                    .await?;
+            }
+            self.history
+                .rekey_account(provider, old, "default")
+                .map_err(|error| error.to_string())?;
+        }
+
+        if configured_accounts.len() > 1 {
+            config
+                .remove_account(provider, account)
+                .map_err(|error| error.to_string())?;
+        } else {
+            config
+                .remove_provider(provider)
+                .map_err(|error| error.to_string())?;
+        }
 
         let removed = self.accounts.remove(index);
+        if promote_from.is_some() {
+            let promoted_index = self
+                .accounts
+                .iter()
+                .position(|configured| {
+                    configured.provider.as_str() == provider
+                        && configured.account.as_str() == promote_from.as_deref().unwrap_or("")
+                })
+                .expect("the promoted account was checked before migration");
+            let promoted = &mut self.accounts[promoted_index];
+            promoted.account = AccountId::default();
+            promoted.status.account = AccountId::default().to_string();
+            promoted.status.account_label = None;
+            promoted.source =
+                crate::registry::source_for_account(provider, &promoted.account, &config);
+            if promoted.rebuildable() {
+                promoted.client = None;
+            }
+        }
+        self.probe_credentials(Some(provider)).await;
+
+        if promote_from.is_some() {
+            let promoted = self
+                .accounts
+                .iter()
+                .find(|configured| {
+                    configured.provider.as_str() == provider
+                        && configured.account == AccountId::default()
+                })
+                .expect("the promoted account was just renamed")
+                .status
+                .clone();
+            let _ = self.updates.send(Publication::Changed(promoted)).await;
+        }
         let _ = self
             .updates
             .send(Publication::Removed {
@@ -503,6 +709,69 @@ impl Engine {
                 account: removed.account.as_str().to_owned(),
             })
             .await;
+        Ok(())
+    }
+
+    /// Puts one provider's configured accounts in the order the user selected.
+    pub async fn set_account_order(
+        &mut self,
+        provider: &str,
+        accounts: &[String],
+    ) -> Result<(), String> {
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        let providers = config.providers().map_err(|error| error.to_string())?;
+        if !providers.iter().any(|configured| configured == provider) {
+            return Err(format!("provider {provider} is not configured"));
+        }
+        let configured = config
+            .accounts(provider)
+            .map_err(|error| error.to_string())?;
+        if accounts.first().map(String::as_str) != Some("default") {
+            return Err("the default account must be first".to_owned());
+        }
+        let mut wanted = accounts.to_vec();
+        wanted.sort_unstable();
+        let mut expected = configured.clone();
+        expected.sort_unstable();
+        if wanted != expected {
+            return Err(format!(
+                "the account order for {provider} must name every account exactly once"
+            ));
+        }
+        if !self
+            .accounts
+            .iter()
+            .any(|configured| configured.provider.as_str() == provider)
+        {
+            return Err(format!("provider {provider} is not running"));
+        }
+
+        config
+            .set_accounts(provider, accounts)
+            .map_err(|error| error.to_string())?;
+
+        let mut retained = Vec::with_capacity(self.accounts.len());
+        let mut provider_accounts = Vec::new();
+        let mut insertion = None;
+        for account in self.accounts.drain(..) {
+            if account.provider.as_str() == provider {
+                insertion.get_or_insert(retained.len());
+                provider_accounts.push(account);
+            } else {
+                retained.push(account);
+            }
+        }
+        provider_accounts.sort_by_key(|account| {
+            accounts
+                .iter()
+                .position(|id| id == account.account.as_str())
+                .unwrap_or(accounts.len())
+        });
+        let insertion = insertion.expect("the provider was checked before reordering");
+        retained.splice(insertion..insertion, provider_accounts);
+        self.accounts = retained;
+
+        let _ = self.updates.send(Publication::Reordered(providers)).await;
         Ok(())
     }
 
@@ -801,6 +1070,11 @@ impl Engine {
                         let result = self.add_provider(&provider).await;
                         let _ = reply.send(result);
                     }
+                    Some(Command::AddAccount { provider, account, reply }) => {
+                        let result = self.add_account(&provider, &account).await;
+                        let _ = reply.send(result);
+                    }
+
                     Some(Command::RemoveProvider { provider, account, reply }) => {
                         let result = self.remove_provider(&provider, &account).await;
                         let _ = reply.send(result);
@@ -817,6 +1091,11 @@ impl Engine {
                         let result = self.select_auth_source(&provider, &account, selection).await;
                         let _ = reply.send(result);
                     }
+                    Some(Command::SetAccountOrder { provider, accounts, reply }) => {
+                        let result = self.set_account_order(&provider, &accounts).await;
+                        let _ = reply.send(result);
+                    }
+
                     Some(Command::SetWindowNotify { provider, account, window, enabled, reply }) => {
                         let result = self
                             .set_window_notify(&provider, &account, &window, enabled)
@@ -1463,6 +1742,7 @@ fn worst_used(windows: &[WindowStatus]) -> Option<f64> {
 mod tests {
     use super::*;
     use crate::notify::{Notice, Notifier, NotifyError};
+    use std::collections::HashMap;
     use std::sync::Mutex;
     use tidemark_core::providers::BoxFuture;
     use tidemark_types::{AuthCandidate, AuthSelection, Window, WindowKey, WindowLength};
@@ -1670,6 +1950,78 @@ mod tests {
             _provider: &'a ProviderId,
             _account: &'a AccountId,
         ) -> BoxFuture<'a, Result<(), SecretError>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+    #[derive(Debug, Default)]
+    struct StoredSecrets(Mutex<HashMap<(Kind, String, String), String>>);
+
+    impl StoredSecrets {
+        fn insert(&self, kind: Kind, provider: &str, account: &str, secret: &str) {
+            self.0.lock().expect("no test panics here").insert(
+                (kind, provider.to_owned(), account.to_owned()),
+                secret.to_owned(),
+            );
+        }
+    }
+
+    impl Secrets for StoredSecrets {
+        fn get<'a>(
+            &'a self,
+            kind: Kind,
+            provider: &'a ProviderId,
+            account: &'a AccountId,
+        ) -> BoxFuture<'a, Result<Option<Credential>, SecretError>> {
+            let found = self
+                .0
+                .lock()
+                .expect("no test panics here")
+                .get(&(kind, provider.to_string(), account.to_string()))
+                .cloned()
+                .map(Credential::new);
+            Box::pin(async move { Ok(found) })
+        }
+
+        fn set<'a>(
+            &'a self,
+            kind: Kind,
+            provider: &'a ProviderId,
+            account: &'a AccountId,
+            secret: &'a Credential,
+        ) -> BoxFuture<'a, Result<(), SecretError>> {
+            let value = (
+                (kind, provider.to_string(), account.to_string()),
+                secret.expose().to_owned(),
+            );
+            self.0
+                .lock()
+                .expect("no test panics here")
+                .insert(value.0, value.1);
+            Box::pin(async { Ok(()) })
+        }
+
+        fn compare_and_set<'a>(
+            &'a self,
+            _kind: Kind,
+            _provider: &'a ProviderId,
+            _account: &'a AccountId,
+            _expected: &'a Credential,
+            _replacement: &'a Credential,
+        ) -> BoxFuture<'a, Result<bool, SecretError>> {
+            Box::pin(async { Ok(false) })
+        }
+
+        fn delete<'a>(
+            &'a self,
+            kind: Kind,
+            provider: &'a ProviderId,
+            account: &'a AccountId,
+        ) -> BoxFuture<'a, Result<(), SecretError>> {
+            self.0.lock().expect("no test panics here").remove(&(
+                kind,
+                provider.to_string(),
+                account.to_string(),
+            ));
             Box::pin(async { Ok(()) })
         }
     }
@@ -1979,6 +2331,249 @@ mod tests {
         assert_eq!(config.providers().expect("readable"), order);
         let publication = harness.updates.recv().await.expect("announced");
         assert!(matches!(publication, Publication::Reordered(published) if published == order));
+    }
+    #[tokio::test]
+    async fn an_account_addition_persists_and_publishes_pending_status() {
+        let mut harness = Harness::configured("runtime-add-account", &["kimi"]).await;
+
+        harness
+            .engine
+            .add_account("kimi", "work")
+            .await
+            .expect("account added");
+
+        assert_eq!(
+            harness
+                .engine
+                .accounts()
+                .iter()
+                .map(|account| account.account().as_str())
+                .collect::<Vec<_>>(),
+            ["default", "work"]
+        );
+        let publication = harness.updates.recv().await.expect("announced");
+        assert!(matches!(
+            publication,
+            Publication::Changed(status)
+                if status.provider == "kimi"
+                    && status.account == "work"
+                    && status.state == ProviderState::Pending.as_wire()
+        ));
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(
+            config.accounts("kimi").expect("accounts readable"),
+            ["default", "work"]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_default_removal_promotes_the_first_survivor_and_rekeys_history() {
+        let mut harness = Harness::configured("runtime-promote-account", &["kimi"]).await;
+        harness
+            .engine
+            .add_account("kimi", "work")
+            .await
+            .expect("account added");
+        harness.published();
+
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+
+        harness
+            .engine
+            .remove_provider("kimi", "default")
+            .await
+            .expect("default removed");
+
+        assert_eq!(harness.engine.accounts().len(), 1);
+        assert_eq!(harness.engine.accounts()[0].account().as_str(), "default");
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &reading.windows[0].key)
+                .expect("old history read"),
+            None
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "default", &reading.windows[0].key)
+                .expect("promoted history read"),
+            Some(1)
+        );
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(
+            config.accounts("kimi").expect("accounts readable"),
+            ["default"]
+        );
+
+        let mut saw_changed = false;
+        let mut saw_removed = false;
+        while let Ok(publication) = harness.updates.try_recv() {
+            match publication {
+                Publication::Changed(status) if status.provider == "kimi" => {
+                    saw_changed = status.account == "default";
+                }
+                Publication::Removed { provider, account }
+                    if provider == "kimi" && account == "default" =>
+                {
+                    saw_removed = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_changed, "the promoted account must be republished");
+        assert!(saw_removed, "the removed default must leave the topology");
+    }
+
+    #[tokio::test]
+    async fn the_account_order_requires_a_default_first_permutation_and_persists_it() {
+        let mut harness = Harness::configured("runtime-account-order", &["kimi"]).await;
+        harness
+            .engine
+            .add_account("kimi", "work")
+            .await
+            .expect("work added");
+        harness
+            .engine
+            .add_account("kimi", "personal")
+            .await
+            .expect("personal added");
+        harness.published();
+
+        assert!(
+            harness
+                .engine
+                .set_account_order("kimi", &["default".into(), "missing".into()])
+                .await
+                .is_err(),
+            "an order that is not a permutation must be refused"
+        );
+        assert_eq!(
+            Config::at(harness.config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "work", "personal"]
+        );
+
+        let order = vec!["default".into(), "personal".into(), "work".into()];
+        harness
+            .engine
+            .set_account_order("kimi", &order)
+            .await
+            .expect("order persisted");
+        assert_eq!(
+            harness
+                .engine
+                .accounts()
+                .iter()
+                .map(|account| account.account().as_str())
+                .collect::<Vec<_>>(),
+            ["default", "personal", "work"]
+        );
+        assert_eq!(
+            Config::at(harness.config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            order
+        );
+        assert!(matches!(
+            harness.updates.recv().await,
+            Some(Publication::Reordered(providers)) if providers == ["kimi"]
+        ));
+    }
+    #[tokio::test]
+    async fn a_promoted_account_keeps_its_secret_and_history_after_reload() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-promote-reload-{}.toml",
+            std::process::id()
+        ));
+        let history_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-promote-reload-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+        let _ = std::fs::remove_file(&history_path);
+        let mut config = Config::at(config_path.clone()).expect("empty config parses");
+        config.add_provider("kimi").expect("provider configured");
+        config
+            .set_accounts("kimi", &["default".into(), "work".into()])
+            .expect("accounts configured");
+
+        let secrets = Arc::new(StoredSecrets::default());
+        secrets.insert(Kind::Key, "kimi", "work", "work-secret");
+        let secrets_dyn: Arc<dyn Secrets> = secrets.clone();
+        let accounts = crate::registry::accounts(&secrets_dyn, &config).expect("accounts built");
+        let (tx, rx) = mpsc::channel(64);
+        let notices = Arc::new(Recorder::default());
+        let mut harness = Harness {
+            engine: Engine::new(
+                accounts,
+                History::open(history_path.clone()).expect("history opened"),
+                secrets_dyn.clone(),
+                tx,
+                config_path.clone(),
+                scheduler::RefreshMode::Auto,
+                Arc::clone(&notices) as Arc<dyn Notifier>,
+            ),
+            updates: rx,
+            config_path: config_path.clone(),
+            notices,
+        };
+
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+        harness
+            .engine
+            .remove_provider("kimi", "default")
+            .await
+            .expect("default removed");
+
+        let promoted_secret = secrets_dyn
+            .get(Kind::Key, &ProviderId::new("kimi"), &AccountId::default())
+            .await
+            .expect("promoted secret read")
+            .expect("promoted secret present");
+        assert_eq!(promoted_secret.expose(), "work-secret");
+        assert!(
+            secrets_dyn
+                .get(Kind::Key, &ProviderId::new("kimi"), &AccountId::new("work"),)
+                .await
+                .expect("old secret read")
+                .is_none()
+        );
+
+        let reloaded_config = Config::at(config_path.clone()).expect("config reloaded");
+        let reloaded_accounts =
+            crate::registry::accounts(&secrets_dyn, &reloaded_config).expect("accounts reloaded");
+        assert_eq!(reloaded_accounts.len(), 1);
+        assert_eq!(reloaded_accounts[0].account().as_str(), "default");
+        let reloaded_history = History::open(history_path.clone()).expect("history reloaded");
+        assert_eq!(
+            reloaded_history
+                .current_segment("kimi", "default", &reading.windows[0].key)
+                .expect("promoted history read"),
+            Some(1)
+        );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_file(history_path);
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -117,6 +117,20 @@ pub enum Command {
         /// caller's mirror of it is updated asynchronously and must not be guessed at.
         reply: oneshot::Sender<Result<Vec<(String, String)>, String>>,
     },
+    /// Rename one configured account, migrating the credential and history keyed by its
+    /// id, and report the persisted topology result.
+    RenameAccount {
+        /// Stable provider slug.
+        provider: String,
+        /// The configured account id being renamed.
+        account: String,
+        /// The new account id, unique within the provider.
+        new: String,
+        /// Completion with every surviving `(provider, account)` pair once persistence
+        /// and in-memory mutation finish. The reply carries the topology because the
+        /// caller's mirror of it is updated asynchronously and must not be guessed at.
+        reply: oneshot::Sender<Result<Vec<(String, String)>, String>>,
+    },
     /// Validate and persist one provider setting in the same queue as topology writes.
     SetOption {
         /// Stable provider slug.
@@ -439,6 +453,26 @@ impl Account {
     }
 }
 
+/// One not-yet-durable identity migration, and what it takes to refuse it.
+///
+/// Held from the moment the credential and history move until the config write that
+/// makes the new id permanent. That write is the durability point: everything before
+/// it must be reversible, because a failure there leaves the file naming the old id.
+/// Carries a [`Credential`] it may have to put back; its `Debug` is redacted, so the
+/// derived one prints no secret.
+#[derive(Debug)]
+struct MigrationUndo {
+    provider: String,
+    old: String,
+    new: String,
+    kind: Option<Kind>,
+    /// What the destination slot held before the migrating credential replaced it,
+    /// which a promotion's `default` can tell. A destination that held nothing keeps
+    /// the copy: under an id nothing reads yet, it is a harmless orphan the next
+    /// attempt overwrites.
+    replaced: Option<Credential>,
+}
+
 /// The poll loop.
 #[derive(Debug)]
 pub struct Engine {
@@ -591,33 +625,124 @@ impl Engine {
         Ok(())
     }
 
-    /// Copies one stored credential to a promoted account id, deleting the old slot only after
-    /// the replacement has been accepted.
-    async fn rekey_secret(
-        secrets: Arc<dyn Secrets>,
-        kind: Kind,
+    /// Copies the credential one account uses to its new id and moves its history
+    /// rows there, deleting nothing.
+    ///
+    /// Rename and promotion both run this before they touch the config: the copy
+    /// makes the new id immediately usable once the write lands, and refusing to
+    /// delete the old slots until after it keeps a failed write from leaving a
+    /// configured account without its credential. History rows already under the
+    /// destination are cleared in the same transaction: the destination was
+    /// validated unconfigured, or is the id of an account this same write removes,
+    /// so its rows are a predecessor's and keeping them would attribute them to the
+    /// account that inherits the id.
+    async fn migrate_identity(
+        &mut self,
+        kind: Option<Kind>,
         provider: &str,
         old: &str,
         new: &str,
-    ) -> Result<(), String> {
+    ) -> Result<MigrationUndo, String> {
         let provider_id = ProviderId::new(provider);
         let old_id = AccountId::new(old);
         let new_id = AccountId::new(new);
-        let Some(secret) = secrets
-            .get(kind, &provider_id, &old_id)
-            .await
-            .map_err(|error| error.to_string())?
-        else {
-            return Ok(());
+        let mut replaced = None;
+        if let Some(kind) = kind
+            && let Some(secret) = self
+                .secrets
+                .get(kind, &provider_id, &old_id)
+                .await
+                .map_err(|error| error.to_string())?
+        {
+            replaced = self
+                .secrets
+                .get(kind, &provider_id, &new_id)
+                .await
+                .map_err(|error| error.to_string())?;
+            self.secrets
+                .set(kind, &provider_id, &new_id, &secret)
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        // Nothing held means nothing to copy: the account's credential state moves with
+        // its id, and a later login writes the new slot directly.
+        let undo = MigrationUndo {
+            provider: provider.to_owned(),
+            old: old.to_owned(),
+            new: new.to_owned(),
+            kind,
+            replaced,
         };
-        secrets
-            .set(kind, &provider_id, &new_id, &secret)
-            .await
-            .map_err(|error| error.to_string())?;
-        secrets
-            .delete(kind, &provider_id, &old_id)
-            .await
-            .map_err(|error| error.to_string())
+        if let Err(error) = self
+            .history
+            .rekey_account_discarding_destination(provider, old, new)
+        {
+            // The copy is not durable either until the rekey lands beside it; put
+            // back what it displaced before reporting the failure.
+            Self::restore_destination(&self.secrets, &undo).await;
+            return Err(error.to_string());
+        }
+        Ok(undo)
+    }
+
+    /// Takes a refused migration back, leaving the old id exactly as it was.
+    ///
+    /// Run when the config write fails: the topology still names the old id, so its
+    /// credential and history must still be under it. Failures here are logged rather
+    /// than returned — the caller is already reporting the write that failed, and
+    /// what this can leave behind is an orphan the next attempt converges over.
+    async fn undo_migration(&mut self, undo: MigrationUndo) {
+        Self::restore_destination(&self.secrets, &undo).await;
+        if let Err(error) =
+            self.history
+                .rekey_account_discarding_destination(&undo.provider, &undo.new, &undo.old)
+        {
+            tracing::error!(
+                %error, provider = %undo.provider, account = %undo.old,
+                "could not put a refused migration's history back under its account"
+            );
+        }
+    }
+
+    /// Puts back what a migration's copy displaced, when the migration did not
+    /// become durable. Logged rather than returned: the caller is already reporting
+    /// a failure, and what this leaves behind is a slot under an id nothing reads.
+    async fn restore_destination(secrets: &Arc<dyn Secrets>, undo: &MigrationUndo) {
+        if let (Some(kind), Some(previous)) = (undo.kind, undo.replaced.as_ref())
+            && let Err(error) = secrets
+                .set(
+                    kind,
+                    &ProviderId::new(&undo.provider),
+                    &AccountId::new(&undo.new),
+                    previous,
+                )
+                .await
+        {
+            tracing::warn!(
+                %error, provider = %undo.provider, account = %undo.new,
+                "could not restore the credential a refused migration replaced"
+            );
+        }
+    }
+
+    /// Deletes both credential kinds under one account id, logging rather than
+    /// failing.
+    ///
+    /// By the time this runs, the migration that orphaned the id is durable, and an
+    /// error returned here would tell the caller the rename or promotion failed when
+    /// the file says it did not.
+    async fn forget_secret_slots(secrets: &Arc<dyn Secrets>, provider: &str, account: &str) {
+        for kind in [Kind::Key, Kind::Token] {
+            if let Err(error) = secrets
+                .delete(kind, &ProviderId::new(provider), &AccountId::new(account))
+                .await
+            {
+                tracing::warn!(
+                    %error, provider, account,
+                    "could not clear the credential slots of a migrated-away id"
+                );
+            }
+        }
     }
 
     /// Removes an exact account from future polling, promoting the first survivor when the
@@ -664,54 +789,55 @@ impl Engine {
                 .and_then(|account| account.status.credential_kind())
                 .and_then(stored_kind)
         });
+        let mut undo = None;
         if let Some(old) = promote_from.as_ref() {
             if !self.accounts.iter().any(|configured| {
                 configured.provider.as_str() == provider && configured.account.as_str() == old
             }) {
                 return Err(format!("account {provider}/{old} is not configured"));
             }
-            if let Some(kind) = promoted_kind {
-                Self::rekey_secret(Arc::clone(&self.secrets), kind, provider, old, "default")
-                    .await?;
-            }
-            self.history
-                .rekey_account(provider, old, "default")
-                .map_err(|error| error.to_string())?;
+            undo = Some(
+                self.migrate_identity(promoted_kind, provider, old, "default")
+                    .await?,
+            );
         }
 
-        if configured_accounts.len() > 1 {
-            config
-                .remove_account(provider, account)
-                .map_err(|error| error.to_string())?;
+        // The durability point: everything before it is reversible, everything after it
+        // is cleanup of ids the file no longer names.
+        let persisted = if configured_accounts.len() > 1 {
+            config.remove_account(provider, account)
         } else {
-            config
-                .remove_provider(provider)
-                .map_err(|error| error.to_string())?;
+            config.remove_provider(provider)
+        };
+        if let Err(error) = persisted {
+            if let Some(undo) = undo {
+                self.undo_migration(undo).await;
+            }
+            return Err(error.to_string());
         }
 
-        // The removal is durable, so the removed account's credentials can be cleared.
-        // A promotion has already moved the survivor's own kind into the `default` slot;
-        // the kinds the survivor does not use belonged to the removed account alone, and
-        // they sit under ids that are gone (`old`) or have changed hands (`default`).
-        // A keyring failure here is logged rather than returned: the topology has already
-        // been persisted, and a caller told the removal failed would be wrong about that.
+        // The removal is durable, so the ids it retired can be cleared. A promotion
+        // has already copied the survivor's own kind into the `default` slot; the kinds
+        // the survivor does not use belonged to the removed account alone, under an id
+        // that has changed hands. A keyring failure here is logged rather than returned:
+        // the topology has already been persisted, and a caller told the removal failed
+        // would be wrong about that.
         if let Some(old) = promote_from.as_ref() {
+            Self::forget_secret_slots(&self.secrets, provider, old).await;
             let provider_id = ProviderId::new(provider);
             for kind in [Kind::Key, Kind::Token] {
                 if Some(kind) == promoted_kind {
                     continue;
                 }
-                for id in [old.as_str(), AccountId::default().as_str()] {
-                    if let Err(error) = self
-                        .secrets
-                        .delete(kind, &provider_id, &AccountId::new(id))
-                        .await
-                    {
-                        tracing::warn!(
-                            %error, provider, account = id,
-                            "could not clear a credential the promoted account does not use"
-                        );
-                    }
+                if let Err(error) = self
+                    .secrets
+                    .delete(kind, &provider_id, &AccountId::default())
+                    .await
+                {
+                    tracing::warn!(
+                        %error, provider, account = AccountId::default().as_str(),
+                        "could not clear a credential the promoted account does not use"
+                    );
                 }
             }
         }
@@ -778,6 +904,110 @@ impl Engine {
                 (
                     account.provider.as_str().to_owned(),
                     account.account.as_str().to_owned(),
+                )
+            })
+            .collect())
+    }
+
+    /// Renames one configured account, migrating the credential and history rows keyed
+    /// by its id. The reply carries the surviving topology.
+    ///
+    /// The id is a storage key in three places — the keyring, the history tables, the
+    /// config's account list — and all three move together or not at all: the credential
+    /// is copied and the history re-keyed before the config write, nothing under the old
+    /// id is deleted until after it, and a write that refuses puts the history back and
+    /// leaves the old id exactly as it was. The `default` account cannot be renamed: it
+    /// is the structural first account of its provider, and the id it would move to is
+    /// refused by uniqueness anyway.
+    pub async fn rename_account(
+        &mut self,
+        provider: &str,
+        account: &str,
+        new: &str,
+    ) -> Result<Vec<(String, String)>, String> {
+        if account == AccountId::default().as_str() {
+            return Err("the default account cannot be renamed".to_owned());
+        }
+        if new == account {
+            return Err(format!("account {provider}/{new} is already named that"));
+        }
+        if !valid_account_slug(new) {
+            return Err(format!("account {new:?} is not a valid lowercase slug"));
+        }
+        let Some(index) = self.accounts.iter().position(|configured| {
+            configured.provider.as_str() == provider && configured.account.as_str() == account
+        }) else {
+            return Err(format!("account {provider}/{account} is not configured"));
+        };
+        let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
+        let mut accounts = config
+            .accounts(provider)
+            .map_err(|error| error.to_string())?;
+        let Some(position) = accounts.iter().position(|held| held == account) else {
+            return Err(format!("account {provider}/{account} is not configured"));
+        };
+        if accounts.iter().any(|held| held == new)
+            || self
+                .accounts
+                .iter()
+                .any(|held| held.provider.as_str() == provider && held.account.as_str() == new)
+        {
+            return Err(format!("account {provider}/{new} is already configured"));
+        }
+
+        let kind = self.accounts[index]
+            .status
+            .credential_kind()
+            .and_then(stored_kind);
+        let undo = self.migrate_identity(kind, provider, account, new).await?;
+
+        // Position preserved: the new id takes the old one's place in the array, which
+        // is the whole difference between a rename and a remove-then-add.
+        accounts[position] = new.to_owned();
+        if let Err(error) = config.set_accounts(provider, &accounts) {
+            self.undo_migration(undo).await;
+            return Err(error.to_string());
+        }
+
+        // Durable. The old id's slots can go: the used kind was copied, and any other
+        // kind under it belonged to the account alone.
+        Self::forget_secret_slots(&self.secrets, provider, account).await;
+
+        let renamed = &mut self.accounts[index];
+        renamed.account = AccountId::new(new);
+        renamed.status.account = new.to_owned();
+        renamed.status.account_label = Some(new.to_owned());
+        renamed.source = crate::registry::source_for_account(provider, &renamed.account, &config);
+        if renamed.rebuildable() {
+            // The client in hand was built under the old id: a poll it served would read
+            // the deleted slot and file the reading under the dead id, so the next poll
+            // has to build one from the new id.
+            renamed.client = None;
+        }
+        self.probe_credentials(Some(provider)).await;
+
+        // The old id stops existing the moment the file names the new one, and its
+        // published entry must leave with it — first, because the two pairs differ and
+        // so that `Removed` cannot collide with the `Changed` that follows it. Never a
+        // `Reordered`: the position never moved.
+        let _ = self
+            .updates
+            .send(Publication::Removed {
+                provider: provider.to_owned(),
+                account: account.to_owned(),
+            })
+            .await;
+        let _ = self
+            .updates
+            .send(Publication::Changed(self.accounts[index].status.clone()))
+            .await;
+        Ok(self
+            .accounts
+            .iter()
+            .map(|held| {
+                (
+                    held.provider.as_str().to_owned(),
+                    held.account.as_str().to_owned(),
                 )
             })
             .collect())
@@ -1165,6 +1395,15 @@ impl Engine {
 
                     Some(Command::RemoveProvider { provider, account, reply }) => {
                         let result = self.remove_provider(&provider, &account).await;
+                        let _ = reply.send(result);
+                    }
+                    Some(Command::RenameAccount {
+                        provider,
+                        account,
+                        new,
+                        reply,
+                    }) => {
+                        let result = self.rename_account(&provider, &account, &new).await;
                         let _ = reply.send(result);
                     }
                     Some(Command::SetOption { provider, account, name, value, reply }) => {
@@ -2042,21 +2281,30 @@ mod tests {
         }
     }
     #[derive(Debug, Default)]
-    struct StoredSecrets(Mutex<HashMap<(Kind, String, String), String>>);
+    struct StoredSecrets {
+        slots: Mutex<HashMap<(Kind, String, String), String>>,
+        fail_deletes: std::sync::atomic::AtomicBool,
+    }
 
     impl StoredSecrets {
         fn insert(&self, kind: Kind, provider: &str, account: &str, secret: &str) {
-            self.0.lock().expect("no test panics here").insert(
+            self.slots.lock().expect("no test panics here").insert(
                 (kind, provider.to_owned(), account.to_owned()),
                 secret.to_owned(),
             );
+        }
+
+        /// Makes every delete fail the way a locked keyring would.
+        fn refuse_deletes(&self) {
+            self.fail_deletes
+                .store(true, std::sync::atomic::Ordering::SeqCst);
         }
 
         /// Everything held, as `(kind, provider, account, secret)`, sorted for exact
         /// comparison.
         fn held(&self) -> Vec<(String, String, String, String)> {
             let mut entries: Vec<_> = self
-                .0
+                .slots
                 .lock()
                 .expect("no test panics here")
                 .iter()
@@ -2086,7 +2334,7 @@ mod tests {
             account: &'a AccountId,
         ) -> BoxFuture<'a, Result<Option<Credential>, SecretError>> {
             let found = self
-                .0
+                .slots
                 .lock()
                 .expect("no test panics here")
                 .get(&(kind, provider.to_string(), account.to_string()))
@@ -2106,7 +2354,7 @@ mod tests {
                 (kind, provider.to_string(), account.to_string()),
                 secret.expose().to_owned(),
             );
-            self.0
+            self.slots
                 .lock()
                 .expect("no test panics here")
                 .insert(value.0, value.1);
@@ -2130,7 +2378,10 @@ mod tests {
             provider: &'a ProviderId,
             account: &'a AccountId,
         ) -> BoxFuture<'a, Result<(), SecretError>> {
-            self.0.lock().expect("no test panics here").remove(&(
+            if self.fail_deletes.load(std::sync::atomic::Ordering::SeqCst) {
+                return Box::pin(async { Err(SecretError::Locked) });
+            }
+            self.slots.lock().expect("no test panics here").remove(&(
                 kind,
                 provider.to_string(),
                 account.to_string(),
@@ -2485,6 +2736,65 @@ mod tests {
         );
     }
 
+    /// A harness over a settings file and a recorded keyring the test fills itself, so a
+    /// migration's durable state can be asserted exactly.
+    fn stored_harness(
+        config_path: std::path::PathBuf,
+        accounts: &[&str],
+    ) -> (Harness, Arc<StoredSecrets>) {
+        let _ = std::fs::remove_file(&config_path);
+        let mut config = Config::at(config_path.clone()).expect("empty config parses");
+        config.add_provider("kimi").expect("provider configured");
+        config
+            .set_accounts(
+                "kimi",
+                &accounts.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+            )
+            .expect("accounts configured");
+        let secrets = Arc::new(StoredSecrets::default());
+        let secrets_dyn: Arc<dyn Secrets> = secrets.clone();
+        let accounts = crate::registry::accounts(&secrets_dyn, &config).expect("accounts built");
+        let (tx, rx) = mpsc::channel(64);
+        let notices = Arc::new(Recorder::default());
+        (
+            Harness {
+                engine: Engine::new(
+                    accounts,
+                    History::in_memory().expect("an in-memory database opens"),
+                    secrets_dyn,
+                    tx,
+                    config_path.clone(),
+                    scheduler::RefreshMode::Auto,
+                    Arc::clone(&notices) as Arc<dyn Notifier>,
+                ),
+                updates: rx,
+                config_path,
+                notices,
+            },
+            secrets,
+        )
+    }
+
+    /// A directory that hands a config inside it back its writer when it goes, and
+    /// nothing else — the test that owns the directory removes it.
+    struct ReadOnlyDir(std::path::PathBuf);
+
+    impl ReadOnlyDir {
+        fn refuse_writes(path: &std::path::Path) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o500))
+                .expect("directory made read-only");
+            Self(path.to_path_buf())
+        }
+    }
+
+    impl Drop for ReadOnlyDir {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
     #[tokio::test]
     async fn a_default_removal_promotes_the_first_survivor_and_rekeys_history() {
         let mut harness = Harness::configured("runtime-promote-account", &["kimi"]).await;
@@ -2713,6 +3023,540 @@ mod tests {
              is gone"
         );
         let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_rename_migrates_the_credential_the_history_and_the_config_position() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-rename-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, secrets) =
+            stored_harness(config_path.clone(), &["default", "work", "personal"]);
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        secrets.insert(Kind::Token, "kimi", "work", "stale-token");
+
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("work history written");
+        let mut stale = snapshot(50.0, 3600);
+        stale.provider = ProviderId::new("kimi");
+        stale.account = AccountId::new("team");
+        stale.windows[0].used_percent = 7.0;
+        harness
+            .engine
+            .history
+            .ingest(&stale)
+            .expect("stale destination history written");
+
+        // A client built under the old id would file its next reading under the dead id,
+        // so the rename has to drop one it finds in place.
+        harness.engine.accounts[1].client = Some(Fake::new(Vec::new()));
+
+        let topology = harness
+            .engine
+            .rename_account("kimi", "work", "team")
+            .await
+            .expect("renamed");
+
+        assert_eq!(
+            topology,
+            vec![
+                ("kimi".to_owned(), "default".to_owned()),
+                ("kimi".to_owned(), "team".to_owned()),
+                ("kimi".to_owned(), "personal".to_owned()),
+            ],
+            "the reply carries the surviving topology"
+        );
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "kimi".to_owned(),
+                "team".to_owned(),
+                "work-key".to_owned()
+            )],
+            "the used kind moved to the new id, and both kinds under the old id are gone"
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &reading.windows[0].key)
+                .expect("old history read"),
+            None
+        );
+        let points = harness
+            .engine
+            .history
+            .points("kimi", "team", &reading.windows[0].key, 1)
+            .expect("new points read");
+        assert_eq!(points.len(), 1);
+        assert_eq!(
+            points[0].used_percent, 50.0,
+            "the destination's stale rows were cleared, not inherited"
+        );
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "team", "personal"],
+            "the new id takes the old one's place, not the array's end"
+        );
+        let renamed = &harness.engine.accounts()[1];
+        assert_eq!(renamed.account().as_str(), "team");
+        assert_eq!(renamed.status.account_label.as_deref(), Some("team"));
+        assert!(
+            renamed.client.is_none(),
+            "the client built under the old id is dropped so the next poll reads the new slot"
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_rename_publishes_the_retired_id_first_and_replaces_it_with_the_new_one() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-rename-publish-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, _secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+
+        // The published state a client already holds: both accounts of the provider.
+        let published = crate::service::Published::default();
+        for account in [0, 1] {
+            published
+                .upsert(harness.engine.accounts()[account].status.clone())
+                .await;
+        }
+
+        harness
+            .engine
+            .rename_account("kimi", "work", "team")
+            .await
+            .expect("renamed");
+
+        // The publisher applies these mechanically; driving the same shapes through the
+        // real `Published` is the set a `GetStatus` client ends up with.
+        let mut sequence = Vec::new();
+        while let Ok(publication) = harness.updates.try_recv() {
+            match publication {
+                Publication::Changed(status) => {
+                    sequence.push(("changed", status.account.clone()));
+                    published.upsert(status).await;
+                }
+                Publication::Removed { provider, account } => {
+                    sequence.push(("removed", account.clone()));
+                    published.remove(&provider, &account).await;
+                }
+                Publication::Reordered(_) => {
+                    panic!("a rename preserves position and does not reorder")
+                }
+            }
+        }
+        assert_eq!(
+            sequence,
+            vec![
+                ("removed", "work".to_owned()),
+                ("changed", "team".to_owned())
+            ],
+            "the retired id leaves first; the ids differ, so that Removed cannot collide \n             with the Changed that follows it"
+        );
+        let identities: Vec<(String, String)> = published
+            .all()
+            .await
+            .into_iter()
+            .map(|status| (status.provider, status.account))
+            .collect();
+        assert!(
+            identities.contains(&("kimi".to_owned(), "team".to_owned())),
+            "the new id is published"
+        );
+        assert!(
+            !identities.contains(&("kimi".to_owned(), "work".to_owned())),
+            "the old id is not a ghost"
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_rename_refuses_an_id_the_config_cannot_take_without_touching_anything() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-rename-refuse-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+
+        for (account, new) in [
+            ("default", "team"),
+            ("work", "work"),
+            ("work", "Team"),
+            ("work", "default"),
+            ("missing", "team"),
+        ] {
+            assert!(
+                harness
+                    .engine
+                    .rename_account("kimi", account, new)
+                    .await
+                    .is_err(),
+                "renaming {account} to {new} must be refused"
+            );
+        }
+        assert!(
+            harness
+                .engine
+                .rename_account("zai", "work", "team")
+                .await
+                .is_err(),
+            "a provider that is not configured must be refused"
+        );
+
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "kimi".to_owned(),
+                "work".to_owned(),
+                "work-key".to_owned()
+            )],
+            "no credential moved"
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &reading.windows[0].key)
+                .expect("history read"),
+            Some(1),
+            "no history moved"
+        );
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "work"]
+        );
+        assert!(
+            harness.updates.try_recv().is_err(),
+            "a refused rename publishes nothing"
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_refused_rename_leaves_the_old_id_fully_usable() {
+        let dir = std::env::temp_dir().join(format!(
+            "tidemark-engine-rename-refused-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("directory created");
+        let config_path = dir.join("config.toml");
+        let (mut harness, secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+
+        // The config write is the durability point; a directory that cannot be written
+        // to refuses it after the credential copy and the history re-key.
+        let read_only = ReadOnlyDir::refuse_writes(&dir);
+
+        assert!(
+            harness
+                .engine
+                .rename_account("kimi", "work", "team")
+                .await
+                .is_err(),
+            "the config write refuses the rename"
+        );
+
+        assert_eq!(
+            secrets.held(),
+            vec![
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "team".to_owned(),
+                    "work-key".to_owned()
+                ),
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "work".to_owned(),
+                    "work-key".to_owned()
+                ),
+            ],
+            "the old slot is intact; the copy under the new id is a harmless orphan"
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &reading.windows[0].key)
+                .expect("old history read"),
+            Some(1),
+            "the history is back under the old id"
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "team", &reading.windows[0].key)
+                .expect("new history read"),
+            None
+        );
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "work"]
+        );
+        assert_eq!(
+            harness.engine.accounts()[1].account().as_str(),
+            "work",
+            "the in-memory id never moved"
+        );
+        assert!(
+            harness.updates.try_recv().is_err(),
+            "a refused rename publishes nothing"
+        );
+
+        // The next attempt converges over the orphan the refusal left behind.
+        drop(read_only);
+        harness
+            .engine
+            .rename_account("kimi", "work", "team")
+            .await
+            .expect("the retry overwrites the orphan copy");
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "kimi".to_owned(),
+                "team".to_owned(),
+                "work-key".to_owned()
+            )]
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "team", &reading.windows[0].key)
+                .expect("new history read"),
+            Some(1)
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_keyring_failure_after_a_durable_rename_is_logged_not_returned() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-rename-keyring-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+        secrets.refuse_deletes();
+
+        harness
+            .engine
+            .rename_account("kimi", "work", "team")
+            .await
+            .expect("the rename is durable; the cleanup is not the caller's problem");
+
+        assert_eq!(
+            secrets.held(),
+            vec![
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "team".to_owned(),
+                    "work-key".to_owned()
+                ),
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "work".to_owned(),
+                    "work-key".to_owned()
+                ),
+            ],
+            "the copy landed; the refused delete leaves the old slot behind"
+        );
+        assert_eq!(harness.engine.accounts()[1].account().as_str(), "team");
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "team"]
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "team", &reading.windows[0].key)
+                .expect("new history read"),
+            Some(1)
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_promotion_of_a_used_default_discards_its_rows_and_keeps_the_survivors() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-promote-used-default-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, _secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        let mut predecessor = snapshot(42.0, 3600);
+        predecessor.provider = ProviderId::new("kimi");
+        harness
+            .engine
+            .history
+            .ingest(&predecessor)
+            .expect("the removed default's history written");
+        let mut survivor = snapshot(7.0, 3600);
+        survivor.provider = ProviderId::new("kimi");
+        survivor.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&survivor)
+            .expect("the survivor's history written");
+
+        let topology = harness
+            .engine
+            .remove_provider("kimi", "default")
+            .await
+            .expect("a used default no longer blocks its own removal");
+
+        assert_eq!(topology, vec![("kimi".to_owned(), "default".to_owned())]);
+        let window = survivor.windows[0].key.clone();
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &window)
+                .expect("old history read"),
+            None
+        );
+        let points = harness
+            .engine
+            .history
+            .points("kimi", "default", &window, 1)
+            .expect("promoted history read");
+        assert_eq!(points.len(), 1);
+        assert_eq!(
+            points[0].used_percent, 7.0,
+            "the survivor inherits the id, not the predecessor's rows"
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn a_refused_promotion_keeps_both_accounts_credentials() {
+        let dir = std::env::temp_dir().join(format!(
+            "tidemark-engine-promote-refused-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("directory created");
+        let config_path = dir.join("config.toml");
+        let (mut harness, secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        secrets.insert(Kind::Key, "kimi", "default", "default-key");
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+
+        let read_only = ReadOnlyDir::refuse_writes(&dir);
+
+        assert!(
+            harness
+                .engine
+                .remove_provider("kimi", "default")
+                .await
+                .is_err(),
+            "the config write refuses the removal"
+        );
+
+        assert_eq!(
+            secrets.held(),
+            vec![
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "default".to_owned(),
+                    "default-key".to_owned()
+                ),
+                (
+                    "key".to_owned(),
+                    "kimi".to_owned(),
+                    "work".to_owned(),
+                    "work-key".to_owned()
+                ),
+            ],
+            "nothing was deleted, and the copy that reached the `default` slot was put back"
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .current_segment("kimi", "work", &reading.windows[0].key)
+                .expect("history read"),
+            Some(1),
+            "the history is back under the survivor's own id"
+        );
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "work"]
+        );
+        assert_eq!(
+            harness.engine.accounts().len(),
+            2,
+            "the in-memory topology never moved"
+        );
+        drop(read_only);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -49,11 +49,11 @@ pub enum Publication {
         /// Stable account name.
         account: String,
     },
-    /// Put the published accounts in this provider order.
+    /// Put the published accounts in their complete provider and account order.
     ///
     /// A sequence rather than a status, because that is what changed: the readings are
     /// exactly as they were, and a client redrawing a grid needs the positions.
-    Reordered(Vec<String>),
+    Reordered(Vec<(String, String)>),
 }
 
 /// One application-wide preference mutation.
@@ -209,7 +209,11 @@ pub enum Command {
 /// A closure rather than a trait because that is all it is: the five providers are
 /// constructed five different ways, and only the daemon knows which one it is holding.
 pub type Factory = Box<
-    dyn Fn(Credential, &BTreeMap<String, String>) -> Result<Arc<dyn Provider>, ProviderError>
+    dyn Fn(
+            &AccountId,
+            Credential,
+            &BTreeMap<String, String>,
+        ) -> Result<Arc<dyn Provider>, ProviderError>
         + Send
         + Sync,
 >;
@@ -221,7 +225,9 @@ pub type Factory = Box<
 /// settings — and a setting that never reached the built client would take effect only on
 /// the next daemon restart.
 pub type Rebuild = Box<
-    dyn Fn(&BTreeMap<String, String>) -> Result<Arc<dyn Provider>, ProviderError> + Send + Sync,
+    dyn Fn(&AccountId, &BTreeMap<String, String>) -> Result<Arc<dyn Provider>, ProviderError>
+        + Send
+        + Sync,
 >;
 
 /// One account the daemon watches.
@@ -702,13 +708,15 @@ impl Engine {
                 .clone();
             let _ = self.updates.send(Publication::Changed(promoted)).await;
         }
-        let _ = self
-            .updates
-            .send(Publication::Removed {
-                provider: removed.provider.as_str().to_owned(),
-                account: removed.account.as_str().to_owned(),
-            })
-            .await;
+        if promote_from.is_none() {
+            let _ = self
+                .updates
+                .send(Publication::Removed {
+                    provider: removed.provider.as_str().to_owned(),
+                    account: removed.account.as_str().to_owned(),
+                })
+                .await;
+        }
         Ok(())
     }
 
@@ -770,8 +778,18 @@ impl Engine {
         let insertion = insertion.expect("the provider was checked before reordering");
         retained.splice(insertion..insertion, provider_accounts);
         self.accounts = retained;
+        let order = self
+            .accounts
+            .iter()
+            .map(|account| {
+                (
+                    account.provider.as_str().to_owned(),
+                    account.account.as_str().to_owned(),
+                )
+            })
+            .collect();
 
-        let _ = self.updates.send(Publication::Reordered(providers)).await;
+        let _ = self.updates.send(Publication::Reordered(order)).await;
         Ok(())
     }
 
@@ -799,10 +817,17 @@ impl Engine {
                 // the grid does with one anyway.
                 .unwrap_or(providers.len())
         });
-        let _ = self
-            .updates
-            .send(Publication::Reordered(providers.to_vec()))
-            .await;
+        let order = self
+            .accounts
+            .iter()
+            .map(|account| {
+                (
+                    account.provider.as_str().to_owned(),
+                    account.account.as_str().to_owned(),
+                )
+            })
+            .collect();
+        let _ = self.updates.send(Publication::Reordered(order)).await;
         Ok(())
     }
 
@@ -1174,8 +1199,9 @@ impl Engine {
         if let Some(rebuild) = self.accounts[index].rebuild.as_ref() {
             // Owns its credential discovery: there is no stored key to read, so the
             // settings are the whole of what the replacement is built from.
+            let account = self.accounts[index].account.clone();
             let options = self.accounts[index].option_values();
-            match rebuild(&options) {
+            match rebuild(&account, &options) {
                 Ok(client) => self.accounts[index].client = Some(client),
                 Err(error) => {
                     self.accounts[index].failures = self.accounts[index].failures.saturating_add(1);
@@ -1209,7 +1235,7 @@ impl Engine {
                     .factory
                     .as_ref()
                     .expect("checked just above");
-                match factory(credential, &options) {
+                match factory(&account, credential, &options) {
                     Ok(client) => {
                         tracing::debug!(provider = %provider, "credential loaded");
                         Loaded::Client(client)
@@ -1243,7 +1269,6 @@ impl Engine {
             }
         }
     }
-
     /// Files one fetch result and publishes the account.
     async fn apply(&mut self, index: usize, result: Result<Snapshot, ProviderError>) {
         match result {
@@ -2330,7 +2355,13 @@ mod tests {
         let config = Config::at(harness.config_path.clone()).expect("parses");
         assert_eq!(config.providers().expect("readable"), order);
         let publication = harness.updates.recv().await.expect("announced");
-        assert!(matches!(publication, Publication::Reordered(published) if published == order));
+        let published = match &publication {
+            Publication::Reordered(entries) => {
+                entries.iter().map(|(p, _)| p.clone()).collect::<Vec<_>>()
+            }
+            _ => panic!("expected Reordered, got {publication:?}"),
+        };
+        assert_eq!(published, order);
     }
     #[tokio::test]
     async fn an_account_addition_persists_and_publishes_pending_status() {
@@ -2431,7 +2462,10 @@ mod tests {
             }
         }
         assert!(saw_changed, "the promoted account must be republished");
-        assert!(saw_removed, "the removed default must leave the topology");
+        assert!(
+            !saw_removed,
+            "the promoted account absorbs default; no Removed publication is needed"
+        );
     }
 
     #[tokio::test]
@@ -2489,7 +2523,12 @@ mod tests {
         );
         assert!(matches!(
             harness.updates.recv().await,
-            Some(Publication::Reordered(providers)) if providers == ["kimi"]
+            Some(Publication::Reordered(accounts))
+                if accounts == vec![
+                    ("kimi".into(), "default".into()),
+                    ("kimi".into(), "personal".into()),
+                    ("kimi".into(), "work".into()),
+                ]
         ));
     }
     #[tokio::test]
@@ -2684,7 +2723,7 @@ mod tests {
         let account = Account::keyless(
             ProviderId::new("cursor"),
             AccountId::default(),
-            Box::new(move |_| {
+            Box::new(move |_, _| {
                 Ok(Arc::new(AuthFake {
                     sources: source_copy.clone(),
                 }) as Arc<dyn Provider>)
@@ -2893,7 +2932,7 @@ mod tests {
         let account = Account::new(
             ProviderId::new("zai"),
             AccountId::default(),
-            Box::new(move |_credential, options| {
+            Box::new(move |_, _credential, options| {
                 recorder
                     .lock()
                     .expect("no test panics holding this")
@@ -3082,7 +3121,9 @@ mod tests {
             vec![Account::new(
                 ProviderId::new("fake"),
                 AccountId::default(),
-                Box::new(|_, _| Ok(Fake::new(vec![Ok(snapshot(1.0, 3600))]) as Arc<dyn Provider>)),
+                Box::new(|_, _, _| {
+                    Ok(Fake::new(vec![Ok(snapshot(1.0, 3600))]) as Arc<dyn Provider>)
+                }),
             )],
             Arc::new(Keyring(|| Err(SecretError::Locked))),
         );
@@ -3108,7 +3149,7 @@ mod tests {
             vec![Account::new(
                 ProviderId::new("fake"),
                 AccountId::default(),
-                Box::new(|_, _| Ok(Fake::new(vec![]) as Arc<dyn Provider>)),
+                Box::new(|_, _, _| Ok(Fake::new(vec![]) as Arc<dyn Provider>)),
             )],
             Arc::new(Keyring(|| Ok(None))),
         );
@@ -3125,7 +3166,7 @@ mod tests {
             vec![Account::new(
                 ProviderId::new("fake"),
                 AccountId::default(),
-                Box::new(|_, _| {
+                Box::new(|_, _, _| {
                     Ok(Fake::new(vec![
                         Err(ProviderError::Credential { status: 401 }),
                         Ok(snapshot(3.0, 3600)),
@@ -3545,7 +3586,7 @@ mod tests {
         let mut harness = harness_with_config(
             vec![
                 Account::with_client(Fake::new(vec![Ok(reading(0, 42.0, 3600))])).with_rebuild(
-                    Box::new(|_| {
+                    Box::new(|_, _| {
                         Ok(Fake::new(vec![Ok(reading(0, 42.0, 3600))]) as Arc<dyn Provider>)
                     }),
                 ),

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -235,8 +235,14 @@ async fn run() -> Result<(), Box<dyn Error>> {
                             tracing::warn!(%error, "could not announce a removal");
                         }
                     }
-                    Publication::Reordered(providers) => {
-                        published.reorder(&providers).await;
+                    Publication::Reordered(accounts) => {
+                        published.reorder(&accounts).await;
+                        let mut providers = Vec::new();
+                        for (provider, _) in &accounts {
+                            if !providers.iter().any(|known| known == provider) {
+                                providers.push(provider.clone());
+                            }
+                        }
                         if let Err(error) = Daemon::order_changed(&emitter, providers).await {
                             tracing::warn!(%error, "could not announce a reorder");
                         }

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -610,8 +610,7 @@ fn antigravity_account(
     .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
-        let account = account_id;
-        Box::new(move |options| {
+        Box::new(move |account, options| {
             let source = if account.as_str() == "default" {
                 Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
             } else {
@@ -643,8 +642,7 @@ fn claude_account(
     .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
-        let account = account_id;
-        Box::new(move |options| {
+        Box::new(move |account, options| {
             let source = if account.as_str() == "default" {
                 Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
             } else {
@@ -676,8 +674,7 @@ fn codex_account(
     .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
-        let account = account_id;
-        Box::new(move |options| {
+        Box::new(move |account, options| {
             let source = if account.as_str() == "default" {
                 Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
             } else {
@@ -701,11 +698,11 @@ fn keyed_account(spec: &'static keyed::Spec, account: &AccountId) -> Account {
     Account::new(
         ProviderId::new(spec.id),
         account_id.clone(),
-        Box::new(move |credential, options| {
+        Box::new(move |account, credential, options| {
             // The URL is resolved at build time, which is why storing a key or changing a
             // setting drops the client: either may change which host this account talks to.
             Ok(Arc::new(keyed::Keyed::new(
-                account_id.clone(),
+                account.clone(),
                 spec,
                 credential,
                 options,
@@ -732,7 +729,9 @@ fn hand_written_account(spec: &'static keyed::HandSpec, account: &AccountId) -> 
         let account = Account::keyless(
             ProviderId::new(spec.id),
             account.clone(),
-            Box::new(move |options| (spec.build)(Credential::new(String::new()), options)),
+            Box::new(move |account_id, options| {
+                (spec.build)(account_id.clone(), Credential::new(String::new()), options)
+            }),
         )
         .with_credential(spec.credential);
         if spec.credential_hint.is_empty() {
@@ -743,7 +742,9 @@ fn hand_written_account(spec: &'static keyed::HandSpec, account: &AccountId) -> 
     Account::new(
         ProviderId::new(spec.id),
         account.clone(),
-        Box::new(move |credential, options| (spec.build)(credential, options)),
+        Box::new(move |account_id, credential, options| {
+            (spec.build)(account_id.clone(), credential, options)
+        }),
     )
     .with_credential(spec.credential)
     .with_hint(spec.credential_hint)
@@ -1332,7 +1333,7 @@ mod tests {
         credential: CredentialKind::None,
         credential_hint: "",
         options: &[],
-        build: |_, _| Err(ProviderError::Local("not built in a test".into())),
+        build: |_, _, _| Err(ProviderError::Local("not built in a test".into())),
     };
 
     static KEY_SPEC: keyed::HandSpec = keyed::HandSpec {
@@ -1341,7 +1342,7 @@ mod tests {
         credential: CredentialKind::Key,
         credential_hint: "Test console \u{2192} API keys.",
         options: &[],
-        build: |_, _| Err(ProviderError::Local("not built in a test".into())),
+        build: |_, _, _| Err(ProviderError::Local("not built in a test".into())),
     };
 
     #[test]

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -513,7 +513,7 @@ fn source_value(provider: &str, config: &Config) -> Source {
 }
 
 /// Extra configured accounts have no vendor CLI file, so they always use Tidemark's login.
-fn source_for_account(provider: &str, account: &AccountId, config: &Config) -> Source {
+pub(crate) fn source_for_account(provider: &str, account: &AccountId, config: &Config) -> Source {
     if account.as_str() == "default" {
         source_value(provider, config)
     } else {
@@ -543,24 +543,15 @@ pub fn external_present(provider: &str) -> Option<bool> {
     }
 }
 
-/// Which credential the next poll will use, resolving an unset setting the way the
-/// provider itself resolves [`Source::Auto`]. `None` for a provider with one credential.
+/// Which credential the next poll will use, from the source selected for this account.
 ///
-/// The stored value is read off the published options rather than the file: the engine
-/// has already refreshed them, and re-reading `config.toml` here could disagree with them
-/// for the length of a reload. The `Auto` branches mirror the clients' own control flow
-/// rather than approximating it: Claude and Codex reach the vendor file only when the
-/// Secret Service answered that nothing is stored — a held token wins, and a locked
-/// keyring errors out before the file is ever opened — while Antigravity tries the local
-/// server first whenever `agy` is installed.
-pub fn auth_source(provider: &str, status: &ProviderStatus) -> Option<String> {
+/// The account carries the constructor's resolved source. `Source::Auto` still follows the
+/// provider's historical runtime rule using the probe answers, while explicit `Cli` and
+/// `OAuth` sources are authoritative — especially for non-default accounts, which never
+/// have a vendor CLI file.
+pub fn auth_source(provider: &str, source: Source, status: &ProviderStatus) -> Option<String> {
     oauth_entry(provider)?;
-    let stored = status
-        .options
-        .iter()
-        .find(|option| option.name == AUTH_SOURCE)
-        .map(|option| option.value.as_str());
-    let resolved = match Source::from_value(stored) {
+    let resolved = match source {
         Source::OAuth => OAUTH_SOURCE,
         Source::Cli => CLI_SOURCE,
         Source::Auto => match provider {
@@ -609,12 +600,14 @@ fn antigravity_account(
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Account, ProviderError> {
+    let source = source_for_account(antigravity::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(antigravity::Antigravity::new(
         account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_for_account(antigravity::PROVIDER_ID, account, config),
+        source,
     )?))
+    .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
         let account = account_id;
@@ -640,12 +633,14 @@ fn claude_account(
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Account, ProviderError> {
+    let source = source_for_account(claude::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(claude::Claude::new(
         account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_for_account(claude::PROVIDER_ID, account, config),
+        source,
     )?))
+    .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
         let account = account_id;
@@ -671,12 +666,14 @@ fn codex_account(
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Account, ProviderError> {
+    let source = source_for_account(codex::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(codex::Codex::new(
         account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_for_account(codex::PROVIDER_ID, account, config),
+        source,
     )?))
+    .with_source(source)
     .with_rebuild({
         let secrets = Arc::clone(secrets);
         let account = account_id;
@@ -694,7 +691,7 @@ fn codex_account(
         })
     })
     .with_credential(CredentialKind::OAuth)
-    .with_hint("Sign in with Tidemark, or read the Codex CLI's own login."))
+    .with_hint("Sign in through Tidemark, or read the Codex CLI's own login."))
 }
 
 /// Every key-authenticated account is built the same way: the engine hands over the stored
@@ -867,6 +864,20 @@ mod tests {
         .expect("Claude account builds");
 
         assert_eq!(account.account().as_str(), "work");
+    }
+
+    #[test]
+    fn an_extra_account_forces_oauth_even_when_cli_is_configured() {
+        let path = scratch_config(
+            "claude-extra-source",
+            "providers = [\"claude\"]\n\n[provider.claude]\nsource = \"cli\"\n",
+        );
+        let config = Config::at(path.clone()).expect("config reads");
+        assert_eq!(
+            source_for_account(claude::PROVIDER_ID, &AccountId::new("work"), &config),
+            Source::OAuth
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
@@ -1209,6 +1220,25 @@ mod tests {
         status
     }
 
+    fn auth_source_from_status(provider: &str, status: &ProviderStatus) -> Option<String> {
+        let source = status
+            .options
+            .iter()
+            .find(|option| option.name == AUTH_SOURCE)
+            .map(|option| option.value.as_str());
+        auth_source(provider, Source::from_value(source), status)
+    }
+
+    #[test]
+    fn an_explicit_oauth_source_overrides_probe_answers() {
+        let mut status = probed_status(claude::PROVIDER_ID, Some(CLI_SOURCE));
+        status.has_credential = Some(false);
+        assert_eq!(
+            auth_source(claude::PROVIDER_ID, Source::OAuth, &status).as_deref(),
+            Some(OAUTH_SOURCE)
+        );
+    }
+
     #[test]
     fn claude_says_which_credential_the_next_poll_will_use() {
         for stored in [OAUTH_SOURCE, CLI_SOURCE] {
@@ -1216,7 +1246,7 @@ mod tests {
             let mut status = probed_status(claude::PROVIDER_ID, Some(stored));
             status.has_credential = Some(false);
             assert_eq!(
-                auth_source(claude::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(claude::PROVIDER_ID, &status).as_deref(),
                 Some(stored)
             );
         }
@@ -1228,7 +1258,7 @@ mod tests {
             let mut status = probed_status(claude::PROVIDER_ID, None);
             status.has_credential = has_credential;
             assert_eq!(
-                auth_source(claude::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(claude::PROVIDER_ID, &status).as_deref(),
                 Some(expected),
                 "auto reaches the vendor file only on Ok(None), not on a locked keyring"
             );
@@ -1241,7 +1271,7 @@ mod tests {
             let mut status = probed_status(codex::PROVIDER_ID, Some(stored));
             status.has_credential = Some(false);
             assert_eq!(
-                auth_source(codex::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(codex::PROVIDER_ID, &status).as_deref(),
                 Some(stored)
             );
         }
@@ -1253,7 +1283,7 @@ mod tests {
             let mut status = probed_status(codex::PROVIDER_ID, None);
             status.has_credential = has_credential;
             assert_eq!(
-                auth_source(codex::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(codex::PROVIDER_ID, &status).as_deref(),
                 Some(expected),
                 "auto reaches the vendor file only on Ok(None), not on a locked keyring"
             );
@@ -1266,7 +1296,7 @@ mod tests {
             let mut status = probed_status(antigravity::PROVIDER_ID, Some(stored));
             status.external_present = Some(true);
             assert_eq!(
-                auth_source(antigravity::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(antigravity::PROVIDER_ID, &status).as_deref(),
                 Some(stored)
             );
         }
@@ -1278,7 +1308,7 @@ mod tests {
             let mut status = probed_status(antigravity::PROVIDER_ID, None);
             status.external_present = external_present;
             assert_eq!(
-                auth_source(antigravity::PROVIDER_ID, &status).as_deref(),
+                auth_source_from_status(antigravity::PROVIDER_ID, &status).as_deref(),
                 Some(expected),
                 "auto tries the local server first whenever agy is installed"
             );
@@ -1288,7 +1318,7 @@ mod tests {
     #[test]
     fn a_provider_with_one_credential_says_nothing_about_a_source() {
         assert_eq!(
-            auth_source("zai", &probed_status("zai", None)),
+            auth_source_from_status("zai", &probed_status("zai", None)),
             None,
             "there is no second credential for the next poll to use"
         );

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -266,22 +266,23 @@ fn hand_written_definition(spec: &keyed::HandSpec, config: &Config) -> ProviderD
 /// Builds one configured account, or returns `None` for a slug this build does not support.
 pub fn account(
     provider: &str,
+    account: &AccountId,
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Option<Account>, ProviderError> {
     let account = match provider {
-        antigravity::PROVIDER_ID => Some(antigravity_account(secrets, config)?),
-        claude::PROVIDER_ID => Some(claude_account(secrets, config)?),
-        codex::PROVIDER_ID => Some(codex_account(secrets, config)?),
+        antigravity::PROVIDER_ID => Some(antigravity_account(account, secrets, config)?),
+        claude::PROVIDER_ID => Some(claude_account(account, secrets, config)?),
+        codex::PROVIDER_ID => Some(codex_account(account, secrets, config)?),
         other => keyed::CATALOG
             .iter()
             .find(|spec| spec.id == other)
-            .map(|spec| keyed_account(spec))
+            .map(|spec| keyed_account(spec, account))
             .or_else(|| {
                 HAND_WRITTEN
                     .iter()
                     .find(|spec| spec.id == other)
-                    .map(|spec| hand_written_account(spec))
+                    .map(|spec| hand_written_account(spec, account))
             }),
     };
     Ok(account.map(|account| {
@@ -383,9 +384,19 @@ pub fn accounts(
         .map_err(|error| ProviderError::Local(error.to_string()))?;
     let mut accounts = Vec::with_capacity(providers.len());
     for provider in providers {
-        match account(&provider, secrets, config)? {
-            Some(account) => accounts.push(account),
-            None => tracing::warn!(provider, "configured provider is unsupported by this build"),
+        for account_id in config
+            .accounts(&provider)
+            .map_err(|error| ProviderError::Local(error.to_string()))?
+        {
+            let account_id = AccountId::new(account_id);
+            match account(&provider, &account_id, secrets, config)? {
+                Some(account) => accounts.push(account),
+                None => tracing::warn!(
+                    provider,
+                    account = %account_id,
+                    "configured provider is unsupported by this build"
+                ),
+            }
         }
     }
     Ok(accounts)
@@ -501,6 +512,15 @@ fn source_value(provider: &str, config: &Config) -> Source {
     Source::from_value(config.option(provider, AUTH_SOURCE))
 }
 
+/// Extra configured accounts have no vendor CLI file, so they always use Tidemark's login.
+fn source_for_account(provider: &str, account: &AccountId, config: &Config) -> Source {
+    if account.as_str() == "default" {
+        source_value(provider, config)
+    } else {
+        Source::OAuth
+    }
+}
+
 /// Whether the local login a provider can read instead of a Tidemark login exists on this
 /// machine — `None` for a provider that has no such login at all.
 ///
@@ -585,18 +605,27 @@ pub async fn login_document(
 }
 
 fn antigravity_account(
+    account: &AccountId,
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Account, ProviderError> {
+    let account_id = account.clone();
     Ok(Account::with_client(Arc::new(antigravity::Antigravity::new(
+        account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_value(antigravity::PROVIDER_ID, config),
+        source_for_account(antigravity::PROVIDER_ID, account, config),
     )?))
     .with_rebuild({
         let secrets = Arc::clone(secrets);
+        let account = account_id;
         Box::new(move |options| {
-            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
+            let source = if account.as_str() == "default" {
+                Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
+            } else {
+                Source::OAuth
+            };
             Ok(Arc::new(antigravity::Antigravity::new(
+                account.clone(),
                 Some(Arc::clone(&secrets)),
                 source,
             )?) as Arc<dyn Provider>)
@@ -606,54 +635,84 @@ fn antigravity_account(
     .with_hint("Sign in with Google through Tidemark, or read a signed-in agy session."))
 }
 
-fn claude_account(secrets: &Arc<dyn Secrets>, config: &Config) -> Result<Account, ProviderError> {
+fn claude_account(
+    account: &AccountId,
+    secrets: &Arc<dyn Secrets>,
+    config: &Config,
+) -> Result<Account, ProviderError> {
+    let account_id = account.clone();
     Ok(Account::with_client(Arc::new(claude::Claude::new(
+        account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_value(claude::PROVIDER_ID, config),
+        source_for_account(claude::PROVIDER_ID, account, config),
     )?))
     .with_rebuild({
         let secrets = Arc::clone(secrets);
+        let account = account_id;
         Box::new(move |options| {
-            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
-            Ok(
-                Arc::new(claude::Claude::new(Some(Arc::clone(&secrets)), source)?)
-                    as Arc<dyn Provider>,
-            )
+            let source = if account.as_str() == "default" {
+                Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
+            } else {
+                Source::OAuth
+            };
+            Ok(Arc::new(claude::Claude::new(
+                account.clone(),
+                Some(Arc::clone(&secrets)),
+                source,
+            )?) as Arc<dyn Provider>)
         })
     })
     .with_credential(CredentialKind::OAuth)
     .with_hint("Sign in through Tidemark, or read Claude Code's own login."))
 }
 
-fn codex_account(secrets: &Arc<dyn Secrets>, config: &Config) -> Result<Account, ProviderError> {
+fn codex_account(
+    account: &AccountId,
+    secrets: &Arc<dyn Secrets>,
+    config: &Config,
+) -> Result<Account, ProviderError> {
+    let account_id = account.clone();
     Ok(Account::with_client(Arc::new(codex::Codex::new(
+        account_id.clone(),
         Some(Arc::clone(secrets)),
-        source_value(codex::PROVIDER_ID, config),
+        source_for_account(codex::PROVIDER_ID, account, config),
     )?))
     .with_rebuild({
         let secrets = Arc::clone(secrets);
+        let account = account_id;
         Box::new(move |options| {
-            let source = Source::from_value(options.get(AUTH_SOURCE).map(String::as_str));
-            Ok(
-                Arc::new(codex::Codex::new(Some(Arc::clone(&secrets)), source)?)
-                    as Arc<dyn Provider>,
-            )
+            let source = if account.as_str() == "default" {
+                Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
+            } else {
+                Source::OAuth
+            };
+            Ok(Arc::new(codex::Codex::new(
+                account.clone(),
+                Some(Arc::clone(&secrets)),
+                source,
+            )?) as Arc<dyn Provider>)
         })
     })
     .with_credential(CredentialKind::OAuth)
-    .with_hint("Sign in through Tidemark, or read the Codex CLI's own login."))
+    .with_hint("Sign in with Tidemark, or read the Codex CLI's own login."))
 }
 
 /// Every key-authenticated account is built the same way: the engine hands over the stored
 /// key and the account's settings, and the spec says what to do with them.
-fn keyed_account(spec: &'static keyed::Spec) -> Account {
+fn keyed_account(spec: &'static keyed::Spec, account: &AccountId) -> Account {
+    let account_id = account.clone();
     Account::new(
         ProviderId::new(spec.id),
-        AccountId::default(),
+        account_id.clone(),
         Box::new(move |credential, options| {
             // The URL is resolved at build time, which is why storing a key or changing a
             // setting drops the client: either may change which host this account talks to.
-            Ok(Arc::new(keyed::Keyed::new(spec, credential, options)?) as Arc<dyn Provider>)
+            Ok(Arc::new(keyed::Keyed::new(
+                account_id.clone(),
+                spec,
+                credential,
+                options,
+            )?) as Arc<dyn Provider>)
         }),
     )
     .with_credential(CredentialKind::Key)
@@ -664,7 +723,7 @@ fn keyed_account(spec: &'static keyed::Spec) -> Account {
 /// the engine hands over the stored key and the account's settings, and the provider's own
 /// builder says what to do with them. It, too, resolves its URLs at build time and refuses
 /// a required option that is unset, naming it.
-fn hand_written_account(spec: &'static keyed::HandSpec) -> Account {
+fn hand_written_account(spec: &'static keyed::HandSpec, account: &AccountId) -> Account {
     if matches!(
         spec.credential,
         CredentialKind::None | CredentialKind::External
@@ -675,7 +734,7 @@ fn hand_written_account(spec: &'static keyed::HandSpec) -> Account {
         // there is genuinely nothing to say about where a nonexistent secret comes from.
         let account = Account::keyless(
             ProviderId::new(spec.id),
-            AccountId::default(),
+            account.clone(),
             Box::new(move |options| (spec.build)(Credential::new(String::new()), options)),
         )
         .with_credential(spec.credential);
@@ -686,7 +745,7 @@ fn hand_written_account(spec: &'static keyed::HandSpec) -> Account {
     }
     Account::new(
         ProviderId::new(spec.id),
-        AccountId::default(),
+        account.clone(),
         Box::new(move |credential, options| (spec.build)(credential, options)),
     )
     .with_credential(spec.credential)
@@ -769,6 +828,45 @@ mod tests {
         ));
         std::fs::write(&path, contents).expect("seeds config");
         path
+    }
+
+    #[test]
+    fn a_configured_provider_builds_one_account_per_account_id() {
+        let path = scratch_config(
+            "zai-accounts",
+            "providers = [\"zai\"]\n\n[provider.zai]\naccounts = [\"default\", \"work\"]\n",
+        );
+        let config = Config::at(path.clone()).expect("config reads");
+        let accounts = accounts(&secrets(), &config).expect("accounts build");
+
+        assert_eq!(
+            accounts
+                .iter()
+                .map(|account| account.account().as_str().to_owned())
+                .collect::<Vec<_>>(),
+            ["default", "work"]
+        );
+        assert!(
+            accounts
+                .iter()
+                .all(|account| account.provider().as_str() == "zai")
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_claude_account_reports_its_constructed_account_id() {
+        let config = empty_config();
+        let account = account(
+            claude::PROVIDER_ID,
+            &AccountId::new("work"),
+            &secrets(),
+            &config,
+        )
+        .expect("builds")
+        .expect("Claude account builds");
+
+        assert_eq!(account.account().as_str(), "work");
     }
 
     #[test]
@@ -856,9 +954,14 @@ mod tests {
             "providers = [\"cursor\"]\n\n[provider.cursor]\nauth-source = \"browser\"\nauth-browser = \"zen\"\nauth-profile = \"work\"\n",
         );
         let config = Config::at(path.clone()).expect("config reads");
-        let account = account(cursor::PROVIDER_ID, &secrets(), &config)
-            .expect("builds")
-            .expect("Cursor account builds");
+        let account = account(
+            cursor::PROVIDER_ID,
+            &AccountId::default(),
+            &secrets(),
+            &config,
+        )
+        .expect("builds")
+        .expect("Cursor account builds");
         assert_eq!(
             account.status().auth_selection,
             Some(tidemark_types::AuthSelection {
@@ -893,9 +996,14 @@ mod tests {
             "providers = [\"qoder\"]\n\n[provider.qoder]\nauth-source = \"browser\"\nauth-browser = \"firefox\"\nauth-profile = \"Default\"\n",
         );
         let config = Config::at(path.clone()).expect("config reads");
-        let account = account(qoder::PROVIDER_ID, &secrets(), &config)
-            .expect("builds")
-            .expect("Qoder account builds");
+        let account = account(
+            qoder::PROVIDER_ID,
+            &AccountId::default(),
+            &secrets(),
+            &config,
+        )
+        .expect("builds")
+        .expect("Qoder account builds");
         assert_eq!(
             account.status().auth_selection,
             Some(tidemark_types::AuthSelection {
@@ -932,9 +1040,14 @@ mod tests {
             "providers = [\"t3chat\"]\n\n[provider.t3chat]\nauth-source = \"browser\"\nauth-browser = \"firefox\"\nauth-profile = \"Default\"\n",
         );
         let config = Config::at(path.clone()).expect("config reads");
-        let account = account(t3chat::PROVIDER_ID, &secrets(), &config)
-            .expect("builds")
-            .expect("T3 Chat account builds");
+        let account = account(
+            t3chat::PROVIDER_ID,
+            &AccountId::default(),
+            &secrets(),
+            &config,
+        )
+        .expect("builds")
+        .expect("T3 Chat account builds");
         assert_eq!(
             account.status().auth_selection,
             Some(tidemark_types::AuthSelection {
@@ -1011,9 +1124,14 @@ mod tests {
             "providers = [\"zoommate\"]\n\n[provider.zoommate]\nauth-source = \"browser\"\nauth-browser = \"firefox\"\nauth-profile = \"Default\"\n",
         );
         let config = Config::at(path.clone()).expect("config reads");
-        let account = account(zoommate::PROVIDER_ID, &secrets(), &config)
-            .expect("builds")
-            .expect("ZoomMate account builds");
+        let account = account(
+            zoommate::PROVIDER_ID,
+            &AccountId::default(),
+            &secrets(),
+            &config,
+        )
+        .expect("builds")
+        .expect("ZoomMate account builds");
         assert_eq!(
             account.status().auth_selection,
             Some(tidemark_types::AuthSelection {
@@ -1066,7 +1184,7 @@ mod tests {
             claude::PROVIDER_ID,
             codex::PROVIDER_ID,
         ] {
-            let account = account(slug, &secrets(), &config)
+            let account = account(slug, &AccountId::default(), &secrets(), &config)
                 .expect("no error")
                 .expect("an OAuth provider builds an account");
             assert!(
@@ -1223,7 +1341,7 @@ mod tests {
         // `Account::new` would ask the keyring for a key that was never stored and report
         // `NoCredential` forever, so a keyless account is built without a factory at all —
         // and without a hint, there being nowhere to send anyone for a credential.
-        let account = hand_written_account(&KEYLESS_SPEC);
+        let account = hand_written_account(&KEYLESS_SPEC, &AccountId::default());
         assert_eq!(
             account.status().credential.as_deref(),
             Some(CredentialKind::None.as_wire())
@@ -1375,7 +1493,7 @@ mod tests {
             assert_eq!(entry.credential_hint, spec.credential_hint);
             assert_eq!(entry.options.len(), spec.options.len());
             assert!(
-                account(spec.id, &secrets(), &config)
+                account(spec.id, &AccountId::default(), &secrets(), &config)
                     .expect("no error")
                     .is_some(),
                 "{} must build an account",
@@ -1431,16 +1549,22 @@ mod tests {
 
     #[test]
     fn a_keyed_spec_builds_a_configured_account() {
-        let built = account("zai", &secrets(), &empty_config()).expect("no error");
+        let built =
+            account("zai", &AccountId::default(), &secrets(), &empty_config()).expect("no error");
         assert!(built.is_some(), "a slug in keyed::CATALOG must build");
     }
 
     #[test]
     fn a_slug_no_build_supports_is_still_not_an_account() {
         assert!(
-            account("nonesuch", &secrets(), &empty_config())
-                .expect("no error")
-                .is_none(),
+            account(
+                "nonesuch",
+                &AccountId::default(),
+                &secrets(),
+                &empty_config()
+            )
+            .expect("no error")
+            .is_none(),
             "an unknown slug is warned about, not turned into an account"
         );
     }

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -599,10 +599,24 @@ impl Daemon {
         }
 
         // The engine's answer is the topology; the published mirror of it is updated by a
-        // separate task and can lag this reply, so it must not be guessed at. Rebuilding
-        // the whole set keeps a promotion's renames — the survivor's new id and the death
-        // of its old one — from desynchronizing the validation every call depends on.
-        *self.configured.write().await = topology.into_iter().collect();
+        // separate task and can lag this reply, so it must not be guessed at. Only this
+        // provider's pairs are taken from it, under one guard: the reply is a snapshot
+        // of every provider taken when the engine handled the removal, and an add for a
+        // different provider that completes while this method is still in its keyring
+        // cleanup would be wiped out by a whole-set replacement. Rebuilding the whole
+        // provider's set at once keeps a promotion's renames — the survivor's new id and
+        // the death of its old one — from desynchronizing the validation every call
+        // depends on.
+        {
+            let mut configured = self.configured.write().await;
+            configured.retain(|(held, _)| held != provider);
+            configured.extend(
+                topology
+                    .iter()
+                    .filter(|(held, _)| held == provider)
+                    .cloned(),
+            );
+        }
 
         match cleanup {
             Some(error) => Err(error),
@@ -1609,6 +1623,22 @@ mod tests {
         }]
     }
 
+    /// A catalog of keyed providers, for tests that need more than one provider.
+    fn catalog_with(providers: &[&str]) -> Vec<ProviderDefinition> {
+        providers
+            .iter()
+            .map(|provider| ProviderDefinition {
+                provider: (*provider).into(),
+                title: (*provider).into(),
+                credential: "key".into(),
+                credential_hint: format!("{provider} dashboard → API keys."),
+                external: None,
+                browser_auth: None,
+                options: Vec::new(),
+            })
+            .collect()
+    }
+
     /// A daemon over a fixed set of accounts, with the channel its commands land on.
     async fn daemon_over(
         accounts: Vec<ProviderStatus>,
@@ -2353,6 +2383,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_removal_does_not_wipe_a_concurrent_add_for_another_provider() {
+        let (secrets, mut cleanup_gate) = GatedDeleteSecrets::new();
+        let published = Published::default();
+        published.upsert(key_account("zai")).await;
+        published.upsert(key_account("kimi")).await;
+        let (commands, mut queue) = mpsc::channel(8);
+        let daemon = Arc::new(Daemon::new(
+            published,
+            PublishedUpdate::default(),
+            catalog_with(&["zai", "kimi"]),
+            vec![
+                ("zai".into(), "default".into()),
+                ("kimi".into(), "default".into()),
+            ],
+            commands,
+            secrets,
+        ));
+        let responder = tokio::spawn(async move {
+            // The removal's answer is a snapshot taken before the concurrent add: kimi
+            // still has only its default account in it.
+            let Command::RemoveProvider {
+                provider, reply, ..
+            } = queue.recv().await.expect("removal reaches engine")
+            else {
+                panic!("unexpected command");
+            };
+            assert_eq!(provider, "zai");
+            reply
+                .send(Ok(vec![("kimi".into(), "default".into())]))
+                .expect("caller waits");
+            let Command::AddAccount {
+                provider,
+                account,
+                reply,
+            } = queue.recv().await.expect("add reaches engine")
+            else {
+                panic!("unexpected command");
+            };
+            assert_eq!((provider.as_str(), account.as_str()), ("kimi", "work"));
+            reply.send(Ok(())).expect("caller waits");
+            queue
+        });
+        let removing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.remove_provider("zai", "default").await }
+        });
+
+        // Hold the removal inside its post-success keyring cleanup — two Secret Service
+        // round trips, not a microsecond — while another provider's add completes.
+        let release = cleanup_gate
+            .recv()
+            .await
+            .expect("the removal reached its cleanup window");
+        daemon
+            .add_account("kimi", "work")
+            .await
+            .expect("a different provider's add is not blocked");
+        release.send(()).expect("the removal finishes its cleanup");
+        removing
+            .await
+            .expect("removal task did not panic")
+            .expect("removed");
+        responder.await.expect("responder finished");
+
+        daemon
+            .account("kimi", "work")
+            .await
+            .expect("the concurrent add survives the removal's reconciliation");
+        assert!(matches!(
+            daemon.account("zai", "default").await,
+            Err(fdo::Error::InvalidArgs(_))
+        ));
+    }
+
+    #[tokio::test]
     async fn stale_refresh_cannot_undo_the_real_sign_out_mutation() {
         const PROVIDER: &str = "antigravity";
         let (daemon, secrets, mut commands) = daemon_over(vec![oauth_account(PROVIDER)]).await;
@@ -2497,6 +2602,77 @@ mod tests {
             _account: &'a AccountId,
         ) -> tidemark_core::providers::BoxFuture<'a, Result<(), SecretError>> {
             Box::pin(async { Err(SecretError::Locked) })
+        }
+    }
+
+    /// A keyring whose first delete parks until the test releases it, so a removal can
+    /// be held deterministically inside its post-success cleanup window.
+    #[derive(Debug)]
+    struct GatedDeleteSecrets {
+        handoff: mpsc::UnboundedSender<oneshot::Sender<()>>,
+        gated: std::sync::atomic::AtomicBool,
+    }
+
+    impl GatedDeleteSecrets {
+        fn new() -> (Arc<Self>, mpsc::UnboundedReceiver<oneshot::Sender<()>>) {
+            let (handoff, entered) = mpsc::unbounded_channel();
+            (
+                Arc::new(Self {
+                    handoff,
+                    gated: std::sync::atomic::AtomicBool::new(false),
+                }),
+                entered,
+            )
+        }
+    }
+
+    impl Secrets for GatedDeleteSecrets {
+        fn get<'a>(
+            &'a self,
+            _kind: Kind,
+            _provider: &'a ProviderId,
+            _account: &'a AccountId,
+        ) -> tidemark_core::providers::BoxFuture<'a, Result<Option<Credential>, SecretError>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn set<'a>(
+            &'a self,
+            _kind: Kind,
+            _provider: &'a ProviderId,
+            _account: &'a AccountId,
+            _secret: &'a Credential,
+        ) -> tidemark_core::providers::BoxFuture<'a, Result<(), SecretError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn compare_and_set<'a>(
+            &'a self,
+            _kind: Kind,
+            _provider: &'a ProviderId,
+            _account: &'a AccountId,
+            _expected: &'a Credential,
+            _replacement: &'a Credential,
+        ) -> tidemark_core::providers::BoxFuture<'a, Result<bool, SecretError>> {
+            Box::pin(async { Ok(false) })
+        }
+
+        fn delete<'a>(
+            &'a self,
+            _kind: Kind,
+            _provider: &'a ProviderId,
+            _account: &'a AccountId,
+        ) -> tidemark_core::providers::BoxFuture<'a, Result<(), SecretError>> {
+            if self.gated.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                return Box::pin(async { Ok(()) });
+            }
+            let (release, released) = oneshot::channel();
+            let _ = self.handoff.send(release);
+            Box::pin(async {
+                released.await.expect("the test releases the first delete");
+                Ok(())
+            })
         }
     }
 

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -434,6 +434,29 @@ impl Daemon {
         ids
     }
 
+    /// Takes every account mutation lock of one provider, in sorted id order, and holds
+    /// them for an identity migration.
+    async fn lock_provider_identities<'a>(&'a self, provider: &'a str) -> IdentityMigration<'a> {
+        loop {
+            let ids = self.provider_accounts(provider).await;
+            let mut guards = Vec::with_capacity(ids.len());
+            for id in &ids {
+                // Owned guards, so the lock's `Arc` lives exactly as long as the guard —
+                // one per account, all held until the migration has finished.
+                let mutation = self.mutation(provider, id).await;
+                guards.push(mutation.lock_owned().await);
+            }
+            if self.provider_accounts(provider).await == ids {
+                return IdentityMigration {
+                    daemon: self,
+                    provider,
+                    ids,
+                    _guards: guards,
+                };
+            }
+        }
+    }
+
     /// Removes and aborts a pending login, if one exists.
     async fn cancel_pending_login(&self, provider: &str, account: &str) {
         if let Some(mut pending) = self.logins.lock().await.remove(&key(provider, account)) {
@@ -450,6 +473,29 @@ impl Daemon {
     }
 }
 
+/// Every account mutation lock of one provider, held across an identity migration.
+///
+/// A rename or a promotion rekeys credential slots by id, and a credential written to
+/// any of the provider's ids while that is in flight is the write it would lose: the
+/// whole provider's ids are held, taken in sorted order so two such flows cannot
+/// deadlock. The id set is re-read once the guards are held and the attempt restarted
+/// if it moved — an account added while the locks were being taken must join the guard,
+/// not escape it.
+///
+/// The same holder carries the migration's epilogue: the engine's reply is the topology,
+/// and the service's mirror of it — the set every call validates ids against — is
+/// rebuilt from that answer rather than guessed at, because the published copy is
+/// updated asynchronously.
+struct IdentityMigration<'a> {
+    daemon: &'a Daemon,
+    provider: &'a str,
+    /// The ids the guards cover, in the sorted order their locks were taken in.
+    ids: Vec<String>,
+    /// One owned guard per id, held until the migration has finished. Underscored
+    /// because holding them is their whole job.
+    _guards: Vec<tokio::sync::OwnedMutexGuard<()>>,
+}
+
 /// The D-Bus error a keyring failure becomes.
 ///
 /// A locked keyring is the one that matters: it is not the caller's mistake and not a
@@ -460,6 +506,27 @@ fn keyring_error(error: SecretError) -> fdo::Error {
             fdo::Error::Failed("the keyring is locked; unlock it and try again".into())
         }
         other => fdo::Error::Failed(other.to_string()),
+    }
+}
+
+impl IdentityMigration<'_> {
+    /// Replaces this provider's configured pairs with the ones the engine's reply named.
+    ///
+    /// Only this provider's pairs move, under one guard: the reply is a snapshot of
+    /// every provider taken when the engine handled the command, and an add for a
+    /// different provider that completes meanwhile would be wiped out by a whole-set
+    /// replacement. Rebuilding the whole provider's set at once keeps a migration's
+    /// renames — the survivor's new id and the death of its old one — from
+    /// desynchronizing the validation every call depends on.
+    async fn reconcile(&self, topology: &[(String, String)]) {
+        let mut configured = self.daemon.configured.write().await;
+        configured.retain(|(held, _)| held != self.provider);
+        configured.extend(
+            topology
+                .iter()
+                .filter(|(held, _)| held == self.provider)
+                .cloned(),
+        );
     }
 }
 
@@ -525,31 +592,14 @@ impl Daemon {
     /// promotion moves the survivor into the `default` slot and rekeys its credential
     /// inside the engine, so the service deletes only for an id the answer shows is gone.
     async fn remove_provider(&self, provider: &str, account: &str) -> fdo::Result<()> {
-        // Hold every account of the provider, in sorted order, across the whole flow: a
-        // promotion rekeys a secret slot by id, and a credential written to any of the
-        // provider's ids while that is in flight is the write it would lose. The set is
-        // re-read after the locks are held and the attempt restarted if it moved — an
-        // account added while the removal was locking must join the guard, not escape it.
-        let (ids, _guards) = loop {
-            let ids = self.provider_accounts(provider).await;
-            let mut guards = Vec::with_capacity(ids.len());
-            for id in &ids {
-                // Owned guards, so the lock's `Arc` lives exactly as long as the guard —
-                // one per account, all held until the removal has finished.
-                let mutation = self.mutation(provider, id).await;
-                guards.push(mutation.lock_owned().await);
-            }
-            if self.provider_accounts(provider).await == ids {
-                break (ids, guards);
-            }
-        };
+        let migration = self.lock_provider_identities(provider).await;
         self.account(provider, account).await?;
 
         // A login in flight for an id a promotion is about to rename would finish by
         // storing a token under an id no configured account reads, so every pending
         // login of the provider goes before the command — not just the target's.
-        if account == AccountId::default().as_str() && ids.len() > 1 {
-            for id in &ids {
+        if account == AccountId::default().as_str() && migration.ids.len() > 1 {
+            for id in &migration.ids {
                 self.cancel_pending_login(provider, id).await;
             }
         } else {
@@ -599,24 +649,8 @@ impl Daemon {
         }
 
         // The engine's answer is the topology; the published mirror of it is updated by a
-        // separate task and can lag this reply, so it must not be guessed at. Only this
-        // provider's pairs are taken from it, under one guard: the reply is a snapshot
-        // of every provider taken when the engine handled the removal, and an add for a
-        // different provider that completes while this method is still in its keyring
-        // cleanup would be wiped out by a whole-set replacement. Rebuilding the whole
-        // provider's set at once keeps a promotion's renames — the survivor's new id and
-        // the death of its old one — from desynchronizing the validation every call
-        // depends on.
-        {
-            let mut configured = self.configured.write().await;
-            configured.retain(|(held, _)| held != provider);
-            configured.extend(
-                topology
-                    .iter()
-                    .filter(|(held, _)| held == provider)
-                    .cloned(),
-            );
-        }
+        // separate task and can lag this reply, so it must not be guessed at.
+        migration.reconcile(&topology).await;
 
         match cleanup {
             Some(error) => Err(error),
@@ -667,6 +701,59 @@ impl Daemon {
         })
         .await?;
         self.configured.write().await.insert(key(provider, account));
+        Ok(())
+    }
+
+    /// Renames one configured account, carrying its credential and history to the new id.
+    ///
+    /// The engine migrates them durability-first — the credential is copied before
+    /// anything is deleted, and the old slots go only once the new topology is on disk —
+    /// so a failure anywhere before that point leaves the old id exactly as it was. The
+    /// new id is validated here for the same reason `add_account` validates its own: an
+    /// id the config can never hold is an argument error, not an engine failure after a
+    /// round trip.
+    async fn rename_account(&self, provider: &str, account: &str, new: &str) -> fdo::Result<()> {
+        let migration = self.lock_provider_identities(provider).await;
+        self.account(provider, account).await?;
+        if account == AccountId::default().as_str() {
+            return Err(fdo::Error::InvalidArgs(
+                "the default account is the provider's structural first account and \n                 cannot be renamed"
+                    .into(),
+            ));
+        }
+        if new == account {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "account {provider}/{new} is already named that"
+            )));
+        }
+        if !crate::engine::valid_account_slug(new) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "account {new:?} is not a valid account id: lowercase letters, digits \n                 and hyphens"
+            )));
+        }
+        if self.configured.read().await.contains(&key(provider, new)) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "account {provider}/{new} is already configured"
+            )));
+        }
+
+        // A login in flight for the id the rename retires would finish by storing a
+        // token under an id no configured account reads. The new id cannot have one:
+        // nothing validates a login against an unconfigured id.
+        self.cancel_pending_login(provider, account).await;
+
+        let topology = self
+            .config_request(|reply| Command::RenameAccount {
+                provider: provider.to_owned(),
+                account: account.to_owned(),
+                new: new.to_owned(),
+                reply,
+            })
+            .await?;
+
+        // The engine's answer is the topology; the published mirror of it is updated by
+        // a separate task and can lag this reply, so it must not be guessed at.
+        migration.reconcile(&topology).await;
         Ok(())
     }
 
@@ -2733,6 +2820,250 @@ mod tests {
             commands.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn renaming_rejects_every_invalid_argument_before_the_engine_is_asked() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+
+        for (provider, account, new) in [
+            ("kimi", "work", "team"),
+            ("zai", "missing", "team"),
+            ("zai", "default", "team"),
+            ("zai", "work", "work"),
+            ("zai", "work", "Team"),
+            ("zai", "work", "default"),
+        ] {
+            let error = daemon
+                .rename_account(provider, account, new)
+                .await
+                .expect_err(&format!(
+                    "renaming {provider}/{account} to {new} must be refused"
+                ));
+            assert!(
+                matches!(error, fdo::Error::InvalidArgs(_)),
+                "renaming {provider}/{account} to {new} is an argument error, not an engine failure"
+            );
+        }
+        assert!(
+            matches!(commands.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "no refused rename reaches the engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rename_migrates_through_the_engine_and_reconciles_the_configured_set() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let responder = tokio::spawn(async move {
+            let Command::RenameAccount {
+                provider,
+                account,
+                new,
+                reply,
+            } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            assert_eq!(
+                (provider.as_str(), account.as_str(), new.as_str()),
+                ("zai", "work", "team")
+            );
+            reply
+                .send(Ok(vec![
+                    ("zai".into(), "default".into()),
+                    ("zai".into(), "team".into()),
+                ]))
+                .expect("caller waits");
+        });
+
+        daemon
+            .rename_account("zai", "work", "team")
+            .await
+            .expect("renamed");
+
+        assert!(
+            daemon.account("zai", "team").await.is_ok(),
+            "the configured set names the new id"
+        );
+        assert!(
+            matches!(
+                daemon.account("zai", "work").await,
+                Err(fdo::Error::InvalidArgs(_))
+            ),
+            "the retired id leaves the configured set with the reply's topology"
+        );
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_failed_rename_leaves_the_configured_set_alone() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let responder = tokio::spawn(async move {
+            let Command::RenameAccount { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            reply
+                .send(Err("the settings file refused the write".to_owned()))
+                .expect("caller waits");
+        });
+
+        let error = daemon
+            .rename_account("zai", "work", "team")
+            .await
+            .expect_err("the engine refused the rename");
+        assert!(matches!(error, fdo::Error::Failed(_)));
+        assert!(
+            daemon.account("zai", "work").await.is_ok(),
+            "the old id stays configured when nothing became durable"
+        );
+        assert!(
+            matches!(
+                daemon.account("zai", "team").await,
+                Err(fdo::Error::InvalidArgs(_))
+            ),
+            "the new id never entered the configured set"
+        );
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_rename_holds_the_providers_mutation_locks_until_it_finishes() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let daemon = Arc::new(daemon);
+        let (rename_seen, rename_reached_engine) = tokio::sync::oneshot::channel();
+        let (finish_rename, release_engine_reply) = tokio::sync::oneshot::channel();
+        let responder = tokio::spawn(async move {
+            let Command::RenameAccount { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            rename_seen.send(()).expect("test is waiting");
+            let _ = release_engine_reply.await;
+            reply
+                .send(Ok(vec![
+                    ("zai".into(), "default".into()),
+                    ("zai".into(), "team".into()),
+                ]))
+                .expect("caller waits");
+            commands
+        });
+        let renaming = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.rename_account("zai", "work", "team").await }
+        });
+        rename_reached_engine
+            .await
+            .expect("the rename reached the engine holding every account's lock");
+
+        // A credential stored under the id being retired while the migration is in
+        // flight is the write it would lose.
+        let setting = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.set_key("zai", "work", "too-late").await }
+        });
+        for _ in 0..10 {
+            if setting.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !setting.is_finished(),
+            "a credential mutation for the renamed id serializes against the rename"
+        );
+
+        finish_rename.send(()).expect("responder waits");
+        renaming
+            .await
+            .expect("rename task did not panic")
+            .expect("engine accepted the rename");
+        let error = setting
+            .await
+            .expect("credential task did not panic")
+            .expect_err("the retired id is gone from the configured set");
+        assert!(matches!(error, fdo::Error::InvalidArgs(_)));
+        let mut commands = responder.await.expect("responder finished");
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_rename_cancels_a_pending_login_for_the_retired_id() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct Dropped(Arc<AtomicBool>);
+        impl Drop for Dropped {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let dropped = Arc::new(AtomicBool::new(false));
+        let task_dropped = Arc::clone(&dropped);
+        let (started, ready) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _guard = Dropped(task_dropped);
+            started.send(()).expect("test is waiting");
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+        ready.await.expect("pending task started");
+        daemon
+            .logins
+            .lock()
+            .await
+            .insert(key("zai", "work"), Pending::new(task));
+        let responder = tokio::spawn(async move {
+            let Command::RenameAccount { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            reply
+                .send(Ok(vec![
+                    ("zai".into(), "default".into()),
+                    ("zai".into(), "team".into()),
+                ]))
+                .expect("caller waits");
+        });
+
+        daemon
+            .rename_account("zai", "work", "team")
+            .await
+            .expect("renamed");
+        for _ in 0..10 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(dropped.load(Ordering::SeqCst), "the login task was aborted");
+        assert!(daemon.logins.lock().await.is_empty());
+        responder.await.expect("responder finished");
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -345,6 +345,10 @@ impl Daemon {
         status.credential = Some(definition.credential.clone());
         status.credential_hint = Some(definition.credential_hint.clone());
         status.options = definition.options.clone();
+        // The same label the engine will publish once the first status exists, so a client
+        // does not see a card gain its name part-way through configuring the account.
+        status.account_label =
+            (account != AccountId::default().as_str()).then(|| account.to_owned());
         Ok(status)
     }
 
@@ -368,10 +372,10 @@ impl Daemon {
     }
 
     /// Sends a configuration mutation and waits until the poll loop has persisted it.
-    async fn config_request(
+    async fn config_request<T>(
         &self,
-        make: impl FnOnce(oneshot::Sender<Result<(), String>>) -> Command,
-    ) -> fdo::Result<()> {
+        make: impl FnOnce(oneshot::Sender<Result<T, String>>) -> Command,
+    ) -> fdo::Result<T> {
         let (reply, answer) = oneshot::channel();
         self.commands
             .send(make(reply))
@@ -413,6 +417,21 @@ impl Daemon {
                 .entry(key(provider, account))
                 .or_insert_with(|| Arc::new(Mutex::new(()))),
         )
+    }
+
+    /// Every configured account id of one provider, sorted: the order their mutation
+    /// locks are taken in, so two operations touching the same provider cannot deadlock.
+    async fn provider_accounts(&self, provider: &str) -> Vec<String> {
+        let mut ids: Vec<String> = self
+            .configured
+            .read()
+            .await
+            .iter()
+            .filter(|(configured, _)| configured == provider)
+            .map(|(_, account)| account.clone())
+            .collect();
+        ids.sort();
+        ids
     }
 
     /// Removes and aborts a pending login, if one exists.
@@ -496,34 +515,174 @@ impl Daemon {
         Ok(())
     }
 
-    /// Removes one configured account after clearing every credential Tidemark owns.
+    /// Removes one configured account, promoting the first survivor when it was the
+    /// default.
+    ///
+    /// Nothing is deleted from the keyring until the engine has persisted the removal: a
+    /// promotion can still fail after this point — a rekey collision, a history error, a
+    /// config write — and a topology that survives while its credentials are gone is the
+    /// one loss this file must never cause. Cleanup after success is identity-aware: a
+    /// promotion moves the survivor into the `default` slot and rekeys its credential
+    /// inside the engine, so the service deletes only for an id the answer shows is gone.
     async fn remove_provider(&self, provider: &str, account: &str) -> fdo::Result<()> {
-        let mutation = self.mutation(provider, account).await;
-        let _guard = mutation.lock().await;
+        // Hold every account of the provider, in sorted order, across the whole flow: a
+        // promotion rekeys a secret slot by id, and a credential written to any of the
+        // provider's ids while that is in flight is the write it would lose. The set is
+        // re-read after the locks are held and the attempt restarted if it moved — an
+        // account added while the removal was locking must join the guard, not escape it.
+        let (ids, _guards) = loop {
+            let ids = self.provider_accounts(provider).await;
+            let mut guards = Vec::with_capacity(ids.len());
+            for id in &ids {
+                // Owned guards, so the lock's `Arc` lives exactly as long as the guard —
+                // one per account, all held until the removal has finished.
+                let mutation = self.mutation(provider, id).await;
+                guards.push(mutation.lock_owned().await);
+            }
+            if self.provider_accounts(provider).await == ids {
+                break (ids, guards);
+            }
+        };
         self.account(provider, account).await?;
-        self.cancel_pending_login(provider, account).await;
 
+        // A login in flight for an id a promotion is about to rename would finish by
+        // storing a token under an id no configured account reads, so every pending
+        // login of the provider goes before the command — not just the target's.
+        if account == AccountId::default().as_str() && ids.len() > 1 {
+            for id in &ids {
+                self.cancel_pending_login(provider, id).await;
+            }
+        } else {
+            self.cancel_pending_login(provider, account).await;
+        }
+
+        let topology = self
+            .config_request(|reply| Command::RemoveProvider {
+                provider: provider.to_owned(),
+                account: account.to_owned(),
+                reply,
+            })
+            .await?;
+
+        // The same net for logins that started against an id the finished removal turns
+        // out not to have kept: the engine's answer, not the caller's intent, says which
+        // identities still exist.
+        let stranded: Vec<String> = self
+            .logins
+            .lock()
+            .await
+            .keys()
+            .filter(|(login_provider, id)| {
+                login_provider == provider && !topology.contains(&(provider.to_owned(), id.clone()))
+            })
+            .map(|(_, id)| id.clone())
+            .collect();
+        for id in stranded {
+            self.cancel_pending_login(provider, &id).await;
+        }
+
+        // Only now that the removal is durable, and only for an id nothing moved into: a
+        // promotion leaves the survivor living under `default`, and deleting there would
+        // take its credential. Both kinds are attempted so one locked keyring leaves at
+        // most one residue rather than skipping the second kind.
         let provider_id = ProviderId::new(provider);
         let account_id = AccountId::new(account);
-        self.secrets
-            .delete(Kind::Key, &provider_id, &account_id)
-            .await
-            .map_err(keyring_error)?;
-        self.secrets
-            .delete(Kind::Token, &provider_id, &account_id)
-            .await
-            .map_err(keyring_error)?;
+        let promoted = account == AccountId::default().as_str()
+            && topology.iter().any(|(held, _)| held == provider);
+        let mut cleanup = None;
+        if !promoted {
+            for kind in [Kind::Key, Kind::Token] {
+                if let Err(error) = self.secrets.delete(kind, &provider_id, &account_id).await {
+                    cleanup.get_or_insert(keyring_error(error));
+                }
+            }
+        }
 
-        self.config_request(|reply| Command::RemoveProvider {
+        // The engine's answer is the topology; the published mirror of it is updated by a
+        // separate task and can lag this reply, so it must not be guessed at. Rebuilding
+        // the whole set keeps a promotion's renames — the survivor's new id and the death
+        // of its old one — from desynchronizing the validation every call depends on.
+        *self.configured.write().await = topology.into_iter().collect();
+
+        match cleanup {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Adds one more account to a provider this build knows and the config already has,
+    /// and waits for it to be persisted.
+    ///
+    /// The id is checked here for the same reason the provider slug is: an id config can
+    /// never hold should fail as an argument error, not as an engine failure after a
+    /// round trip. Whether the provider supports a second account at all is the engine's
+    /// to answer — that is a property of the provider, not of the argument.
+    async fn add_account(&self, provider: &str, account: &str) -> fdo::Result<()> {
+        let mutation = self.mutation(provider, account).await;
+        let _guard = mutation.lock().await;
+        if !self
+            .catalog
+            .iter()
+            .any(|definition| definition.provider == provider)
+        {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "provider {provider} is not supported by this build"
+            )));
+        }
+        if !crate::engine::valid_account_slug(account) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "account {account:?} is not a valid account id: lowercase letters, digits \
+                 and hyphens"
+            )));
+        }
+        if self
+            .configured
+            .read()
+            .await
+            .contains(&key(provider, account))
+        {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "account {provider}/{account} is already configured"
+            )));
+        }
+
+        self.config_request(|reply| Command::AddAccount {
             provider: provider.to_owned(),
             account: account.to_owned(),
             reply,
         })
         .await?;
-        self.configured
-            .write()
-            .await
-            .remove(&key(provider, account));
+        self.configured.write().await.insert(key(provider, account));
+        Ok(())
+    }
+
+    /// Puts one provider's accounts in the order a client's user arranged them in.
+    ///
+    /// The same contract as `SetOrder`, one level down: the list must name every
+    /// configured account of the provider exactly once, because the order and the set it
+    /// reorders live in the same `accounts` array. Whether the default account must lead
+    /// is the engine's rule — the engine is what rewrites the file — so a client that
+    /// gets it wrong hears it from the source of truth rather than from a copy of the
+    /// rule here.
+    async fn set_account_order(&self, provider: &str, accounts: Vec<String>) -> fdo::Result<()> {
+        let mut held = self.provider_accounts(provider).await;
+        let mut wanted = accounts.clone();
+        wanted.sort_unstable();
+        wanted.dedup();
+        held.sort_unstable();
+        if wanted.len() != accounts.len() || wanted != held {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "the order must name every configured account of {provider} exactly once"
+            )));
+        }
+
+        self.config_request(|reply| Command::SetAccountOrder {
+            provider: provider.to_owned(),
+            accounts: accounts.clone(),
+            reply,
+        })
+        .await?;
+        tracing::info!(provider, ?accounts, "account order changed");
         Ok(())
     }
 
@@ -1431,6 +1590,13 @@ mod tests {
         status
     }
 
+    /// One non-default account of a provider, the shape a second card carries.
+    fn account_of(provider: &str, account: &str) -> ProviderStatus {
+        let mut status = key_account(provider);
+        status.account = account.to_owned();
+        status
+    }
+
     fn catalog() -> Vec<ProviderDefinition> {
         vec![ProviderDefinition {
             provider: "zai".into(),
@@ -1588,6 +1754,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_configured_account_without_a_status_publishes_its_slug_as_the_label() {
+        let (commands, _queue) = mpsc::channel(4);
+        let daemon = Daemon::new(
+            Published::default(),
+            PublishedUpdate::default(),
+            catalog(),
+            vec![
+                ("zai".into(), "default".into()),
+                ("zai".into(), "work".into()),
+            ],
+            commands,
+            Arc::new(FakeSecrets::default()),
+        );
+
+        let labelled = daemon
+            .account("zai", "work")
+            .await
+            .expect("configured before publication");
+        assert_eq!(labelled.account_label.as_deref(), Some("work"));
+        let plain = daemon
+            .account("zai", "default")
+            .await
+            .expect("configured before publication");
+        assert_eq!(
+            plain.account_label, None,
+            "the default account is the provider itself"
+        );
+    }
+
+    #[tokio::test]
     async fn current_segment_is_serialized_through_the_engine() {
         let (daemon, _secrets, mut commands) = daemon_over(vec![key_account("zai")]).await;
         let responder = tokio::spawn(async move {
@@ -1690,7 +1886,104 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn removing_deletes_both_owned_secret_kinds_before_the_engine_request() {
+    async fn adding_an_account_waits_for_the_engine_result() {
+        let (daemon, _secrets, mut commands) =
+            daemon_over_catalog(vec![key_account("zai")], catalog()).await;
+        let responder = tokio::spawn(async move {
+            match commands.recv().await.expect("command") {
+                Command::AddAccount {
+                    provider,
+                    account,
+                    reply,
+                } => {
+                    assert_eq!((provider.as_str(), account.as_str()), ("zai", "work"));
+                    reply.send(Ok(())).expect("caller waits");
+                }
+                command => panic!("unexpected command: {command:?}"),
+            }
+        });
+
+        daemon.add_account("zai", "work").await.expect("added");
+        responder.await.expect("responder finished");
+
+        daemon
+            .account("zai", "work")
+            .await
+            .expect("the configured set knows the new account straight away");
+    }
+
+    #[tokio::test]
+    async fn adding_an_account_for_an_unknown_provider_is_an_invalid_argument() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(Vec::new(), catalog()).await;
+
+        let error = daemon
+            .add_account("not-a-provider", "work")
+            .await
+            .expect_err("unknown providers are rejected before the engine");
+
+        assert!(matches!(error, fdo::Error::InvalidArgs(_)));
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn adding_a_malformed_account_slug_is_an_invalid_argument() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(Vec::new(), catalog()).await;
+
+        for slug in ["", "Work", "work-", "-work", "two words", "work_1", "wörk"] {
+            let error = daemon.add_account("zai", slug).await.unwrap_err();
+            assert!(
+                matches!(error, fdo::Error::InvalidArgs(_)),
+                "{slug:?} is not an id the config can hold"
+            );
+        }
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn adding_an_already_configured_account_id_is_an_invalid_argument() {
+        let (daemon, _secrets, mut commands) =
+            daemon_over_catalog(vec![key_account("zai")], catalog()).await;
+
+        let error = daemon
+            .add_account("zai", "default")
+            .await
+            .expect_err("a configured id cannot be added twice");
+        assert!(matches!(error, fdo::Error::InvalidArgs(_)));
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        // And one added in this session, not only one loaded from config.
+        let responder = tokio::spawn(async move {
+            let Command::AddAccount { reply, .. } = commands.recv().await.expect("command") else {
+                panic!("unexpected command");
+            };
+            reply.send(Ok(())).expect("caller waits");
+            commands
+        });
+        daemon.add_account("zai", "work").await.expect("added");
+        let mut commands = responder.await.expect("responder finished");
+
+        let error = daemon
+            .add_account("zai", "work")
+            .await
+            .expect_err("the session's own add is in the configured set too");
+        assert!(matches!(error, fdo::Error::InvalidArgs(_)));
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_removal_deletes_its_credentials_only_after_the_engine_persisted_it() {
         let (daemon, secrets, mut commands) =
             daemon_over_catalog(vec![key_account("zai")], catalog()).await;
         for kind in [Kind::Key, Kind::Token] {
@@ -1704,6 +1997,8 @@ mod tests {
                 .await
                 .expect("seeded");
         }
+        let seeded = secrets.held();
+        assert_eq!(seeded.len(), 2, "both owned kinds are seeded");
         let observed = Arc::clone(&secrets);
         let responder = tokio::spawn(async move {
             match commands.recv().await.expect("command") {
@@ -1713,11 +2008,14 @@ mod tests {
                     reply,
                 } => {
                     assert_eq!((provider.as_str(), account.as_str()), ("zai", "default"));
-                    assert!(
-                        observed.held().is_empty(),
-                        "both secrets are gone before topology changes"
+                    assert_eq!(
+                        observed.held(),
+                        seeded,
+                        "nothing is deleted before the removal is durable: a promotion that \
+                         fails inside the engine would strand the topology without its \
+                         credentials"
                     );
-                    reply.send(Ok(())).expect("caller waits");
+                    reply.send(Ok(Vec::new())).expect("caller waits");
                 }
                 command => panic!("unexpected command: {command:?}"),
             }
@@ -1728,7 +2026,10 @@ mod tests {
             .await
             .expect("removed");
 
-        assert!(secrets.held().is_empty());
+        assert!(
+            secrets.held().is_empty(),
+            "after a durable removal the keyring holds nothing for the account"
+        );
         responder.await.expect("responder finished");
     }
 
@@ -1746,7 +2047,7 @@ mod tests {
             };
             remove_seen.send(()).expect("test is waiting");
             let _ = release_engine_reply.await;
-            reply.send(Ok(())).expect("caller waits");
+            reply.send(Ok(Vec::new())).expect("caller waits");
             commands
         });
         let removing = tokio::spawn({
@@ -1755,7 +2056,7 @@ mod tests {
         });
         removal_reached_engine
             .await
-            .expect("removal reached the engine after deleting secrets");
+            .expect("removal reached the engine holding the account's lock");
 
         let setting = tokio::spawn({
             let daemon = Arc::clone(&daemon);
@@ -1787,6 +2088,267 @@ mod tests {
         assert!(matches!(
             commands.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_promoting_removal_leaves_the_survivors_credential_to_the_engine() {
+        let (daemon, secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        for account in ["default", "work"] {
+            secrets
+                .set(
+                    Kind::Key,
+                    &ProviderId::new("zai"),
+                    &AccountId::new(account),
+                    &Credential::new(format!("{account}-key")),
+                )
+                .await
+                .expect("seeded");
+        }
+        let held = secrets.held();
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider {
+                provider,
+                account,
+                reply,
+            } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            assert_eq!((provider.as_str(), account.as_str()), ("zai", "default"));
+            // The engine promotes `work` into the `default` slot and moves that
+            // credential itself; deleting under `default` here would take the survivor's
+            // key with it.
+            reply
+                .send(Ok(vec![("zai".into(), "default".into())]))
+                .expect("caller waits");
+        });
+
+        daemon
+            .remove_provider("zai", "default")
+            .await
+            .expect("removed");
+
+        assert_eq!(
+            secrets.held(),
+            held,
+            "promotion cleanup belongs to the engine, which knows the survivor's kind"
+        );
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_promoting_removal_reconciles_the_configured_set_to_the_new_identity() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            // The engine renamed `work` into `default`; the reply carries the survivors.
+            reply
+                .send(Ok(vec![("zai".into(), "default".into())]))
+                .expect("caller waits");
+        });
+
+        daemon
+            .remove_provider("zai", "default")
+            .await
+            .expect("removed");
+
+        daemon
+            .account("zai", "default")
+            .await
+            .expect("the promoted identity is configured under its new id");
+        assert!(
+            matches!(
+                daemon.account("zai", "work").await,
+                Err(fdo::Error::InvalidArgs(_))
+            ),
+            "the id the survivor no longer uses must stop validating"
+        );
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_credential_mutation_cannot_overlap_a_promoting_removal() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let daemon = Arc::new(daemon);
+        let (remove_seen, removal_reached_engine) = tokio::sync::oneshot::channel();
+        let (finish_removal, release_engine_reply) = tokio::sync::oneshot::channel();
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider {
+                provider,
+                account,
+                reply,
+            } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            assert_eq!((provider.as_str(), account.as_str()), ("zai", "default"));
+            remove_seen.send(()).expect("test is waiting");
+            let _ = release_engine_reply.await;
+            reply
+                .send(Ok(vec![("zai".into(), "default".into())]))
+                .expect("caller waits");
+            commands
+        });
+        let removing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.remove_provider("zai", "default").await }
+        });
+        removal_reached_engine
+            .await
+            .expect("removal reached the engine holding every account's lock");
+
+        // The survivor is still called `work` until the engine renames it; a credential
+        // stored under that id while the secret rekey is in flight is the write a
+        // promotion would lose.
+        let setting = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.set_key("zai", "work", "too-late").await }
+        });
+        for _ in 0..10 {
+            if setting.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !setting.is_finished(),
+            "a credential mutation for any of the provider's accounts serializes against \
+             the removal"
+        );
+
+        finish_removal.send(()).expect("responder waits");
+        removing
+            .await
+            .expect("removal task did not panic")
+            .expect("engine accepted removal");
+        let error = setting
+            .await
+            .expect("credential task did not panic")
+            .expect_err("the id the survivor no longer uses is gone");
+        assert!(matches!(error, fdo::Error::InvalidArgs(_)));
+        let mut commands = responder.await.expect("responder finished");
+        assert!(matches!(
+            commands.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_removal_locks_an_account_added_while_it_was_locking() {
+        let (daemon, secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let daemon = Arc::new(daemon);
+        let secrets = Arc::clone(&secrets);
+
+        // Hold `work`, the last lock in sorted order, so the removal is parked
+        // mid-acquisition — it already holds `default` — when a concurrent add widens
+        // the provider's id set.
+        let held = daemon.mutation("zai", "work").await;
+        let _held = held.lock().await;
+        let removing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.remove_provider("zai", "default").await }
+        });
+        let mut parked = false;
+        for _ in 0..10_000 {
+            if daemon.mutation("zai", "default").await.try_lock().is_err() {
+                parked = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            parked,
+            "the removal takes the provider's account locks in sorted order"
+        );
+
+        // The concurrent add finished while the removal was locking: `extra` is
+        // configured now, and the removal must not leave it outside its guard.
+        daemon.configured.write().await.insert(key("zai", "extra"));
+        drop(_held);
+
+        let mut locked_extra = false;
+        for _ in 0..10_000 {
+            if daemon.mutation("zai", "extra").await.try_lock().is_err() {
+                locked_extra = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            locked_extra,
+            "a removal re-reads the id set while locking, so an account added beneath it \
+             cannot escape the provider-wide guard"
+        );
+
+        let setting = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.set_key("zai", "extra", "sk-late").await }
+        });
+        for _ in 0..10 {
+            if setting.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !setting.is_finished(),
+            "the late account's mutation waits too"
+        );
+
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            reply
+                .send(Ok(vec![
+                    ("zai".into(), "default".into()),
+                    ("zai".into(), "extra".into()),
+                ]))
+                .expect("caller waits");
+            commands
+        });
+        removing
+            .await
+            .expect("removal task did not panic")
+            .expect("engine accepted removal");
+        setting
+            .await
+            .expect("credential task did not panic")
+            .expect("the account the topology kept accepts its key");
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "zai".to_owned(),
+                "extra".to_owned(),
+                "sk-late".to_owned()
+            )]
+        );
+        let mut commands = responder.await.expect("responder finished");
+        assert!(matches!(
+            commands.recv().await.expect("the stored key wakes the loop"),
+            Command::Reload { provider: Some(provider) } if provider == "zai"
         ));
     }
 
@@ -1833,7 +2395,9 @@ mod tests {
             else {
                 panic!("unexpected command");
             };
-            reply.send(Ok(())).expect("caller waits for removal");
+            reply
+                .send(Ok(Vec::new()))
+                .expect("caller waits for removal");
         });
 
         daemon
@@ -1937,24 +2501,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_secret_delete_failure_leaves_the_provider_configured() {
+    async fn a_cleanup_failure_after_a_durable_removal_still_reconciles_the_topology() {
         let published = Published::default();
         published.upsert(key_account("zai")).await;
         let (commands, mut command_queue) = mpsc::channel(4);
-        let daemon = Daemon::new(
+        let daemon = Arc::new(Daemon::new(
             published,
             PublishedUpdate::default(),
             catalog(),
             vec![("zai".into(), "default".into())],
             commands,
             Arc::new(FailingDeleteSecrets),
-        );
-
-        assert!(daemon.remove_provider("zai", "default").await.is_err());
-        assert!(matches!(
-            command_queue.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
         ));
+        let removing = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move { daemon.remove_provider("zai", "default").await }
+        });
+        let Command::RemoveProvider { reply, .. } =
+            tokio::time::timeout(std::time::Duration::from_secs(5), command_queue.recv())
+                .await
+                .expect("the removal reaches the engine before any keyring write")
+                .expect("the queue is alive")
+        else {
+            panic!("unexpected command");
+        };
+        reply
+            .send(Ok(Vec::new()))
+            .expect("caller waits for the durable removal");
+
+        let error = removing
+            .await
+            .expect("removal task did not panic")
+            .expect_err("the keyring failure is surfaced, not swallowed");
+        assert!(matches!(error, fdo::Error::Failed(_)));
+        assert!(
+            matches!(
+                daemon.account("zai", "default").await,
+                Err(fdo::Error::InvalidArgs(_))
+            ),
+            "the topology the engine persisted is authoritative even when cleanup failed"
+        );
     }
 
     #[tokio::test]
@@ -2006,7 +2592,7 @@ mod tests {
             else {
                 panic!("unexpected command");
             };
-            reply.send(Ok(())).expect("caller waits");
+            reply.send(Ok(Vec::new())).expect("caller waits");
         });
 
         daemon
@@ -2021,6 +2607,134 @@ mod tests {
         }
 
         assert!(dropped.load(Ordering::SeqCst), "the login task was aborted");
+        assert!(daemon.logins.lock().await.is_empty());
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_promoting_removal_cancels_every_pending_login_of_the_provider() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct Dropped(Arc<AtomicBool>);
+        impl Drop for Dropped {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut work = oauth_account("zai");
+        work.account = "work".into();
+        let (daemon, _secrets, mut commands) =
+            daemon_over_catalog(vec![oauth_account("zai"), work], catalog()).await;
+        let pending = || {
+            let dropped = Arc::new(AtomicBool::new(false));
+            let flag = Arc::clone(&dropped);
+            let (started, ready) = tokio::sync::oneshot::channel();
+            let task = tokio::spawn(async move {
+                let _guard = Dropped(flag);
+                started.send(()).expect("test is waiting");
+                std::future::pending::<()>().await;
+                Ok(())
+            });
+            (dropped, task, ready)
+        };
+        let (default_dropped, default_task, default_ready) = pending();
+        let (work_dropped, work_task, work_ready) = pending();
+        default_ready.await.expect("default login started");
+        work_ready.await.expect("work login started");
+        {
+            let mut logins = daemon.logins.lock().await;
+            logins.insert(key("zai", "default"), Pending::new(default_task));
+            logins.insert(key("zai", "work"), Pending::new(work_task));
+        }
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            reply
+                .send(Ok(vec![("zai".into(), "default".into())]))
+                .expect("caller waits");
+        });
+
+        daemon
+            .remove_provider("zai", "default")
+            .await
+            .expect("removed");
+        for _ in 0..10 {
+            if work_dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            default_dropped.load(Ordering::SeqCst),
+            "the removed account's login was aborted"
+        );
+        assert!(
+            work_dropped.load(Ordering::SeqCst),
+            "a login keyed by the promoted account's old id would commit a token under an \
+             id no configured account reads"
+        );
+        assert!(daemon.logins.lock().await.is_empty());
+        responder.await.expect("responder finished");
+    }
+
+    #[tokio::test]
+    async fn a_login_for_an_id_the_new_topology_drops_is_cancelled() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct Dropped(Arc<AtomicBool>);
+        impl Drop for Dropped {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut work = oauth_account("zai");
+        work.account = "work".into();
+        let (daemon, _secrets, mut commands) =
+            daemon_over_catalog(vec![oauth_account("zai"), work], catalog()).await;
+        let dropped = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&dropped);
+        let (started, ready) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _guard = Dropped(flag);
+            started.send(()).expect("test is waiting");
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+        ready.await.expect("pending task started");
+        daemon
+            .logins
+            .lock()
+            .await
+            .insert(key("zai", "work"), Pending::new(task));
+        let responder = tokio::spawn(async move {
+            let Command::RemoveProvider { reply, .. } = commands.recv().await.expect("command")
+            else {
+                panic!("unexpected command");
+            };
+            // The engine's answer drops the whole provider, `work` included.
+            reply.send(Ok(Vec::new())).expect("caller waits");
+        });
+
+        daemon
+            .remove_provider("zai", "default")
+            .await
+            .expect("removed");
+        for _ in 0..10 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "no pending login may outlive the topology the engine just answered with"
+        );
         assert!(daemon.logins.lock().await.is_empty());
         responder.await.expect("responder finished");
     }
@@ -2309,6 +3023,88 @@ mod tests {
             panic!("unexpected command");
         };
         assert_eq!(providers, ["kimi", "zai"]);
+        assert!(!ordering.is_finished(), "D-Bus waits for persistence");
+        reply.send(Ok(())).expect("caller waits for reply");
+        ordering
+            .await
+            .expect("ordering task did not panic")
+            .expect("engine accepted the order");
+    }
+
+    #[tokio::test]
+    async fn an_account_order_that_is_not_a_permutation_is_refused_before_the_engine() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+
+        for order in [
+            vec!["default".to_owned()],
+            vec!["default".to_owned(), "default".to_owned()],
+            vec!["default".to_owned(), "work".to_owned(), "extra".to_owned()],
+            Vec::new(),
+        ] {
+            assert!(
+                daemon
+                    .set_account_order("zai", order.clone())
+                    .await
+                    .is_err(),
+                "{order:?} is not the configured account set"
+            );
+        }
+        assert!(
+            commands.try_recv().is_err(),
+            "a refused order never reaches the engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_account_order_for_an_unconfigured_provider_is_refused() {
+        let (daemon, _secrets, mut commands) =
+            daemon_over_catalog(vec![key_account("zai")], catalog()).await;
+
+        assert!(
+            daemon
+                .set_account_order("kimi", vec!["default".into()])
+                .await
+                .is_err()
+        );
+        assert!(commands.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn a_valid_account_order_is_serialized_through_the_engine() {
+        let (daemon, _secrets, mut commands) = daemon_over_catalog(
+            vec![key_account("zai"), account_of("zai", "work")],
+            catalog(),
+        )
+        .await;
+        let daemon = Arc::new(daemon);
+        // `work` first is a permutation of the configured set; whether the default must
+        // lead is the engine's rule to enforce, not a reason to reject the call here.
+        let ordering = tokio::spawn({
+            let daemon = Arc::clone(&daemon);
+            async move {
+                daemon
+                    .set_account_order("zai", vec!["work".into(), "default".into()])
+                    .await
+            }
+        });
+
+        let Command::SetAccountOrder {
+            provider,
+            accounts,
+            reply,
+        } = tokio::time::timeout(std::time::Duration::from_secs(5), commands.recv())
+            .await
+            .expect("order reaches engine")
+            .expect("the queue is alive")
+        else {
+            panic!("unexpected command");
+        };
+        assert_eq!(provider, "zai");
+        assert_eq!(accounts, ["work", "default"]);
         assert!(!ordering.is_finished(), "D-Bus waits for persistence");
         reply.send(Ok(())).expect("caller waits for reply");
         ordering

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -85,19 +85,21 @@ impl Published {
         Some(statuses.remove(index))
     }
 
-    /// Puts the accounts in this provider order.
+    /// Puts the accounts in the complete provider and account order.
     ///
     /// Applied to the shared vector rather than left to the next `GetStatus` to sort,
     /// because there is nothing for a client to sort by: the order is the user's and this
-    /// is where it is kept. An account whose provider the order does not name keeps its
-    /// place at the end — the sort is stable — so a sequence that has raced a removal
-    /// leaves the survivors alone instead of shuffling them.
-    pub async fn reorder(&self, providers: &[String]) {
+    /// is where it is kept. An account pair the order does not name keeps its place at the
+    /// end — the sort is stable — so a sequence that has raced a removal leaves survivors
+    /// alone instead of shuffling them.
+    pub async fn reorder(&self, accounts: &[(String, String)]) {
         self.0.write().await.sort_by_key(|status| {
-            providers
+            accounts
                 .iter()
-                .position(|slug| *slug == status.provider)
-                .unwrap_or(providers.len())
+                .position(|(provider, account)| {
+                    provider == &status.provider && account == &status.account
+                })
+                .unwrap_or(accounts.len())
         });
     }
 
@@ -1343,9 +1345,12 @@ mod tests {
         published.upsert(status("zai")).await;
         published.upsert(status("kimi")).await;
         published.upsert(status("claude")).await;
-
         published
-            .reorder(&["claude".into(), "zai".into(), "kimi".into()])
+            .reorder(&[
+                ("claude".into(), "default".into()),
+                ("zai".into(), "default".into()),
+                ("kimi".into(), "default".into()),
+            ])
             .await;
 
         let providers: Vec<String> = published
@@ -1358,13 +1363,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_published_order_follows_account_order_after_reordering() {
+        let published = Published::default();
+        let default = status("zai");
+        let mut work = status("zai");
+        work.account = "work".into();
+        published.upsert(default.clone()).await;
+        published.upsert(work.clone()).await;
+        published.upsert(status("kimi")).await;
+
+        published
+            .reorder(&[
+                ("zai".into(), "work".into()),
+                ("zai".into(), "default".into()),
+                ("kimi".into(), "default".into()),
+            ])
+            .await;
+
+        let accounts: Vec<(String, String)> = published
+            .all()
+            .await
+            .into_iter()
+            .map(|status| (status.provider, status.account))
+            .collect();
+        assert_eq!(
+            accounts,
+            [
+                ("zai".into(), "work".into()),
+                ("zai".into(), "default".into()),
+                ("kimi".into(), "default".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn a_reorder_leaves_an_account_it_does_not_name_at_the_end() {
         let published = Published::default();
         published.upsert(status("zai")).await;
         published.upsert(status("kimi")).await;
         published.upsert(status("claude")).await;
-
-        published.reorder(&["claude".into()]).await;
+        published
+            .reorder(&[("claude".into(), "default".into())])
+            .await;
 
         let providers: Vec<String> = published
             .all()

--- a/docs/superpowers/plans/2026-09-01-multi-account-providers.md
+++ b/docs/superpowers/plans/2026-09-01-multi-account-providers.md
@@ -2,6 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+- [x] **Implementation complete** — 2026-09-02, `443b2ad feat(ui): support multi-account providers`.
+  The user performed the visual QA. The shared group backdrop from Task 10 was deliberately
+  removed following user feedback, so it is not part of the shipped implementation. The
+  unchecked execution steps below are retained as the original historical plan.
+
 **Goal:** Let one provider carry several credentialled accounts (a work and a personal Claude, two Z.ai keys), created, named, shown, ordered and removed from the UI.
 
 **Architecture:** The daemon's plumbing is already per-account (`AccountId` flows through

--- a/docs/superpowers/plans/2026-09-01-multi-account-providers.md
+++ b/docs/superpowers/plans/2026-09-01-multi-account-providers.md
@@ -1,0 +1,294 @@
+# Multi-Account Providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one provider carry several credentialled accounts (a work and a personal Claude, two Z.ai keys), created, named, shown, ordered and removed from the UI.
+
+**Architecture:** The daemon's plumbing is already per-account (`AccountId` flows through
+secrets, history, the wire and the tray); only *construction* is hard-coded to one account
+per provider. The plan makes config name an ordered account list per provider, teaches the
+registry/engine to build them, adds two D-Bus methods (`AddAccount`, `SetAccountOrder`),
+and builds the settings rows and the grouped-card main window on top.
+
+**Tech Stack:** Rust 2024 (MSRV 1.92), Tokio + zbus (daemon), GTK4 + libadwaita programmatic
+UI (no `.ui`/gresource), rusqlite, oo7 Secret Service.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-multi-account-providers-design.md` — read it first; this plan argues from it.
+
+## Global Constraints
+
+- Work only on branch `feat/multi-account-providers`. Never commit to `main`.
+- Gate after every task: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`. Run the *targeted* test during a task; run the full gate before each commit that crosses a crate boundary.
+- `tidemark-types` reaches nothing (only `serde`+`zvariant`); `tidemark-core` never touches the display; `tidemark` (UI) speaks only D-Bus — no `tidemark-core`/`reqwest`/`rusqlite` deps. `check-layering.sh` enforces it.
+- No `anyhow`; contextual `thiserror` enums per domain (`ConfigError`, `StorageError`, `ProviderError`, `SecretError`).
+- Secrets keyed `(Kind, ProviderId, AccountId)`; never log a `Credential`.
+- History tables key on `(provider, account, window, …)`; **no schema change** — account column already exists.
+- `providers = [...]` config array stays a flat provider list (the `SetOrder` permutation contract). Accounts live under `[provider.<slug>] accounts = [...]`.
+- `"default"` is always present and always first in a provider's account list.
+- Extra OAuth accounts are Tidemark-login only (no CLI source). `None`/`External` providers stay single-account.
+- `ProviderStatus` is `a{sv}`: new keys are added, absent means absent; old daemons omit them.
+- Tests: built-in `#[test]`/`#[tokio::test]`, colocated `#[cfg(test)] mod tests`, descriptive `a_…`/`the_…` snake_case names, `History::in_memory()`, `FakeSecrets`, hand-rolled loopback servers, `Timestamp::from_unix`. No rstest/mockito/serial/proptest.
+- Commit style: Conventional Commits with scopes (`feat(core):`, `fix(daemon):`, `feat(ui):`).
+
+---
+
+## Phase A — Core: config + types
+
+### Task 1: `Config::accounts` reader
+
+**Files:**
+- Modify: `crates/tidemark-core/src/config.rs` (add reader near `providers()` ~line 460)
+
+**Interfaces:**
+- Produces: `pub fn accounts(&self, provider: &str) -> Result<Vec<String>, ConfigError>` — ordered account ids for `[provider.<slug>] accounts`, defaulting to `vec!["default"]` when the key is absent; errors on a present-but-non-array/non-string value.
+
+- [ ] **Step 1: failing tests**
+
+In `config.rs::tests`:
+
+```rust
+#[test]
+fn a_provider_without_an_accounts_key_has_its_default_account() {
+    let config = Config::from_text(r#"providers = ["zai"]"#);
+    assert_eq!(config.accounts("zai").unwrap(), vec!["default".to_string()]);
+}
+
+#[test]
+fn accounts_come_back_in_file_order() {
+    let config = Config::from_text("[provider.claude]\naccounts = [\"default\", \"work\"]\n");
+    assert_eq!(config.accounts("claude").unwrap(), vec!["default".to_string(), "work".to_string()]);
+}
+
+#[test]
+fn a_non_array_accounts_key_is_refused() {
+    let config = Config::from_text("[provider.zai]\naccounts = \"work\"\n");
+    assert!(matches!(config.accounts("zai"), Err(ConfigError::InvalidAccounts { .. })));
+}
+```
+
+(`Config::from_text` — add a test helper parsing a string into a `Config` over a temp path, mirroring `Config::at`; see existing `scratch_config` pattern in `registry.rs` tests.)
+
+- [ ] **Step 2: run, expect FAIL** — `cargo test -p tidemark-core config::tests -- accounts`
+- [ ] **Step 3: implement `accounts` + `ConfigError::InvalidAccounts`**
+
+- [ ] **Step 1: failing tests**
+
+In `config.rs::tests` (using the existing `scratch(name)` temp-file helper + `Config::at`):
+
+```rust
+#[test]
+fn a_provider_without_an_accounts_key_has_its_default_account() {
+    let path = scratch("accounts-absent");
+    std::fs::write(&path, "providers = [\"zai\"]\n").expect("seed");
+    let config = Config::at(path.clone()).expect("parses");
+    assert_eq!(config.accounts("zai").unwrap(), vec!["default".to_string()]);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
+fn accounts_come_back_in_file_order() {
+    let path = scratch("accounts-order");
+    std::fs::write(&path, "[provider.claude]\naccounts = [\"default\", \"work\"]\n").expect("seed");
+    let config = Config::at(path.clone()).expect("parses");
+    assert_eq!(config.accounts("claude").unwrap(), vec!["default".to_string(), "work".to_string()]);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
+fn a_non_array_accounts_key_is_refused() {
+    let path = scratch("accounts-invalid");
+    std::fs::write(&path, "[provider.zai]\naccounts = \"work\"\n").expect("seed");
+    let config = Config::at(path.clone()).expect("parses");
+    assert!(matches!(config.accounts("zai"), Err(ConfigError::InvalidAccounts { .. })));
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+```
+
+Add `const ACCOUNTS_KEY: &str = "accounts";` and the `InvalidAccounts { path, provider, reason }` variant.
+
+- [ ] **Step 4: run, expect PASS**
+- [ ] **Step 5: commit** — `feat(core): read per-provider account lists`
+
+### Task 2: `Config::set_accounts` writer + promote-on-remove
+
+**Files:**
+- Modify: `crates/tidemark-core/src/config.rs`
+
+**Interfaces:**
+- Produces: `pub fn set_accounts(&mut self, provider: &str, accounts: &[String]) -> Result<(), ConfigError>` — writes the array (staged write via existing `self.write()`); caller guarantees `"default"` is first.
+
+- [ ] **Step 1: failing test** — round-trip: set `["default","work"]`, re-read, assert order; then assert file contains `accounts = ["default", "work"]` under `[provider.zai]`.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemark-core config::tests -- set_accounts`
+- [ ] **Step 3: implement** using `set_option`'s table-descend pattern but inserting an `Array` of `Value::from(each)`; call `normalize_providers(None)?` first like the other writers.
+- [ ] **Step 4: run PASS**
+- [ ] **Step 5: commit** — `feat(core): write per-provider account lists`
+
+### Task 3: `ProviderStatus.account_label` wire field
+
+**Files:**
+- Modify: `crates/tidemark-types/src/wire.rs` (struct ~line 573, plus `pending`/builders)
+
+**Interfaces:**
+- Produces: `pub account_label: Option<String>` on `ProviderStatus`; defaults to `None` everywhere it is constructed. Serde: field stays absent when `None` (the `a{sv}` dict omits it — verify the existing `a_status_survives_the_bus` still passes and add one asserting the key is absent when `None`).
+
+- [ ] **Step 1: failing tests** — (a) a status built with `account_label = Some("Work")` round-trips the bus; (b) a `None` label encodes to a dict with no `account_label` key.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemark-types wire`
+- [ ] **Step 3: add the field** (`Option<String>`, `#[serde(default)]`-compatible with the existing zvariant dict encoding), thread `None` through every constructor (`pending`, engine `Account::new`/`with_client`, service `account()`).
+- [ ] **Step 4: run PASS** (types + a workspace build to catch construction sites)
+- [ ] **Step 5: commit** — `feat(types): carry an optional account label`
+
+---
+
+## Phase B — Daemon: build & publish accounts
+
+### Task 4: registry builds N accounts; constructors take the id
+
+**Files:**
+- Modify: `crates/tidemarkd/src/registry.rs` (`accounts` ~line 377, `account` ~267, `keyed_account` ~649, `hand_written_account` ~667, `claude_account`/`codex_account`/`antigravity_account` ~587-645)
+- Modify: `crates/tidemark-core/src/providers/claude.rs`, `codex.rs`, `antigravity/mod.rs`, `keyed/mod.rs` — `Provider::account()` and the `Secrets` lookups take the constructed `AccountId` instead of `AccountId::default()`.
+
+**Interfaces:**
+- Consumes: `Config::accounts` (Task 1).
+- Produces: `registry::account(provider, account_id, secrets, config)`; `Provider::account()` returns the constructed id; OAuth clients look up `Kind::Token` under their own id.
+
+- [ ] **Step 1: failing tests** — in `registry.rs::tests`: a config with `[provider.zai] accounts=["default","work"]` yields two accounts with ids `default`,`work`; a Claude account built with id `work` reports `account()=="work"`.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemarkd registry`
+- [ ] **Step 3: implement** — thread the `AccountId` through every constructor and the `Source`/secrets plumbing; extra OAuth accounts force `Source::OAuth` (skip CLI).
+- [ ] **Step 4: run PASS** + `cargo test -p tidemark-core providers`
+- [ ] **Step 5: commit** — `feat(daemon): build one account per configured account id`
+
+### Task 5: engine add/remove/promote + `set_account_order`
+
+**Files:**
+- Modify: `crates/tidemarkd/src/engine.rs` (`add_provider` ~435, `remove_provider` ~468, `set_order` ~500, `Command` enum ~79)
+
+**Interfaces:**
+- Produces: `Engine::add_account(provider, account)`, `remove_provider` promotion (removing `"default"` rewrites the survivor list so its first becomes `"default"`), `Engine::set_account_order(provider, &[String])`; new `Command::AddAccount`/`Command::SetAccountOrder` variants.
+
+- [ ] **Step 1: failing tests** — add_account persists+publishes pending; removing `"default"` promotes `work`; set_account_order rejects a non-permutation.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemarkd engine`
+- [ ] **Step 3: implement**, reusing the `config_request`/`Command` + `updates.send(Publication::…)` patterns.
+- [ ] **Step 4: run PASS**
+- [ ] **Step 5: commit** — `feat(daemon): add, order and promote accounts in the engine`
+
+### Task 6: D-Bus `AddAccount` / `SetAccountOrder` + publish `account_label`
+
+**Files:**
+- Modify: `crates/tidemarkd/src/service.rs` (interface ~465; `Published` ordering ~95)
+
+**Interfaces:**
+- Produces: methods `add_account(provider, account)`, `set_account_order(provider, accounts)`; `ProviderStatus.account_label` filled for non-default accounts; `Published::reorder` extended so `SetOrder` (provider slugs) keeps groups contiguous (all of a provider's accounts move together).
+
+- [ ] **Step 1: failing tests** — `add_account` validates unknown provider / duplicate id / malformed slug → `InvalidArgs`; label published for extra, absent for default.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemarkd service`
+- [ ] **Step 3: implement.**
+- [ ] **Step 4: run PASS** + `cargo test -p tidemarkd`
+- [ ] **Step 5: commit** — `feat(daemon): expose add-account and account-order over D-Bus`
+
+### Task 7: rename = migrate (secrets re-key + history re-key)
+
+**Files:**
+- Modify: `crates/tidemark-core/src/storage/mod.rs` (add `rekey_account(provider, old, new)` — one transaction over `window_state`, `segment`, `point`, `notice`)
+- Modify: `crates/tidemarkd/src/service.rs` (`rename_account(provider, old, new)`), `crates/tidemark/src/bus.rs` proxy.
+
+**Interfaces:**
+- Produces: `History::rekey_account(&mut self, provider, old, new) -> Result<(), StorageError>` (transactional `UPDATE … SET account=?new WHERE provider=? AND account=?old` on all four tables); daemon `rename_account` copies the secret slot (get old → set new → delete old), re-keys history, rewrites the `accounts` array in place, reloads.
+
+- [ ] **Step 1: failing tests** — history rows move to the new id and the old id has none; a mid-transaction failure leaves the old id intact (force via a bad new id / closed connection).
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemark-core storage -- rekey`
+- [ ] **Step 3: implement** rekey + the daemon orchestration.
+- [ ] **Step 4: run PASS** + `cargo test -p tidemarkd`
+- [ ] **Step 5: commit** — `feat(daemon): migrate an account's credentials and history on rename`
+
+---
+
+## Phase C — UI proxy + settings dialog
+
+### Task 8: bus proxy + settings list nested rows with "+" and editable label
+
+**Files:**
+- Modify: `crates/tidemark/src/bus.rs` (add `add_account`, `set_account_order`, `rename_account`)
+- Modify: `crates/tidemark/src/provider_settings/list.rs` (nested rows, "+" left of pen, editable label), `provider_settings/mod.rs` (grouping in `apply`, add-account dialog, open detail after add).
+
+**Interfaces:**
+- Produces: proxy methods; `ConfiguredList` renders provider row then indented account rows; "+" opens a name dialog → `add_account` → pushes the account's detail page (reuse `open_detail`); label edit → `rename_account`.
+
+- [ ] **Step 1:** implement proxy methods (mirror existing signatures).
+- [ ] **Step 2:** nested-row rendering + "+" gated on `multi_account_capable(definition)` (Key or OAuth kind).
+- [ ] **Step 3:** add-account name dialog → slugify → `add_account` → `open_detail`.
+- [ ] **Step 4:** label edit wiring → `rename_account`.
+- [ ] **Step 5: verify by driving the real app** (`cargo run -p tidemark`, computer-driven): add a second account to a keyed provider, see it nested, rename it.
+- [ ] **Step 6: commit** — `feat(ui): create, nest and rename accounts in provider settings`
+
+---
+
+## Phase D — UI main window: groups, expand, backdrop, reorder
+
+### Task 9: group cards + expand/collapse with "+N" chevron
+
+**Files:**
+- Modify: `crates/tidemark/src/window.rs` (`show_all`/`show_one`/`make_card` grouping ~352-457)
+- Modify: `crates/tidemark/src/card.rs` (title-row expand button + count; account-label as card title for extra cards)
+
+**Interfaces:**
+- Produces: cards grouped by provider; main card carries an expand toggle showing "+N"; extra cards titled by `account_label`/id; in-memory expand state; auto-expand the group an account was just added to.
+
+- [ ] **Step 1:** group statuses by provider in `show_all`/`show_one`.
+- [ ] **Step 2:** expand button on main card (flat, `pan-down/up-symbolic`, "+N"), toggling insertion/removal of extra cards after the main card.
+- [ ] **Step 3:** verify by driving the window (two accounts → expand shows both full cards, collapse hides them).
+- [ ] **Step 4: commit** — `feat(ui): group a provider's accounts behind an expand toggle`
+
+### Task 10: group backdrop in `CardGrid`
+
+**Files:**
+- Modify: `crates/tidemark/src/grid.rs` (`size_allocate` ~355, `snapshot`, add `group-bin` CSS)
+- Modify: `crates/tidemark/src/style.rs` (backdrop fill, tighter group spacing)
+
+**Interfaces:**
+- Produces: the grid draws one darker rounded-rect region behind the cells of an expanded group, before the cards; tracks which slots belong to an expanded group; handles row-wrapping (multi-rect) and leaves drag painting above the backdrop.
+
+- [ ] **Step 1:** pass group membership into the grid (slot → group).
+- [ ] **Step 2:** paint backdrop region(s) in `snapshot()` for expanded groups only.
+- [ ] **Step 3:** verify visually (backdrop under the group only; collapsed/single providers unchanged).
+- [ ] **Step 4: commit** — `feat(ui): draw a shared backdrop under an expanded account group`
+
+### Task 11: group-aware reorder
+
+**Files:**
+- Modify: `crates/tidemark/src/window.rs` (`connect_reorder` ~625, `show_order` ~678)
+- Modify: `crates/tidemark/src/grid.rs` if the gesture must refuse cross-boundary drags of an extra card.
+
+**Interfaces:**
+- Consumes: `set_account_order` proxy (Task 8).
+- Produces: reorder handler distinguishes provider reorder (`set_order`) from intra-group account reorder (`set_account_order`); expanded extra cards cannot cross a group boundary; collapsed groups drag as whole groups (existing behaviour).
+
+- [ ] **Step 1:** classify `(from,to)` by the providers at those indices; same provider → `set_account_order`, else → `set_order`.
+- [ ] **Step 2:** refuse cross-boundary drags of expanded extra cards.
+- [ ] **Step 3:** verify by dragging in the live window (both directions, both kinds).
+- [ ] **Step 4: commit** — `feat(ui): reorder providers and accounts within a group`
+
+### Task 12: tray label prefers `account_label`
+
+**Files:**
+- Modify: `crates/tidemark/src/tray.rs` (`label` ~113)
+
+- [ ] **Step 1: failing test** — shared provider with a label renders `Name (label)`, without → `Name (account-id)`.
+- [ ] **Step 2: run FAIL** — `cargo test -p tidemark tray`
+- [ ] **Step 3: implement** (prefer `account_label`, fall back to `account`).
+- [ ] **Step 4: run PASS**
+- [ ] **Step 5: commit** — `feat(ui): label tray rows with the account label`
+
+---
+
+## Final gate
+
+- [ ] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`
+- [ ] `shellcheck scripts/*.sh` unchanged-ok; no shell changes expected.
+- [ ] Drive the full flow in the live app: add two accounts to one keyed provider and one OAuth provider, rename one, expand/collapse, reorder both kinds, remove the main (watch promotion), confirm tray labels.
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-09-01-multi-account-providers.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks.
+2. **Inline Execution** — executing-plans, batched with checkpoints.

--- a/docs/superpowers/specs/2026-09-01-multi-account-providers-design.md
+++ b/docs/superpowers/specs/2026-09-01-multi-account-providers-design.md
@@ -1,0 +1,230 @@
+# Multi-Account Providers — Design
+
+> **Status:** Approved design, pre-implementation.
+> **Branch:** `feat/multi-account-providers` — all work lands here, never directly on `main`.
+> **Scope:** API-key and OAuth providers only. Credential-free (`None`) and external-session
+> (`External`, e.g. Antigravity's `agy` read) providers stay single-account.
+
+## What this is
+One provider, several sets of credentials — a work Claude and a personal Claude, two Z.ai
+keys. Today Tidemark builds exactly one `Account` per configured provider, hard-wired to
+`AccountId::default()` at every construction site, even though `AccountId` already flows
+through secrets, history, the D-Bus wire shape and the tray. This feature makes account
+construction plural and gives the UI a way to create, name, show and order the accounts.
+
+The load-bearing observation: **the plumbing is already per-account.** Secrets are keyed
+`(Kind, ProviderId, AccountId)` (`secrets.rs::attributes`); every history table keys on
+`(provider, account, window, …)` (`storage/mod.rs`, with the test
+`accounts_of_the_same_provider_do_not_share_a_segment_counter` already proving isolation);
+`ProviderStatus.account` is on the wire; the tray already renders a shared provider as
+`Claude (work)` (`tray.rs::label`). What is missing is (a) config that can name more than
+one account, (b) registry/engine code that builds them, (c) one D-Bus method to add and
+order them, and (d) the UI.
+
+## Invariants
+
+- A provider's account list always contains `"default"`, and `"default"` is always first.
+  The UI never special-cases a missing main account.
+- Removing the main account promotes the next one: the daemon rewrites the account list so
+  the survivor becomes `"default"`. No other account's id, credentials or history change.
+- Account ids are stable storage keys (config, Secret Service, history, D-Bus). They are
+  lowercase slugs, unique within their provider. Renaming changes the display label and,
+  when confirmed, migrates the id (§ Rename).
+- Extra OAuth accounts are **Tidemark-login only**. The vendor-CLI credential source is
+  exclusive to the default account — the CLI file is one login on disk, so an extra account
+  has no file of its own to read.
+- Presentation invents nothing: a collapsed main card shows only its own account's numbers;
+  accounts are never aggregated into a reading no provider reported.
+- Removed accounts keep their history rows (the existing removal dialog already promises
+  "Quota history will be kept").
+
+## Config
+
+`providers = [...]` stays a flat provider array — it is the card-reorder contract
+(`SetOrder` is validated as an exact permutation of it) and does not change shape. Accounts
+become a per-provider ordered list:
+
+```toml
+providers = ["claude", "zai"]
+
+[provider.claude]
+accounts = ["default", "work"]
+```
+
+`Config::providers()` is untouched. A new `Config::accounts(provider)` returns the ordered
+list, defaulting to `["default"]` when the key is absent — existing config files are
+unchanged and mean exactly what they mean today. Writes go through the same
+edit-in-place, malformed-config-errors rules as every other key.
+
+## Daemon
+
+### Registry & engine
+
+- `registry::accounts` expands each configured provider into one `Account` per entry of
+  `Config::accounts(provider)`, in order. The per-account constructors
+  (`keyed_account`, `claude_account`, `codex_account`, `hand_written_account`) take the
+  `AccountId` and pass it to `Account::new` / `Provider::account()` instead of
+  `AccountId::default()`.
+- `Account::with_client` derives its account from `client.account()` already; the OAuth
+  clients (`Claude`, `Codex`) currently hard-code `AccountId::default()` in
+  `Provider::account()` and in the `Secrets` lookup — they take the id at construction and
+  use it for both.
+- The engine's `accounts` vector is already ordered and polled independently per entry;
+  no scheduler change. `Engine::add_provider` gains an account parameter (today it
+  duplicates-checks on `AccountId::default()`); `Engine::remove_provider` already targets
+  an exact `(provider, account)` pair and is unchanged, plus the promotion rewrite when the
+  removed account was `"default"`.
+- New `Engine::set_account_order(provider, accounts)` rewrites one provider's `accounts`
+  array and re-sorts the in-memory vector, mirroring `set_order`.
+
+### D-Bus surface
+
+Already account-addressed and unchanged: `set_key`, `sign_out`, `begin_login`,
+`await_login`, `cancel_login`, `remove_provider`, `GetStatus`, `ProviderChanged`,
+`Publication::Removed`. All take/emit `(provider, account)`.
+
+Additive:
+
+- **`AddAccount(provider: s, account: s) -> ()`** — validates the id (well-formed slug,
+  unique within the provider, provider supports multi-account), persists to
+  `accounts = [...]`, constructs the `Account`, publishes a pending `ProviderStatus`.
+  Goes through the `Command` queue like `AddProvider`.
+- **`SetAccountOrder(provider: s, accounts: as) -> ()`** — validates an exact permutation
+  of that provider's account list and persists it.
+- **`ProviderStatus.account_label: Option<String>`** — new key in the `a{sv}` dict.
+  `None`/absent for the default account; `Some(label)` for extras. Because the dict is
+  extensible and absent-means-absent, an old daemon simply omits it and the UI falls back
+  to the account id.
+
+`AddProvider` (called from the picker) keeps adding the `"default"` account.
+
+## Provider-settings dialog
+
+### Rows
+
+`ConfiguredList` currently renders one flat `adw::ActionRow` per status. It now groups by
+provider: the provider's row first, then one indented row per extra account, in `accounts`
+order. Each row keeps its own pen (edit) and trash (remove) buttons, operating on that
+`(provider, account)`.
+
+The account row's title is the provider title (fixed); beside it an **editable account
+label** (an inline `adw::EntryRow`-style text the user can change) — per your direction,
+the name lives next to the uneditable provider name, not in a separate dialog.
+
+### The "+" button
+
+Each row for a multi-account-capable provider (credential kind `Key` or `OAuth`) gets a
+**"+" button to the left of the pen** (`list-add-symbolic`, tooltip "Add account"). It
+opens a small `adw::AlertDialog` with one entry row for the account name. On confirm:
+
+1. The name is slugified to the account id (lowercased, non-alphanumeric → `-`).
+2. `AddAccount(provider, id)` is called.
+3. The existing detail sub-page opens for the new account — the *same* authentication UI
+   as today: `build_key_rows` for a key provider, the sign-in row for OAuth.
+4. OAuth waits reuse the existing pending-login flow (the row shows "Waiting for your
+   browser…"); nothing new is built for the wait.
+
+### Rename
+
+The display label is derived from the account id, and the id is the storage key — so a
+rename is a **migrate**, the one genuinely risky operation. Editing the label in place and
+confirming performs, atomically at the daemon:
+
+1. Validate the new id (well-formed, unique within the provider).
+2. Copy the Secret Service slot to the new id (`get` old → `set` new → `delete` old).
+3. Re-key history: `UPDATE … SET account = ?new WHERE provider = ? AND account = ?old`
+   across the `window_state`, `segment`, `point` and notice tables in one transaction.
+4. Rewrite the provider's `accounts` array, preserving position.
+5. Reload the account.
+
+If any step fails the whole rename is refused and the old id is left intact (secret copy
+and history re-key are both reversible up to the final `delete`). If this proves
+controversial in review it can be deferred behind "no rename; delete and re-add" — but it
+is specced because the label is presented as editable.
+
+## Main window
+
+### Grouping
+
+`MainWindow::show_all`/`show_one` group statuses by `status.provider`. The first account
+(`"default"`) is the group's main card; the rest are its extra cards.
+
+### The expand button
+
+A provider with more than one account renders an expand control on its main card: a flat
+circular button with a `pan-down-symbolic`/`pan-up-symbolic` icon plus a **"+N" count**
+label, placed at the end of the title row after the state chip. The title row's existing
+ellipsize rules (mark/name/plan/chip all ellipsize, name last to lose characters) absorb
+the tighter space; the card's `MIN_WIDTH` does not change.
+
+- **Collapsed** (the default, and the state on every window open): the main card shows only
+  its own account's numbers. No aggregation, no worst-case tint — the count is the only
+  signal that more accounts exist.
+- **Expanded**: the extra accounts are inserted directly after the main card as **full
+  cards**, each titled by its account label. Second click collapses them away.
+- Expand state is **in-memory only**. A group auto-expands when the user finishes adding an
+  account to it, so the new card is visible.
+
+### The group backdrop
+
+Per your correction: cards are not individually darkened. The `CardGrid` draws a **shared
+darker rounded-rectangle backdrop under the contiguous block of cells an expanded group
+occupies**, painted in the grid's `snapshot()` before the cards. This is a layout change,
+not a restyle:
+
+- The grid computes every cell's rect in `size_allocate` already; the backdrop is the
+  union of the group's cells, drawn as a rounded region behind them.
+- A group can wrap across rows (the grid is 1–3 columns by width), so the backdrop follows
+  the cells wherever they land rather than assuming one row.
+- A card mid-drag interpolates between slots; the backdrop stays at the resting layout and
+  the dragged card lifts off it, which is the intended look.
+- Collapsed and single-account providers occupy one cell and draw no backdrop — visually
+  identical to today.
+
+The backdrop gets a CSS class (`group-bin`) with a slightly darker fill and marginally
+tighter internal spacing so the grouped cards read as belonging together.
+
+### Reorder
+
+You chose groups + intra-group. The grid's drag gesture reports `(from, to)` slot indices;
+the window's reorder handler maps them back:
+
+- **Across a group boundary** → provider reorder → existing `SetOrder(Vec<slug>)`,
+  unchanged.
+- **Within a group** (both endpoints are extra cards of the same provider) → account
+  reorder → new `SetAccountOrder(provider, Vec<account>)`.
+- An expanded extra card **cannot be dragged across a group boundary** — the gesture is
+  disallowed for that case so the two operations stay unambiguous. Collapsed groups (one
+  visible card) drag as whole groups exactly as today.
+
+This is the piece most likely to need a visual iteration once seen live.
+
+## Tray
+
+Already correct: `tray.rs::label` renders a provider shared by several accounts as
+`Claude (work)`, and `needs_attention` ORs the 70%/90% threshold across every account. One
+refinement: the label prefers `account_label` when present, falling back to the account id.
+
+## Testing
+
+- `Config::accounts` absent-key default, ordering, promotion rewrite, malformed-array
+  refusal.
+- `registry::accounts` builds one `Account` per configured account, in order, with the
+  right ids.
+- Secrets: per-account slot isolation (two accounts of one provider hold different keys).
+- History: the existing per-account segment test stands; add the rename re-key migration
+  (rows move to the new id, old id has none, transaction rolls back on a mid-failure).
+- Engine: `add_account` persists + publishes pending; `remove_provider` on `"default"`
+  promotes the survivor; `set_account_order` validates a permutation.
+- Service: `AddAccount` / `SetAccountOrder` validation errors (duplicate id, unknown
+  provider, malformed slug) surface as `InvalidArgs`.
+- Tray: a shared provider renders `Name (label)`, preferring `account_label`.
+- UI card grouping and the expand button are verified by driving the real window
+  (browser/computer), not by a unit test.
+
+## Out of scope
+
+- CLI-source credentials for extra accounts.
+- Multi-account for `None`/`External` providers.
+- Aggregated/worst-case summary on a collapsed card.
+- Persisting expand state across restarts.


### PR DESCRIPTION
## What

One provider can now carry several credentialled accounts — a work and a personal Claude, two Z.ai keys — created, named, shown, ordered and removed from the UI.

Implements `docs/superpowers/specs/2026-09-01-multi-account-providers-design.md` per `docs/superpowers/plans/2026-09-01-multi-account-providers.md`.

## How

- **Config** — `[provider.<slug>] accounts = ["default", "work"]`: an ordered account list per provider. `providers = [...]` stays a flat array (the `SetOrder` permutation contract). `"default"` is always present and always first; an absent key means exactly today's single account.
- **Registry/engine** — `registry::accounts` builds one `Account` per configured id; every constructor takes the `AccountId` instead of hard-coding the default. Removing the main account promotes the next survivor to `"default"`, migrating its readings; no other account changes. Extra OAuth accounts are Tidemark-login only — the vendor-CLI credential stays exclusive to `default`.
- **D-Bus** (additive) — `AddAccount(provider, account)`, `SetAccountOrder(provider, accounts)`, `RenameAccount(provider, old, new)`; `ProviderStatus.account_label` joins the extensible `a{sv}` dict, so absent stays absent and old daemons/clients simply omit it.
- **Rename is a migrate** — the Secret Service slot is copied to the new key, history rows re-keyed across `window_state`/`segment`/`point`/notice tables in one transaction, the config array rewritten in place; any failure refuses the whole rename and leaves the old id intact.
- **UI** — provider settings nest account rows under their provider with a "+" to add and an inline label edit; the main window groups a provider's cards behind a notification-style expand badge with a "+N" count at the card's top-right corner — expanding cards emerge beneath the main card. Drag reorders providers across groups and accounts within one; the tray prefers the account label over the id.
- **No schema change** — history always keyed on `(provider, account, …)`; per-account isolation was already proven by an existing test.

## Scope boundary

API-key and OAuth providers only; `None`/`External` providers stay single-account — there is exactly one CLI login on disk to read.

## Verification

- `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh` — green after rebasing onto current `main` (all test binaries pass, layering ok).
- The full flow was driven in the live app during development: accounts added to a keyed and an OAuth provider, renamed, expanded/collapsed, reordered both ways, main account removed (promotion watched), tray labels checked.

## Deviation from the plan

Task 10's shared group backdrop was deliberately dropped after visual QA; the expand badge described above is what shipped instead. All other tasks landed as planned.