### PR TITLE
feat(ui): polish multi-account presentation

### DIFF
--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -100,12 +100,56 @@ pub(crate) struct CardExpansion {
     pub(crate) on_toggled: Rc<dyn Fn(bool)>,
 }
 
+/// The provider context and account name shown at the top of a quota card.
+#[derive(Debug)]
+pub(crate) struct CardTitle {
+    heading: String,
+    caption: Option<String>,
+}
+
+impl CardTitle {
+    pub(crate) fn main(heading: String) -> Self {
+        Self {
+            heading,
+            caption: None,
+        }
+    }
+
+    pub(crate) fn child(provider: &str, account: &str) -> Self {
+        Self {
+            heading: account.into(),
+            caption: Some(provider.into()),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct AccountToggleState {
+    label: String,
+    tooltip: &'static str,
+}
+
+fn account_toggle_state(extra_accounts: usize, expanded: bool) -> AccountToggleState {
+    if expanded {
+        AccountToggleState {
+            label: "−".into(),
+            tooltip: "Hide other accounts",
+        }
+    } else {
+        AccountToggleState {
+            label: format!("+{extra_accounts}"),
+            tooltip: "Show other accounts",
+        }
+    }
+}
+
 /// A provider card.
 #[derive(Debug)]
 pub struct Card {
     slot: gtk::Overlay,
     mark: gtk::Image,
     name: gtk::Label,
+    caption: gtk::Label,
     plan: gtk::Label,
     chip: gtk::Label,
     reading: gtk::Box,
@@ -125,7 +169,7 @@ impl Card {
     pub fn new(
         status: &ProviderStatus,
         now: Timestamp,
-        title: String,
+        title: CardTitle,
         on_activate: Rc<dyn Fn(String, String)>,
         expansion: Option<CardExpansion>,
     ) -> Self {
@@ -141,6 +185,11 @@ impl Card {
             .halign(gtk::Align::Start)
             .ellipsize(gtk::pango::EllipsizeMode::End)
             .css_classes(["heading"])
+            .build();
+        let caption = gtk::Label::builder()
+            .halign(gtk::Align::Start)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .css_classes(["caption", "dim-label"])
             .build();
         let plan = gtk::Label::builder()
             .halign(gtk::Align::Start)
@@ -168,23 +217,33 @@ impl Card {
         // at the tighter of the two and the plan makes up the difference. GTK margins cannot
         // be negative, which is why it is this way round.
         let title_row = gtk::Box::builder().spacing(MARK_GAP).build();
+        let title_stack = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(0)
+            .build();
+        title_stack.append(&caption);
+        title_stack.append(&name);
         title_row.append(&mark);
-        title_row.append(&name);
+        title_row.append(&title_stack);
         title_row.append(&plan);
         title_row.append(&chip);
         plan.set_margin_start(TITLE_GAP - MARK_GAP);
 
         let expansion = expansion.map(|expansion| {
-            let content = gtk::Label::builder()
-                .label(format!("+{}", expansion.extra_accounts))
-                .build();
+            let state = account_toggle_state(expansion.extra_accounts, expansion.expanded);
+            let content = gtk::Label::builder().label(&state.label).build();
             let toggle = gtk::ToggleButton::builder()
                 .active(expansion.expanded)
                 .child(&content)
                 .css_classes(["flat", "circular", "quota-account-toggle"])
-                .tooltip_text("Show other accounts")
+                .tooltip_text(state.tooltip)
                 .build();
-            toggle.connect_toggled(move |toggle| (expansion.on_toggled)(toggle.is_active()));
+            toggle.connect_toggled(move |toggle| {
+                let state = account_toggle_state(expansion.extra_accounts, toggle.is_active());
+                content.set_label(&state.label);
+                toggle.set_tooltip_text(Some(state.tooltip));
+                (expansion.on_toggled)(toggle.is_active());
+            });
             toggle
         });
         align_to_baseline(&name, &mark, &plan);
@@ -339,6 +398,7 @@ impl Card {
             slot,
             mark,
             name,
+            caption,
             plan,
             chip,
             reading,
@@ -355,7 +415,7 @@ impl Card {
                 secondary: Vec::new(),
             }),
         };
-        card.set_title(&title);
+        card.set_title(title);
         card.apply(status, now);
         card
     }
@@ -371,8 +431,11 @@ impl Card {
     }
 
     /// Replaces the title resolved by the window for this account.
-    pub fn set_title(&self, title: &str) {
-        self.name.set_label(title);
+    pub fn set_title(&self, title: CardTitle) {
+        self.name.set_label(&title.heading);
+        self.caption
+            .set_label(title.caption.as_deref().unwrap_or_default());
+        self.caption.set_visible(title.caption.is_some());
     }
 
     /// Shows a new status for the same account.
@@ -682,6 +745,35 @@ mod tests {
 
         identity.activate(activate.as_ref());
         assert_eq!(calls.borrow().as_slice(), [("zai".into(), "work".into())]);
+    }
+
+    #[test]
+    fn a_child_card_title_keeps_the_provider_and_account_identity_without_card_chrome() {
+        let title = CardTitle::child("Claude", "Work");
+
+        assert_eq!(title.caption.as_deref(), Some("Claude"));
+        assert_eq!(title.heading, "Work");
+        assert!(
+            !crate::style::STYLE.contains(".quota-child-card"),
+            "nested identity belongs in the provider settings list, not card chrome"
+        );
+    }
+
+    #[test]
+    fn expanding_an_account_toggle_changes_its_words_without_becoming_transparent() {
+        let collapsed = account_toggle_state(2, false);
+        let expanded = account_toggle_state(2, true);
+
+        assert_eq!(collapsed.label, "+2");
+        assert_eq!(collapsed.tooltip, "Show other accounts");
+        assert_eq!(expanded.label, "−");
+        assert_eq!(expanded.tooltip, "Hide other accounts");
+        assert!(
+            crate::style::STYLE.contains(
+                ".quota-account-toggle:checked {\n    background-color: @accent_bg_color;"
+            ),
+            "the active account toggle must remain opaque"
+        );
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/list.rs
+++ b/crates/tidemark/src/provider_settings/list.rs
@@ -92,6 +92,22 @@ enum ProviderRowKind {
     Nested,
 }
 
+/// The fixed visual order for provider-level account controls.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderAction {
+    Add,
+    Edit,
+    Remove,
+}
+
+const PROVIDER_ACTION_SPACING: i32 = 6;
+
+#[derive(Debug, Eq, PartialEq)]
+struct NestedAccountPrefix {
+    margin_start: i32,
+    spacing: i32,
+}
+
 /// Only a provider with a second account needs an expansion affordance.
 fn provider_row_kind(group: &ProviderGroup) -> ProviderRowKind {
     if group.accounts.len() > 1 {
@@ -143,6 +159,58 @@ impl ProviderWidget {
             Self::Nested(row) => row.upcast_ref(),
         }
     }
+}
+
+fn provider_action_order() -> [ProviderAction; 3] {
+    [
+        ProviderAction::Add,
+        ProviderAction::Edit,
+        ProviderAction::Remove,
+    ]
+}
+
+fn provider_action_spacing() -> i32 {
+    PROVIDER_ACTION_SPACING
+}
+
+fn nested_account_prefix_spec() -> NestedAccountPrefix {
+    NestedAccountPrefix {
+        margin_start: 12,
+        spacing: 6,
+    }
+}
+
+fn nested_account_prefix(image: &gtk::Image) -> gtk::Box {
+    let spec = nested_account_prefix_spec();
+    let connector = gtk::Box::builder()
+        .width_request(12)
+        .height_request(28)
+        .valign(gtk::Align::Center)
+        .build();
+    connector.add_css_class("nested-account-connector");
+    let prefix = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .margin_start(spec.margin_start)
+        .spacing(spec.spacing)
+        .build();
+    prefix.append(&connector);
+    prefix.append(image);
+    prefix
+}
+
+fn provider_action_box(add: &gtk::Button, edit: &gtk::Button, remove: &gtk::Button) -> gtk::Box {
+    let actions = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(provider_action_spacing())
+        .build();
+    for action in provider_action_order() {
+        match action {
+            ProviderAction::Add => actions.append(add),
+            ProviderAction::Edit => actions.append(edit),
+            ProviderAction::Remove => actions.append(remove),
+        }
+    }
+    actions
 }
 
 /// One account displayed beneath its provider.
@@ -360,11 +428,9 @@ fn provider_row(
         move |_| on_remove(provider.clone(), account.clone())
     });
 
-    // Suffixes stack left to right in the order they are added, which is what puts the
-    // "+" left of the pen and the trash outside both.
-    row.add_suffix(&add);
-    row.add_suffix(&edit);
-    row.add_suffix(&remove);
+    // `AdwExpanderRow` reverses separately added suffixes. One ordered box keeps this
+    // provider's controls stable whether it is a plain or an expandable row.
+    row.add_suffix(&provider_action_box(&add, &edit, &remove));
 
     let built = ProviderRow {
         provider: status.provider.clone(),
@@ -389,7 +455,7 @@ fn account_row(
     let image = mark::image();
     mark::set(&image, &status.provider);
     let row = adw::ActionRow::builder().use_markup(false).build();
-    row.add_prefix(&image);
+    row.add_prefix(&nested_account_prefix(&image));
 
     let edit = gtk::Button::builder()
         .icon_name("document-edit-symbolic")
@@ -630,7 +696,10 @@ impl Picker {
 mod tests {
     use tidemark_types::{AccountId, ProviderId, ProviderStatus};
 
-    use super::{ProviderGroup, ProviderRowKind, group, provider_row_kind, structure};
+    use super::{
+        ProviderAction, ProviderGroup, ProviderRowKind, group, nested_account_prefix_spec,
+        provider_action_order, provider_action_spacing, provider_row_kind, structure,
+    };
 
     fn status(provider: &str, account: &str) -> ProviderStatus {
         ProviderStatus::pending(&ProviderId::new(provider), &AccountId::new(account))
@@ -680,6 +749,55 @@ mod tests {
         assert_eq!(
             keys(&groups),
             vec![("kimi", vec!["team", "default", "work"])]
+        );
+    }
+
+    #[test]
+    fn nested_provider_actions_keep_add_edit_remove_order() {
+        assert_eq!(
+            provider_action_order(),
+            [
+                ProviderAction::Add,
+                ProviderAction::Edit,
+                ProviderAction::Remove,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_provider_actions_keep_breathing_room_between_controls() {
+        assert_eq!(provider_action_spacing(), 6);
+    }
+
+    #[test]
+    fn nested_account_prefixes_use_a_bold_inset_tree_elbow() {
+        let prefix = nested_account_prefix_spec();
+
+        assert_eq!(prefix.margin_start, 12);
+        assert_eq!(prefix.spacing, 6);
+        assert!(
+            crate::style::STYLE.contains(".nested-account-connector {"),
+            "nested accounts need a tree-elbow connector rather than a navigation arrow"
+        );
+        assert!(
+            crate::style::STYLE.contains("background-repeat: no-repeat;"),
+            "the connector must draw one elbow rather than tile across the row"
+        );
+        assert!(
+            crate::style::STYLE.contains("alpha(currentColor, 0.7)"),
+            "the connector must stay visible against an account row"
+        );
+        assert!(
+            crate::style::STYLE.contains("min-height: 28px;"),
+            "the connector must be as tall as the provider mark it follows"
+        );
+        assert!(
+            crate::style::STYLE.contains("background-size: 2px 14px, 10px 2px;"),
+            "the vertical stem must be bold, long, and joined to its branch"
+        );
+        assert!(
+            crate::style::STYLE.contains("background-position: 1px 1px, 1px center;"),
+            "the elbow must sit left of centre without touching its own bounds"
         );
     }
 

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -41,6 +41,17 @@ pub(crate) const STYLE: &str = "
     transition: transform 150ms ease-out, box-shadow 150ms ease-out;
 }
 
+.nested-account-connector {
+    min-width: 12px;
+    min-height: 28px;
+    background-image:
+        linear-gradient(to right, alpha(currentColor, 0.7), alpha(currentColor, 0.7)),
+        linear-gradient(to right, alpha(currentColor, 0.7), alpha(currentColor, 0.7));
+    background-size: 2px 14px, 10px 2px;
+    background-position: 1px 1px, 1px center;
+    background-repeat: no-repeat;
+}
+
 /* The slot keeps the pointer while the card inside it moves. */
 .quota-grid > .quota-slot:hover > .quota-card {
     transform: translateY(-2px);
@@ -118,6 +129,14 @@ pub(crate) const STYLE: &str = "
     transform: translate(10px, -10px);
     transition: transform 150ms ease-out;
     box-shadow: 0 1px 3px 0 alpha(black, 0.3);
+}
+
+.quota-account-toggle:checked {
+    background-color: @accent_bg_color;
+    color: @accent_fg_color;
+    box-shadow:
+        0 0 0 2px alpha(@accent_fg_color, 0.45),
+        0 1px 3px 0 alpha(black, 0.3);
 }
 
 /* The badge lives in the slot, outside the card surface, so it repeats the card's hover

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -23,7 +23,7 @@ use tidemark_types::{
 
 use crate::about;
 use crate::bus::{self, DaemonProxy, Update};
-use crate::card::{Card, CardExpansion};
+use crate::card::{Card, CardExpansion, CardTitle};
 use crate::detail::DetailDialog;
 use crate::grid::CardGrid;
 use crate::model;
@@ -379,18 +379,10 @@ impl MainWindow {
         let mut cards = Vec::new();
         for group in model::provider_groups(&statuses) {
             let provider = &group[0].provider;
-            let provider_name = model::name(&self.titles(), provider);
             let expanded = self.expanded.borrow().contains(provider);
             let extra_accounts = group.len() - 1;
             for (index, status) in group.iter().enumerate() {
-                let title = if index == 0 {
-                    provider_name.clone()
-                } else {
-                    status
-                        .account_label
-                        .clone()
-                        .unwrap_or_else(|| status.account.clone())
-                };
+                let title = self.card_title(status, index == 0);
                 let expansion = (index == 0 && extra_accounts > 0).then(|| {
                     let weak = Rc::downgrade(self);
                     let provider = provider.clone();
@@ -442,7 +434,7 @@ impl MainWindow {
         match existing {
             Some(index) => {
                 let card = Rc::clone(&self.cards.borrow()[index]);
-                card.set_title(&self.card_title(&status, status.account == "default"));
+                card.set_title(self.card_title(&status, status.account == "default"));
                 card.apply(&status, now);
             }
             None => {
@@ -520,14 +512,13 @@ impl MainWindow {
     }
 
     /// The title a card shows: provider title for the main account, account label otherwise.
-    fn card_title(&self, status: &ProviderStatus, main: bool) -> String {
+    fn card_title(&self, status: &ProviderStatus, main: bool) -> CardTitle {
+        let provider = model::name(&self.titles(), &status.provider);
         if main {
-            model::name(&self.titles(), &status.provider)
+            CardTitle::main(provider)
         } else {
-            status
-                .account_label
-                .clone()
-                .unwrap_or_else(|| status.account.clone())
+            let account = status.account_label.as_deref().unwrap_or(&status.account);
+            CardTitle::child(&provider, account)
         }
     }
 
@@ -536,7 +527,7 @@ impl MainWindow {
         self: &Rc<Self>,
         status: &ProviderStatus,
         now: Timestamp,
-        title: String,
+        title: CardTitle,
         expansion: Option<CardExpansion>,
     ) -> Rc<Card> {
         let weak = Rc::downgrade(self);


### PR DESCRIPTION
## Summary
- show provider context above child-account names on quota cards
- keep the expanded-account toggle opaque and stateful
- order provider actions consistently and add a bright, inset tree-elbow for nested account rows

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- scripts/check-layering.sh

Visual QA was performed by the requester after each connector refinement.