### PR TITLE
docs: mention multi-account providers in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ notifications stay current. Native GTK4 + libadwaita — no Electron, no embedde
 
 - **Every window.** Five-hour, weekly, monthly — whatever the provider
   exposes, each with its own reset time.
+- **Several accounts per provider.** A work and a personal Claude, two Z.ai keys — grouped
+  behind an expand toggle.
 - **A pace mark on every bar.** Fill to the left of the mark means the quota likely lasts until
   the reset; fill to the right means it does not.
 - **Warnings at 70% and 90%,** plus a notification when a window resets. Off by default,


### PR DESCRIPTION
One feature-list line in the block after the video, so the README reflects that a provider can now carry several accounts (#31).

Doc-only change — CI is expected to skip on this PR (that is the `paths-ignore` behaviour from #32 doing its job).