### PR TITLE
feat(zai): read the account wallet and show the balance on the card

### DIFF
--- a/crates/tidemark-core/examples/probe.rs
+++ b/crates/tidemark-core/examples/probe.rs
@@ -13,8 +13,8 @@
 
 use std::io::Read;
 use tidemark_core::providers::keyed::Options;
-use tidemark_core::providers::{Credential, Provider, keyed, zai};
-use tidemark_types::{AccountId, Snapshot, Timestamp, Window};
+use tidemark_core::providers::{Credential, Provider, zai};
+use tidemark_types::{Snapshot, Timestamp, Window};
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
@@ -43,12 +43,7 @@ async fn main() -> std::process::ExitCode {
     let options: Options = [(zai::REGION.to_owned(), region.as_value().to_owned())]
         .into_iter()
         .collect();
-    let provider = match keyed::Keyed::new(
-        AccountId::default(),
-        &zai::SPEC,
-        Credential::new(key.trim()),
-        &options,
-    ) {
+    let provider = match zai::Zai::new(Credential::new(key.trim()), &options) {
         Ok(provider) => provider,
         Err(e) => {
             eprintln!("{e}");
@@ -56,7 +51,8 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
-    eprintln!("GET {}", provider.url());
+    eprintln!("GET {}", provider.quota_url());
+    eprintln!("GET {}", provider.balance_url());
     match provider.fetch().await {
         Ok(snapshot) => {
             print(&snapshot);

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -564,7 +564,6 @@ pub static CATALOG: &[&Spec] = &[
     &synthetic::SPEC,
     &venice::SPEC,
     &warp::SPEC,
-    &zai::SPEC,
     &zenmux::SPEC,
 ];
 

--- a/crates/tidemark-core/src/providers/keyed/zai.rs
+++ b/crates/tidemark-core/src/providers/keyed/zai.rs
@@ -1,11 +1,12 @@
 //! Z.ai / GLM.
 //!
-//! The simplest of the five: one `GET`, a bearer token, no OAuth, no local CLI, no cookies.
-//! It is first precisely because of that — it is the cheapest way to find out whether the
-//! window model survives contact with a real API. It does: one response carried three
-//! windows of three different lengths, and needed no new concepts.
+//! Two `GET`s, a bearer token, no OAuth, no local CLI, no cookies. The first request is
+//! the quota meter; the second reads the wallet the same key can see. It was the simplest
+//! provider in the catalog — one `GET`, describable by a [`super::Spec`] — and the wallet
+//! is what ended that: a second request means a [`super::HandSpec`] and an `impl Provider`
+//! of its own, like OpenRouter's credits-plus-quota before it.
 //!
-//! # What the payload does not tell you
+//! # What the quota payload does not tell you
 //!
 //! `{code, msg, success, data:{limits[], level}}`, where each limit is
 //! `{type, unit, number, percentage, nextResetTime}` plus optional absolutes. Two things
@@ -22,28 +23,70 @@
 //!    weeks.
 //!
 //! 3. **`nextResetTime` is dropped entirely by a window that has just reset**, observed
-//!    live: two hours after the five-hour window rolled over, and with nothing spent in the
-//!    new one, the entry arrived as `{type, unit, number, percentage: 0}` and nothing else.
-//!    The field comes back once the window is in use. The length is still derivable, so the
-//!    window is still drawn — it just has no pace mark until then, and since the five-hour
-//!    window is the one the card leads with, that is a routine state rather than an edge
-//!    case. See `CONTEXT.md` § Vocabulary on Pace.
+//!    live: two hours after the five-hour window rolled over, and with nothing spent in
+//!    the new one, the entry arrived as `{type, unit, number, percentage: 0}` and nothing
+//!    else. The field comes back once the window is in use. The length is still derivable,
+//!    so the window is still drawn — it just has no pace mark until then, and since the
+//!    five-hour window is the one the card leads with, that is a routine state rather
+//!    than an edge case. See `CONTEXT.md` § Vocabulary on Pace.
 //!
 //! `nextResetTime` is Unix **milliseconds**.
+//!
+//! # The second request: the wallet
+//!
+//! `GET /api/biz/account/query-customer-account-report` — the console's own billing call,
+//! and it accepts the same bearer key the quota does (verified live against `api.z.ai`,
+//! `open.bigmodel.cn` and `www.bigmodel.cn`; CodexBar ships it CN-only with a comment
+//! saying the global platform has no equivalent, which no longer holds). `data` carries
+//! `{balance, availableBalance, rechargeAmount, giveAmount, totalSpendAmount,
+//! frozenBalance}` and, on every account this has been observed on, `creditBalance` /
+//! `availableCreditBalance` arrive `null` beside `creditStatus: "NOT_OPEN"` — the credit
+//! ledger is not represented here, because its open state has never been seen and an
+//! unknown shape is not to be invented.
+//!
+//! Three things about that body:
+//!
+//! 1. **The amounts are Java `BigDecimal`s.** Zeros arrive as `0E-9` and `0.000000` —
+//!    valid JSON numbers, if strange ones, and `f64` reads both. The fixtures below keep
+//!    the spellings verbatim so the quirk stays covered.
+//! 2. **There is no currency field.** The global platform bills in USD through Stripe and
+//!    the China one in CNY, so the symbol is chosen by region — a choice, not a reading.
+//! 3. **The request is best-effort.** The quota is the point of the fetch; a wallet that
+//!    will not answer costs the balance and nothing else. Every failure — transport,
+//!    status, unreadable body — is swallowed into silence, never into a failed fetch, and
+//!    never into a credential error the successful quota request has already disproved.
+//!
+//! # What the card does with a wallet
+//!
+//! While there is money on the account, overage bills the wallet and the MCP pool stops
+//! being the binding constraint, so its window yields its row and its absolutes stay in
+//! the details, where they always were; the wallet itself is not a window at all — money
+//! is not a rate, so there is no honest percentage or bar — it is the first row under
+//! [`DetailSection::BALANCE`], which the card lifts as a bold amount beside the quota
+//! rows. At zero — spent out, never topped up, or unreadable — nothing about money is
+//! published at all and the MCP window returns: a wallet with nothing in it is not
+//! something to show, on the card or anywhere else. The rule is on `availableBalance`,
+//! resolved as `availableBalance` when the provider sends it and `balance` otherwise,
+//! and `frozenBalance` aside they agree.
 
-use super::{Auth, Method, OptionSchema, Spec};
-use crate::providers::ProviderError;
+use super::{HandSpec, OptionSchema, Options};
+use crate::providers::{BoxFuture, Credential, Provider, ProviderError, http};
 use serde::Deserialize;
+use std::fmt;
+use std::sync::Arc;
 use tidemark_types::{
-    AccountId, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window, WindowKey,
-    WindowLength,
+    AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
+    WindowKey, WindowLength,
 };
 
 /// The slug this provider's history is filed under. Never changes once shipped.
 pub const PROVIDER_ID: &str = "zai";
 
-/// Path appended to the region's base URL.
+/// Path appended to the region's base URL for the quota meter.
 const QUOTA_PATH: &str = "/api/monitor/usage/quota/limit";
+
+/// Path appended to the region's base URL for the wallet reading.
+const BALANCE_PATH: &str = "/api/biz/account/query-customer-account-report";
 
 /// Which deployment the account lives on. The two are the same API on different hosts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -61,6 +104,15 @@ impl Region {
         match self {
             Self::Global => "https://api.z.ai",
             Self::BigModelCn => "https://open.bigmodel.cn",
+        }
+    }
+
+    /// The currency symbol the region bills in. The wallet body carries no currency of
+    /// its own; this is the platform's pricing currency, not a reading.
+    pub fn currency(self) -> &'static str {
+        match self {
+            Self::Global => "$",
+            Self::BigModelCn => "¥",
         }
     }
 
@@ -85,18 +137,12 @@ impl Region {
 /// Name of the region setting under `[provider.zai]`.
 pub const REGION: &str = "region";
 
-/// Z.ai as the keyed mechanism sees it.
-pub static SPEC: Spec = Spec {
+/// Z.ai as the settings dialog sees it. A [`HandSpec`] rather than a [`super::Spec`]
+/// because the fetch is two requests, and a `Spec` states that it is one.
+pub static SPEC: HandSpec = HandSpec {
     id: PROVIDER_ID,
     title: "Z.ai",
-    endpoint: |options| {
-        let region = Region::from_value(options.get(REGION).map(String::as_str));
-        format!("{}{QUOTA_PATH}", region.base_url())
-    },
-    method: Method::Get,
-    auth: Auth::Bearer,
-    headers: &[],
-    parse: parse_for_account,
+    credential: CredentialKind::Key,
     credential_hint: "Z.ai dashboard → API keys, on whichever region your account is on.",
     options: &[OptionSchema {
         name: REGION,
@@ -111,7 +157,144 @@ pub static SPEC: Spec = Spec {
         ],
         required: false,
     }],
+    build,
 };
+
+/// Builds a pollable client from the stored key and the account's settings.
+fn build(
+    account: AccountId,
+    credential: Credential,
+    options: &Options,
+) -> Result<Arc<dyn Provider>, ProviderError> {
+    Ok(Arc::new(Zai::new_for_account(
+        account, credential, options,
+    )?))
+}
+
+/// One Z.ai account: the key, the region it lives on, and the two URLs both decide.
+pub struct Zai {
+    tidemark_account: AccountId,
+    client: reqwest::Client,
+    credential: Credential,
+    region: Region,
+    quota_url: String,
+    balance_url: String,
+}
+
+impl Zai {
+    /// Builds a client for the default account.
+    pub fn new(credential: Credential, options: &Options) -> Result<Self, ProviderError> {
+        Self::new_for_account(AccountId::default(), credential, options)
+    }
+
+    /// Builds a client. Both URLs are resolved once, here, because the region is part of
+    /// each path's host and a setting that changed it would otherwise take effect only on
+    /// the next daemon restart.
+    fn new_for_account(
+        account: AccountId,
+        credential: Credential,
+        options: &Options,
+    ) -> Result<Self, ProviderError> {
+        let region = Region::from_value(options.get(REGION).map(String::as_str));
+        Self::at(account, credential, region, region.base_url())
+    }
+
+    /// Builds a client against an explicit base. The production constructor's other half,
+    /// and the test suite's door to a loopback server.
+    fn at(
+        account: AccountId,
+        credential: Credential,
+        region: Region,
+        base: &str,
+    ) -> Result<Self, ProviderError> {
+        Ok(Self {
+            tidemark_account: account,
+            client: http::client()?,
+            credential,
+            region,
+            quota_url: format!("{base}{QUOTA_PATH}"),
+            balance_url: format!("{base}{BALANCE_PATH}"),
+        })
+    }
+
+    /// The quota URL this instance polls.
+    pub fn quota_url(&self) -> &str {
+        &self.quota_url
+    }
+
+    /// The wallet URL this instance polls.
+    pub fn balance_url(&self) -> &str {
+        &self.balance_url
+    }
+
+    /// The quota request, built but not sent, so the shape is testable without a server.
+    fn quota_request(&self) -> Result<reqwest::Request, ProviderError> {
+        self.get(&self.quota_url)
+    }
+
+    /// The wallet request, likewise.
+    fn balance_request(&self) -> Result<reqwest::Request, ProviderError> {
+        self.get(&self.balance_url)
+    }
+
+    fn get(&self, url: &str) -> Result<reqwest::Request, ProviderError> {
+        self.client
+            .get(url)
+            .bearer_auth(self.credential.expose())
+            .header(reqwest::header::ACCEPT, "application/json")
+            .build()
+            .map_err(|error| ProviderError::Client(super::redact_query(error)))
+    }
+
+    async fn fetch_inner(&self) -> Result<Snapshot, ProviderError> {
+        if self.credential.is_blank() {
+            return Err(ProviderError::Credential { status: 401 });
+        }
+        let now = Timestamp::now();
+        let quota = parse_for_account(
+            &super::request(PROVIDER_ID, &self.client, self.quota_request()?).await?,
+            now,
+            &self.tidemark_account,
+        )?;
+        // Best-effort, deliberately: the quota is the point of the fetch, and a wallet
+        // that will not answer must not cost the card its windows — nor flip a working
+        // key into a credential error the quota request has already disproved.
+        let wallet = self.wallet().await.ok();
+        Ok(apply_balance(quota, wallet.as_ref(), self.region))
+    }
+
+    /// Fetches and reads the wallet body.
+    async fn wallet(&self) -> Result<WalletAmounts, ProviderError> {
+        let body = super::request(PROVIDER_ID, &self.client, self.balance_request()?).await?;
+        parse_wallet(&body)
+    }
+}
+
+impl fmt::Debug for Zai {
+    /// Written by hand: a derived impl would print the credential the first time anything
+    /// traced a client.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Zai")
+            .field("id", &PROVIDER_ID)
+            .field("quota_url", &self.quota_url)
+            .field("balance_url", &self.balance_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Provider for Zai {
+    fn id(&self) -> ProviderId {
+        ProviderId::new(PROVIDER_ID)
+    }
+
+    fn account(&self) -> AccountId {
+        self.tidemark_account.clone()
+    }
+
+    fn fetch(&self) -> BoxFuture<'_, Result<Snapshot, ProviderError>> {
+        Box::pin(self.fetch_inner())
+    }
+}
 
 /// Turns a response body into a snapshot. Pure: every trap above is reachable from a test.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
@@ -361,6 +544,147 @@ fn details(limits: &[Parsed], level: Option<&str>) -> Vec<DetailSection> {
     sections
 }
 
+/// The wallet amounts, resolved.
+#[derive(Debug, Clone, PartialEq)]
+struct WalletAmounts {
+    /// What can still be spent. `availableBalance` where the provider sends it, `balance`
+    /// otherwise — they differ only by the frozen part.
+    available: f64,
+    /// Ever topped up with money.
+    recharged: f64,
+    /// Ever granted for free.
+    granted: f64,
+    /// Ever spent.
+    spent: f64,
+    /// Held back by the provider.
+    frozen: f64,
+}
+
+/// Reads the wallet body. Pure: the BigDecimal spellings and the absent-amount case are
+/// reachable from a test.
+fn parse_wallet(body: &str) -> Result<WalletAmounts, ProviderError> {
+    #[derive(Deserialize)]
+    struct BalanceEnvelope {
+        code: i64,
+        #[serde(default)]
+        msg: Option<String>,
+        #[serde(default)]
+        success: bool,
+        #[serde(default)]
+        data: Option<BalanceData>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct BalanceData {
+        #[serde(default)]
+        balance: Option<f64>,
+        #[serde(default)]
+        available_balance: Option<f64>,
+        #[serde(default)]
+        recharge_amount: Option<f64>,
+        #[serde(default)]
+        give_amount: Option<f64>,
+        #[serde(default)]
+        total_spend_amount: Option<f64>,
+        #[serde(default)]
+        frozen_balance: Option<f64>,
+    }
+
+    let envelope: BalanceEnvelope = serde_json::from_str(body)
+        .map_err(|e| ProviderError::malformed(format!("not the expected wallet envelope: {e}")))?;
+    if !envelope.success || envelope.code != 200 {
+        let msg = envelope.msg.unwrap_or_else(|| "no message".to_owned());
+        return Err(ProviderError::malformed(format!(
+            "the wallet reported failure: code {} — {msg}",
+            envelope.code
+        )));
+    }
+    let data = envelope
+        .data
+        .ok_or_else(|| ProviderError::malformed("the wallet response carried no data"))?;
+    let readable = |value: Option<f64>| value.filter(|v| v.is_finite());
+    let available = readable(data.available_balance.or(data.balance)).ok_or_else(|| {
+        ProviderError::malformed("the wallet carried no readable balance to show")
+    })?;
+    Ok(WalletAmounts {
+        available,
+        recharged: readable(data.recharge_amount).unwrap_or(0.0),
+        granted: readable(data.give_amount).unwrap_or(0.0),
+        spent: readable(data.total_spend_amount).unwrap_or(0.0),
+        frozen: readable(data.frozen_balance).unwrap_or(0.0),
+    })
+}
+
+/// Folds the wallet into a quota snapshot. Pure: every card rule in the module docs is
+/// reachable from a test.
+///
+/// `None` is a wallet that could not be read: nothing is gated, nothing is invented, and
+/// the details say so.
+fn apply_balance(
+    mut snapshot: Snapshot,
+    wallet: Option<&WalletAmounts>,
+    region: Region,
+) -> Snapshot {
+    // Only a wallet with money in it is published at all. While there is some, overage
+    // bills the wallet and the MCP pool stops being the binding constraint, so its window
+    // yields its row — its absolutes stay in the details, where they always were — and the
+    // wallet becomes the first BALANCE detail row, which the card lifts as a bold amount;
+    // see `DetailSection::BALANCE`. At zero, spent out, or unreadable there is no balance
+    // to show anywhere: no window, no section, and the MCP window returns. The card lifts
+    // the first BALANCE row verbatim and never parses an amount, so whether one is
+    // publishable is this function's decision to make.
+    if let Some(amounts) = wallet.filter(|amounts| amounts.available > 0.0) {
+        snapshot
+            .windows
+            .retain(|window| !window.key.as_str().starts_with("mcp/"));
+        insert_section(&mut snapshot, wallet_details(amounts, region));
+    }
+    snapshot
+}
+
+/// The full amounts, for the detail dialog.
+fn wallet_details(amounts: &WalletAmounts, region: Region) -> DetailSection {
+    let mut rows = vec![labeled("Prepaid balance", money(region, amounts.available))];
+    // A zero is not a fact about the account worth a row; a non-zero one is.
+    for (label, value) in [
+        ("Topped up", amounts.recharged),
+        ("Granted", amounts.granted),
+        ("Frozen", amounts.frozen),
+        ("Spent", amounts.spent),
+    ] {
+        if value > 0.0 {
+            rows.push(labeled(label, money(region, value)));
+        }
+    }
+    DetailSection {
+        title: DetailSection::BALANCE.to_owned(),
+        rows,
+    }
+}
+
+/// Puts a section after the plan, when there is one, and ahead of everything else.
+fn insert_section(snapshot: &mut Snapshot, section: DetailSection) {
+    let at = snapshot
+        .details
+        .iter()
+        .position(|existing| existing.title != DetailSection::PLAN)
+        .unwrap_or(snapshot.details.len());
+    snapshot.details.insert(at, section);
+}
+
+fn labeled(label: &str, value: impl ToString) -> DetailRow {
+    DetailRow {
+        label: label.to_owned(),
+        value: value.to_string(),
+    }
+}
+
+/// An amount in the region's billing currency, two fraction digits.
+fn money(region: Region, amount: f64) -> String {
+    format!("{}{amount:.2}", region.currency())
+}
+
 #[derive(Debug, Deserialize)]
 struct Envelope {
     code: i64,
@@ -410,10 +734,14 @@ struct UsageDetail {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{BufRead, BufReader, Read as _, Write as _};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
 
-    /// Every fixture below is hand-authored. It reproduces the *shape* of a live response —
-    /// which is a fact about the API — with invented numbers, because the values are the
-    /// user's real consumption and this repository is going to be public.
+    /// Every quota fixture below is hand-authored. It reproduces the *shape* of a live
+    /// response — which is a fact about the API — with invented numbers, because the
+    /// values are the user's real consumption and this repository is going to be public.
     const LIVE_SHAPE: &str = r#"{
       "code": 200,
       "msg": "Operation successful",
@@ -426,6 +754,52 @@ mod tests {
           {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":37,"nextResetTime":1787221842997}
         ],
         "level": "pro"
+      },
+      "success": true
+    }"#;
+
+    /// The wallet bodies, likewise: the shape and the BigDecimal spellings (`0E-9`,
+    /// `0.000000`, the null credit ledger) are the live API's, recorded 2026-09-02, and
+    /// the amounts are invented — a coherent story rather than a balance: 25.00 granted,
+    /// nothing topped up, 18.75 spent, 6.25 left.
+    const WALLET_WITH_MONEY: &str = r#"{
+      "code": 200,
+      "msg": "Operation successful",
+      "data": {
+        "balance": 6.25,
+        "rechargeAmount": 0.000000,
+        "giveAmount": 25.000000,
+        "totalSpendAmount": 18.75,
+        "todaySpendAmount": null,
+        "availableBalance": 6.25,
+        "frozenBalance": 0E-9,
+        "creditBalance": null,
+        "availableCreditBalance": null,
+        "creditStatus": "NOT_OPEN",
+        "modelSpendAmountList": null,
+        "isKA": false
+      },
+      "success": true
+    }"#;
+
+    /// The same body as the provider sends an account that has never held money: every
+    /// amount a zero, in each of the two zero spellings.
+    const WALLET_EMPTY: &str = r#"{
+      "code": 200,
+      "msg": "Operation successful",
+      "data": {
+        "balance": 0E-9,
+        "rechargeAmount": 0.000000,
+        "giveAmount": 0.000000,
+        "totalSpendAmount": 0E-9,
+        "todaySpendAmount": null,
+        "availableBalance": 0E-9,
+        "frozenBalance": 0E-9,
+        "creditBalance": null,
+        "availableCreditBalance": null,
+        "creditStatus": "NOT_OPEN",
+        "modelSpendAmountList": null,
+        "isKA": false
       },
       "success": true
     }"#;
@@ -452,12 +826,21 @@ mod tests {
             .unwrap_or_else(|| panic!("no window {key} in {:?}", snapshot.windows))
     }
 
+    fn keys(snapshot: &Snapshot) -> Vec<&str> {
+        let mut keys: Vec<&str> = snapshot.windows.iter().map(|w| w.key.as_str()).collect();
+        keys.sort_unstable();
+        keys
+    }
+
+    fn with_wallet(body: &str) -> Snapshot {
+        let wallet = parse_wallet(body).expect("parses");
+        apply_balance(parsed(LIVE_SHAPE), Some(&wallet), Region::Global)
+    }
+
     #[test]
     fn one_response_carries_three_windows_of_three_lengths() {
         let snapshot = parsed(LIVE_SHAPE);
-        let mut keys: Vec<&str> = snapshot.windows.iter().map(|w| w.key.as_str()).collect();
-        keys.sort_unstable();
-        assert_eq!(keys, ["mcp/w2592000", "w18000", "w604800"]);
+        assert_eq!(keys(&snapshot), ["mcp/w2592000", "w18000", "w604800"]);
         assert_eq!(snapshot.provider.as_str(), "zai");
         assert_eq!(snapshot.captured_at, now());
     }
@@ -648,36 +1031,169 @@ mod tests {
     }
 
     #[test]
-    fn the_spec_carries_the_region_to_the_endpoint() {
-        use crate::providers::keyed::{Auth, Method, Options};
+    fn the_wallet_readings_parse_with_their_bigdecimal_spellings() {
+        let wallet = parse_wallet(WALLET_WITH_MONEY).expect("parses");
+        assert!((wallet.available - 6.25).abs() < 1e-9);
+        assert!((wallet.granted - 25.0).abs() < 1e-9);
+        assert!((wallet.spent - 18.75).abs() < 1e-9);
+        assert_eq!(wallet.recharged, 0.0);
 
-        let global = Options::new();
-        let cn: Options = [("region".to_owned(), "bigmodel-cn".to_owned())]
-            .into_iter()
-            .collect();
+        // The empty wallet's zeros are `0E-9` and `0.000000` on the wire — both must read
+        // as zero, not as a parse failure or as something invented.
+        let empty = parse_wallet(WALLET_EMPTY).expect("parses");
+        assert_eq!(empty.available, 0.0);
+        assert_eq!(empty.spent, 0.0);
+    }
 
+    #[test]
+    fn a_wallet_without_a_readable_amount_is_refused() {
+        // The fetch treats a refusal as "no wallet read": gating on an invented zero would
+        // be the dangerous direction, and so would showing one.
+        for body in [
+            r#"{"code":200,"success":true,"data":{"balance":null,"availableBalance":null}}"#,
+            r#"{"code":200,"success":true,"data":{}}"#,
+            r#"{"code":200,"success":true}"#,
+            r#"{"code":500,"msg":"系统异常","success":false,"data":null}"#,
+            "not json",
+        ] {
+            let error = parse_wallet(body).expect_err("must refuse");
+            assert!(
+                matches!(error, ProviderError::Malformed(_)),
+                "{body}: {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_wallet_with_money_moves_mcp_off_the_card_and_reports_the_amount() {
+        let snapshot = with_wallet(WALLET_WITH_MONEY);
+
+        // The card draws its quota rows and lifts the first BALANCE row as a bold amount;
+        // the MCP window yields its row, and its absolutes were always detail rows and
+        // stay.
+        assert_eq!(keys(&snapshot), ["w18000", "w604800"]);
+        assert!(
+            !keys(&snapshot).contains(&"balance"),
+            "money is not a rate window"
+        );
+
+        let titles: Vec<&str> = snapshot.details.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, ["Plan", "Balance", "Quota", "MCP tools"]);
+        let rows = &snapshot.details[1].rows;
+        assert_eq!(rows[0].label, "Prepaid balance");
+        assert_eq!(rows[0].value, "$6.25");
+        assert_eq!(rows[1].label, "Granted");
+        assert_eq!(rows[1].value, "$25.00");
+        assert_eq!(rows[2].label, "Spent");
+        assert_eq!(rows[2].value, "$18.75");
         assert_eq!(
-            (SPEC.endpoint)(&global),
-            "https://api.z.ai/api/monitor/usage/quota/limit"
+            rows.len(),
+            3,
+            "a zero top-up and a zero freeze are not rows"
         );
         assert_eq!(
-            (SPEC.endpoint)(&cn),
-            "https://open.bigmodel.cn/api/monitor/usage/quota/limit"
+            snapshot.details[2].rows[0].value, "40 of 1000 used · 960 left",
+            "the MCP absolutes stay in the details"
         );
-        assert_eq!(SPEC.id, PROVIDER_ID);
-        assert_eq!(SPEC.auth, Auth::Bearer);
-        assert_eq!(SPEC.method, Method::Get);
+    }
+
+    #[test]
+    fn an_empty_wallet_keeps_the_mcp_window_and_publishes_nothing_about_money() {
+        // At zero the MCP pool is all there is: its window returns, and nothing about the
+        // wallet is published — not a window, not a section. A card lifts the first
+        // BALANCE row verbatim, so a "$0.00" row there would put a bold zero on the card.
+        let snapshot = with_wallet(WALLET_EMPTY);
+        assert_eq!(keys(&snapshot), ["mcp/w2592000", "w18000", "w604800"]);
+        let titles: Vec<&str> = snapshot.details.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, ["Plan", "Quota", "MCP tools"]);
+    }
+
+    #[test]
+    fn a_spent_out_wallet_keeps_the_mcp_window_and_publishes_nothing_about_money() {
+        // Spent to the last cent, the wallet binds no more than an empty one does: the MCP
+        // window returns and there is no balance anywhere.
+        let mut wallet = parse_wallet(WALLET_WITH_MONEY).expect("parses");
+        wallet.available = 0.0;
+        let snapshot = apply_balance(parsed(LIVE_SHAPE), Some(&wallet), Region::Global);
+        let keys = keys(&snapshot);
+        assert!(!keys.contains(&"balance"));
+        assert!(keys.contains(&"mcp/w2592000"));
+        let titles: Vec<&str> = snapshot.details.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, ["Plan", "Quota", "MCP tools"]);
+    }
+
+    #[test]
+    fn a_wallet_that_cannot_be_read_costs_neither_the_windows_nor_the_quota() {
+        let snapshot = apply_balance(parsed(LIVE_SHAPE), None, Region::Global);
+        assert_eq!(keys(&snapshot), ["mcp/w2592000", "w18000", "w604800"]);
+        let titles: Vec<&str> = snapshot.details.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(titles, ["Plan", "Quota", "MCP tools"]);
+    }
+
+    #[test]
+    fn the_wallet_amounts_carry_the_regions_currency() {
+        let wallet = parse_wallet(WALLET_WITH_MONEY).expect("parses");
+        let snapshot = apply_balance(parsed(LIVE_SHAPE), Some(&wallet), Region::BigModelCn);
+        assert_eq!(snapshot.details[1].rows[0].value, "¥6.25");
+    }
+
+    #[test]
+    fn the_five_hour_window_keeps_the_lead_whatever_the_wallet_says() {
+        let snapshot = with_wallet(WALLET_WITH_MONEY);
+        assert_eq!(
+            snapshot.dominant_window().expect("present").key.as_str(),
+            "w18000"
+        );
+    }
+
+    #[test]
+    fn both_urls_carry_the_region() {
+        for (stored, base) in [
+            (None, "https://api.z.ai"),
+            (Some("bigmodel-cn"), "https://open.bigmodel.cn"),
+        ] {
+            let options = stored
+                .map(|value: &str| [(REGION.to_owned(), value.to_owned())])
+                .unwrap_or_default()
+                .into_iter()
+                .collect::<Options>();
+            let zai = Zai::new(Credential::new("fixture-key"), &options).expect("builds");
+            assert_eq!(zai.quota_url(), format!("{base}{QUOTA_PATH}"));
+            assert_eq!(zai.balance_url(), format!("{base}{BALANCE_PATH}"));
+        }
+    }
+
+    #[test]
+    fn both_requests_carry_the_bearer_key_and_the_shared_shape() {
+        let zai = Zai::new(Credential::new("fixture-key"), &Options::new()).expect("builds");
+        for request in [zai.quota_request(), zai.balance_request()] {
+            let request = request.expect("builds");
+            assert_eq!(request.method(), reqwest::Method::GET);
+            assert_eq!(
+                request
+                    .headers()
+                    .get(reqwest::header::AUTHORIZATION)
+                    .expect("present"),
+                "Bearer fixture-key"
+            );
+            assert_eq!(
+                request
+                    .headers()
+                    .get(reqwest::header::ACCEPT)
+                    .expect("present"),
+                "application/json"
+            );
+        }
     }
 
     #[test]
     fn an_unknown_region_falls_back_to_global_rather_than_refusing_to_poll() {
-        use crate::providers::keyed::Options;
-
-        let nonsense: Options = [("region".to_owned(), "atlantis".to_owned())]
+        let options: Options = [("region".to_owned(), "atlantis".to_owned())]
             .into_iter()
             .collect();
+        let zai = Zai::new(Credential::new("key"), &options).expect("builds");
         assert_eq!(
-            (SPEC.endpoint)(&nonsense),
+            zai.quota_url(),
             "https://api.z.ai/api/monitor/usage/quota/limit",
             "a typo in config.toml must not take the account off the air"
         );
@@ -693,5 +1209,127 @@ mod tests {
         let values: Vec<&str> = region.choices.iter().map(|(value, _)| *value).collect();
         assert_eq!(values, ["global", "bigmodel-cn"]);
         assert_eq!(region.default, "global");
+    }
+
+    #[test]
+    fn the_spec_builds_a_client_the_registry_can_poll() {
+        assert_eq!(SPEC.id, PROVIDER_ID);
+        assert_eq!(SPEC.title, "Z.ai");
+        assert_eq!(SPEC.credential, CredentialKind::Key);
+        let provider = build(
+            AccountId::default(),
+            Credential::new("key"),
+            &Options::new(),
+        )
+        .expect("no required options, so no refusal");
+        assert_eq!(provider.id().as_str(), "zai");
+        assert_eq!(provider.account().as_str(), "default");
+    }
+
+    #[test]
+    fn a_zai_client_never_prints_its_credential() {
+        let zai = Zai::new(Credential::new("sk-super-secret"), &Options::new()).expect("builds");
+        let rendered = format!("{zai:?}");
+        assert!(!rendered.contains("super-secret"), "{rendered}");
+    }
+
+    /// A loopback server answering the two requests a fetch makes: the quota path with
+    /// `quota_body`, the wallet path with `wallet_status`/`wallet_body`. Both exchanges
+    /// are captured for the assertions that follow.
+    fn two_request_server(
+        quota_body: &'static str,
+        wallet_status: u16,
+        wallet_body: &'static str,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("loopback listener");
+        let address = listener.local_addr().expect("listener address");
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().expect("request accepted");
+                let mut reader = BufReader::new(&mut stream);
+                let mut head = String::new();
+                let mut content_length = 0;
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).expect("header read");
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        content_length = value.trim().parse().expect("content length");
+                    }
+                    head.push_str(&line);
+                }
+                let mut body = vec![0; content_length];
+                if content_length > 0 {
+                    reader.read_exact(&mut body).expect("body read");
+                }
+                let is_quota = head.starts_with("GET /api/monitor");
+                tx.send(head).expect("request captured");
+                let (status, body) = if is_quota {
+                    ("200 OK", quota_body)
+                } else {
+                    match wallet_status {
+                        200 => ("200 OK", wallet_body),
+                        _ => ("500 Internal Server Error", wallet_body),
+                    }
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .expect("response written");
+            }
+        });
+        (format!("http://{address}"), rx)
+    }
+
+    fn at(base: &str) -> Zai {
+        Zai::at(
+            AccountId::default(),
+            Credential::new("zai-fixture-key"),
+            Region::Global,
+            base,
+        )
+        .expect("builds")
+    }
+
+    #[tokio::test]
+    async fn a_fetch_reads_both_endpoints_and_gates_the_mcp_window() {
+        let (base, requests) = two_request_server(LIVE_SHAPE, 200, WALLET_WITH_MONEY);
+        let snapshot = at(&base).fetch().await.expect("both requests answer");
+        assert_eq!(keys(&snapshot), ["w18000", "w604800"]);
+        assert_eq!(snapshot.details[1].rows[0].value, "$6.25");
+
+        let first = requests.recv().expect("quota request captured");
+        let second = requests.recv().expect("wallet request captured");
+        for (path, head) in [
+            ("/api/monitor/usage/quota/limit", first),
+            ("/api/biz/account/query-customer-account-report", second),
+        ] {
+            assert!(head.starts_with(&format!("GET {path} ")), "{head}");
+            assert!(
+                head.contains("authorization: Bearer zai-fixture-key"),
+                "{head}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_wallet_that_fails_costs_only_the_balance_row() {
+        // The quota is the point of the fetch: a 500 on the wallet must not fail it, gate
+        // the MCP window on a balance nobody read, or turn a working key into a credential
+        // error the quota already disproved.
+        let (base, _requests) = two_request_server(LIVE_SHAPE, 500, "internal");
+        let snapshot = at(&base).fetch().await.expect("the quota still answers");
+        assert_eq!(keys(&snapshot), ["mcp/w2592000", "w18000", "w604800"]);
+        let titles: Vec<&str> = snapshot.details.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(
+            titles,
+            ["Plan", "Quota", "MCP tools"],
+            "no balance section either"
+        );
     }
 }

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -160,6 +160,7 @@ pub struct Card {
     reset: gtk::Label,
     absolutes: gtk::Label,
     rows: gtk::Box,
+    balance: gtk::Label,
     footer: gtk::Label,
     shown: RefCell<Shown>,
 }
@@ -318,6 +319,16 @@ impl Card {
             .spacing(6)
             .build();
 
+        // The wallet amount under the quota rows. Money is not a rate, so it gets no bar
+        // and no percentage — just the provider's phrasing of the amount, bold and between
+        // the headline and the secondary rows in size. See `DetailSection::BALANCE` for the
+        // convention this rides on.
+        let balance = gtk::Label::builder()
+            .halign(gtk::Align::Start)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .css_classes(["quota-balance"])
+            .build();
+
         // Pinned to the bottom so that cards sharing a row line their footers up: the grid
         // gives every card the height of the tallest one, and without this the extra space
         // would fall in a different place on every card.
@@ -336,6 +347,7 @@ impl Card {
         body.append(&reading);
         body.append(&blank);
         body.append(&rows);
+        body.append(&balance);
         body.append(&footer);
         let root = gtk::Overlay::builder()
             .child(&body)
@@ -409,6 +421,7 @@ impl Card {
             reset,
             absolutes,
             rows,
+            balance,
             footer,
             shown: RefCell::new(Shown {
                 status: status.clone(),
@@ -476,6 +489,7 @@ impl Card {
                 self.blank.set_visible(false);
                 self.bar.widget().set_visible(true);
                 self.dominant_title.set_label(&dominant.title);
+                self.set_balance_line(balance);
                 self.rebuild_rows(rest)
             }
             (None, Some(balance)) => {
@@ -486,11 +500,13 @@ impl Card {
                 self.bar.widget().set_visible(false);
                 self.reset.set_visible(false);
                 self.set_absolutes(None);
+                self.set_balance_line(None);
                 self.rebuild_rows(&[])
             }
             (None, None) => {
                 self.reading.set_visible(false);
                 self.blank.set_visible(true);
+                self.set_balance_line(None);
                 let message = blank_message(status);
                 // The card shows the first `BLANK_LINES` of it; the tooltip is where the
                 // rest of a long one is, so that truncating it costs nothing on the way to
@@ -560,6 +576,24 @@ impl Card {
             None => {
                 self.absolutes.set_label("");
                 self.absolutes.set_visible(false);
+            }
+        }
+    }
+
+    /// Shows the wallet amount under the quota rows, or removes the line.
+    ///
+    /// Only a reading with windows draws it: a balance-only card already shows the amount
+    /// as its headline, and this line must not repeat it. Emptied as well as hidden, for
+    /// the same reason `set_absolutes` empties.
+    fn set_balance_line(&self, amount: Option<&str>) {
+        match amount {
+            Some(text) => {
+                self.balance.set_label(text);
+                self.balance.set_visible(true);
+            }
+            None => {
+                self.balance.set_label("");
+                self.balance.set_visible(false);
             }
         }
     }

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -164,6 +164,14 @@ pub(crate) const STYLE: &str = "
     opacity: 0.45;
 }
 
+/* The wallet amount under the quota rows. Bold, and between the headline percentage and
+   the secondary rows in size: money is not a rate — no bar, no percentage — but it is the
+   number the account runs on, so it outranks the rows it sits under. */
+.quota-balance {
+    font-weight: 700;
+    font-size: 1.2em;
+}
+
 /* The credential pill sits in a preferences row of its own so that it gets the full width
    of the group — a header suffix ellipsized both of its labels, and neither `Tidemark
    login` nor `Claude Code login` can be shortened without becoming a guess. A plain

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -28,7 +28,7 @@ use tidemark_core::providers::keyed::{
     self, abacus, aiand, alibaba, augment, codebuff, commandcode, cursor, deepgram, deepinfra,
     factory, fireworks, gemini, grok, groq, ibmbob, kilo, litellm, llmproxy, longcat, manus, mimo,
     mistral, nanogpt, notion, ollama, openai_api, opencode, openrouter, perplexity, poe, qoder,
-    sakana, stepfun, sub2api, t3chat, wayfinder, xai, zoommate,
+    sakana, stepfun, sub2api, t3chat, wayfinder, xai, zai, zoommate,
 };
 use tidemark_core::providers::{
     AUTO_SOURCE, CLI_SOURCE, Credential, OAUTH_SOURCE, Provider, ProviderError, Source,
@@ -127,7 +127,8 @@ fn oauth_entry(provider: &str) -> Option<&'static OAuthEntry> {
 /// through a usage history, StepFun asks a rate-limit RPC and then a plan-status one,
 /// deriving the device id its cookie pair needs from the token's own JWT payload at
 /// build time, xAI reads a prepaid balance and a spend
-/// history — and those whose single request hangs from a required base URL with no
+/// history, and Z.ai follows its quota meters with the wallet
+/// the same key reads, gating its MCP window on the money there is left — and those whose single request hangs from a required base URL with no
 /// default host, where the shared reader's refusal of a bad value must happen at
 /// build time rather than inside an endpoint closure: LLM Proxy and sub2api — and
 /// Wayfinder, a router on this machine that answers without a credential at all and reads
@@ -176,6 +177,7 @@ static HAND_WRITTEN: &[&keyed::HandSpec] = &[
     &t3chat::SPEC,
     &wayfinder::SPEC,
     &xai::SPEC,
+    &zai::SPEC,
     &zoommate::SPEC,
 ];
 
@@ -1477,15 +1479,21 @@ mod tests {
         let config = Config::at(path.clone()).expect("parses");
         assert_eq!(options(zai::PROVIDER_ID, &config)[0].value, "bigmodel-cn");
 
-        // A published option shows what is on disk verbatim; the spec's own `endpoint`
-        // is what keeps an unrecognised value from reaching the wrong host, so an
-        // unrecognised value on disk is not silently rewritten here.
+        // A published option shows what is on disk verbatim; the provider's own URL
+        // resolution is what keeps an unrecognised value from reaching the wrong host, so
+        // an unrecognised value on disk is not silently rewritten here.
         std::fs::write(&path, "[provider.zai]\nregion = \"mars\"\n").expect("seed");
         let config = Config::at(path.clone()).expect("parses");
         assert_eq!(options(zai::PROVIDER_ID, &config)[0].value, "mars");
+        let wrong_host = zai::Zai::new(
+            Credential::new("key"),
+            &BTreeMap::from([("region".to_owned(), "mars".to_owned())]),
+        )
+        .expect("builds");
+        let no_region = zai::Zai::new(Credential::new("key"), &BTreeMap::new()).expect("builds");
         assert_eq!(
-            (zai::SPEC.endpoint)(&BTreeMap::from([("region".to_owned(), "mars".to_owned())])),
-            (zai::SPEC.endpoint)(&BTreeMap::new()),
+            (wrong_host.quota_url(), wrong_host.balance_url()),
+            (no_region.quota_url(), no_region.balance_url()),
             "a typo in a hand-edited file costs the wrong host at request time, not a dead card"
         );
         let _ = std::fs::remove_file(&path);


### PR DESCRIPTION
## What

Z.ai's API key also answers the console's own billing call — `GET /api/biz/account/query-customer-account-report` — on **all three** region hosts (verified live: `api.z.ai`, `open.bigmodel.cn`, `www.bigmodel.cn`; CodexBar ships it CN-only with a "no global equivalent" comment, which no longer holds). The provider now makes that second request and folds the wallet into the reading.

## Card behaviour

| Wallet | Card | Details |
| --- | --- | --- |
| `available > 0` | 5h headline, 7d row, **bold amount** (`.14`) | MCP absolutes + full wallet rows |
| `available == 0` (empty or spent out) | 5h, 7d, MCP — nothing about money | unchanged, no Balance section |
| unreadable | 5h, 7d, MCP | nothing; the quota is the point of the fetch |

The amount rides the existing `DetailSection::BALANCE` convention — first row of the section, lifted by the card verbatim (money is not a rate: no window, no bar, no percentage). New `.quota-balance` style: bold, between the headline % and the secondary rows in size.

## Notes

- zai moves from the keyed `CATALOG` to a `HandSpec` with its own `impl Provider` (two GETs, one bearer key); slug, config, keyring and history untouched.
- Wallet amounts are Java `BigDecimal`s — zeros arrive as `0E-9` / `0.000000`; both parse. No currency field in the payload, so the symbol is region-chosen (`$` / `¥`).
- The wallet request is best-effort: any failure is swallowed into silence, never a failed fetch, never a credential error the successful quota request already disproved.
- `examples/probe.rs` prints both URLs; `registry::HAND_WRITTEN` gains zai.

## Verification

- `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (12/12 suites; 35 zai tests incl. two loopback transport tests with recorded-shape bodies), `check-layering.sh` — all green.
- Probed both live accounts with the real keys: lite ($8.14) shows `5h / 7d / $8.14` with MCP in details; pro ($0.00) shows `5h / 7d / MCP` with no money line.