### PR TITLE
ci: skip markdown-only changes at any depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
+      # '**/*.md' does not match repository-root files (README, CONTEXT, AGENTS) — the
+      # root-level '*.md' entry is what closes that gap.
+      - '*.md'
       - '**/*.md'
       - 'docs/**'
   push:
     branches: [main]
     paths-ignore:
+      - '*.md'
       - '**/*.md'
       - 'docs/**'
 


### PR DESCRIPTION
## What

`paths-ignore` in CI covered `**/*.md` and `docs/**`, but GitHub's path matcher does not match repository-root files with `**/*.md` — so documentation-only changes to root files (`README.md`, `CONTEXT.md`, `AGENTS.md`) still ran the full check matrix.

## Fix

Added the root-level `*.md` pattern next to `**/*.md` on both the `pull_request` and `push` triggers, with a comment so it does not get cleaned up as redundant.

Behaviour is otherwise unchanged: the workflow skips only when **every** changed file matches an ignore pattern — a PR mixing code and docs still runs all checks. The branch is unprotected, so a skipped run cannot block a doc-only merge.

## Verification

- `yq` parses the workflow; `actionlint` reports only the two pre-existing `ubuntu-26.04` runner-label warnings that are equally present on `main` (stale local label list — the runner exists in GitHub's pool).