### PR TITLE
fix(windows): draw through FreeType, not GDI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,6 +2733,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pangocairo"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd199a0fef965b3ebda91a929a1ab5e7729538882c68e8de38e1904d2e094757"
+dependencies = [
+ "cairo-rs 0.22.0",
+ "glib 0.22.8",
+ "pango 0.22.8",
+ "pangocairo-sys",
+]
+
+[[package]]
+name = "pangocairo-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a649a616d67ae68539bc85f00fb45d36fba742ed20fc20e6712a15d8ee52bd3f"
+dependencies = [
+ "cairo-sys-rs 0.22.0",
+ "glib-sys 0.22.8",
+ "libc",
+ "pango-sys 0.22.0",
+ "system-deps 9.0.0",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,6 +3693,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0dae2cbca1f0ff93795713cfe0a4c02f760e3c0b8ae2ab4ec4045808ff429f"
+dependencies = [
+ "cfg-expr 0.20.8",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.4+spec-1.1.0",
+ "version-compare",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,6 +3797,7 @@ dependencies = [
  "ksni",
  "libadwaita",
  "pango 0.22.8",
+ "pangocairo",
  "semver",
  "tidemark-types",
  "tracing",

--- a/crates/tidemark/Cargo.toml
+++ b/crates/tidemark/Cargo.toml
@@ -30,6 +30,11 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 zbus = { version = "5.13.2", features = ["p2p"] }
 
 [target.'cfg(windows)'.dependencies]
+# The FreeType/fontconfig Pango backend, selected over Windows' GDI default at
+# startup. `pango_cairo_font_map_new_for_font_type` is the documented way to ask
+# for it from inside the program rather than through PANGOCAIRO_BACKEND in the
+# environment; see crates/tidemark/src/font.rs for why the default will not do.
+pangocairo = "0.22.9"
 # The Windows tray backend (todo 15). tray-icon drives Win32 tray APIs on its own
 # event-loop thread; `windows` supplies only the message pump that thread must run for
 # menu events to be delivered. Current version pinned per plan §15 via `cargo search`.

--- a/crates/tidemark/src/font.rs
+++ b/crates/tidemark/src/font.rs
@@ -1,11 +1,82 @@
-//! App-private font discovery for Windows.
+//! The Windows text stack: which rasterizer draws, and which font it draws with.
 //!
-//! The installer carries Rubik beside the GTK runtime and adds the private
-//! font to GTK's display-wide map.
+//! Two things have to be settled before the first label exists. The interface is
+//! typeset in Rubik, which the installer carries beside the GTK runtime rather than
+//! installing into the user's font collection, so Pango has to be handed the file.
+//! And Pango has to be told which of its two Windows back ends to use, because the
+//! default one cannot read the font it is being handed.
+//!
+//! # Why not the default back end
+//!
+//! `PangoCairoWin32FontMap` is what `pango_cairo_font_map_get_default()` returns on
+//! Windows, and it goes through GDI. Rubik ships as a single variable font with a
+//! `wght` axis from 300 to 900, and GDI predates that idea: it reads the default
+//! instance's `hmtx` and never looks at `HVAR`, the table that says how advances move
+//! along the axis. Measured on this font at 26pt, GDI drew heavier and heavier glyphs
+//! while handing out one fixed set of advances:
+//!
+//! ```text
+//!               advances       ink of each glyph
+//!   Light       20, 14, 26     20, 12, 24
+//!   Bold        20, 14, 26     23, 16, 27
+//!   Heavy       20, 14, 26     25, 19, 29
+//! ```
+//!
+//! Every glyph past Medium is wider than the box it is placed in, so the headline
+//! percentage on a card — `.title-1`, which libadwaita sets at weight 800 — came out
+//! with its digits overlapping. Nothing in the stylesheet can fix that: the advances
+//! are wrong before CSS is consulted.
+//!
+//! The same back end also declines to fall back. GDI substitution is arranged around
+//! installed font families, and a font added privately to the process is not one, so
+//! any character Rubik does not have — `→` in a provider's credential hint, `⚠`, a
+//! check mark — was drawn as the missing-glyph box instead of being borrowed from a
+//! system font. Families Windows knows about fall back normally, which is what made
+//! this look like a Rubik problem rather than a back-end one.
+//!
+//! `PangoCairoFcFontMap` — cairo's FreeType font type, fontconfig for matching — has
+//! neither fault, and it is the same code path the Linux build has always used. It
+//! reads `HVAR`, so advances grow with weight; it falls back through fontconfig, so
+//! `→` arrives from Arial; and it hints through FreeType at the hint style GTK asks
+//! for, which is why small text stops looking washed. One call at startup buys all
+//! three, and the price is the fontconfig configuration in `etc/fonts` that
+//! `data/packaging/windows/stage-gtk-runtime.sh` now stages beside the DLLs.
 
 use std::path::{Path, PathBuf};
 
 use gtk::prelude::*;
+
+/// Puts Pango on the FreeType back end, before anything asks it for a font.
+///
+/// Must be called before GTK builds its first Pango context: this replaces the
+/// process-wide default font map, and a context already made from the old one keeps
+/// it. `main` calls it first thing, ahead of the `Application` it then runs.
+///
+/// A failure here is a working interface with the old defects rather than no
+/// interface: cairo without a FreeType back end is not a configuration this project
+/// ships, but if one is ever built, it should still start.
+pub(crate) fn use_freetype_rasterizer() {
+    let Some(map) = freetype_font_map() else {
+        tracing::warn!(
+            "cairo has no FreeType back end; text falls back to GDI, where the bundled \
+             variable font mis-spaces its heavier weights and cannot borrow missing glyphs"
+        );
+        return;
+    };
+    pangocairo::FontMap::set_default(Some(&map));
+}
+
+/// A font map that rasterizes through FreeType and matches through fontconfig.
+///
+/// Separate from the call that installs it so the two properties this module exists
+/// for — advances that follow the weight axis, and a fallback that reaches the
+/// machine's own fonts — can be measured without moving the process-wide default.
+fn freetype_font_map() -> Option<pangocairo::FontMap> {
+    pangocairo::FontMap::for_font_type(gtk::cairo::FontType::FontTypeFt)?
+        // pango_cairo_font_map_new_for_font_type returns a PangoCairoFontMap or nothing.
+        .downcast::<pangocairo::FontMap>()
+        .ok()
+}
 
 /// Adds the installed Rubik to GTK's display-wide Pango font map.
 ///
@@ -44,4 +115,149 @@ pub(crate) fn bundled_font_file(executable: &Path) -> PathBuf {
 /// Adds a bundled font file to a Pango font map.
 pub(crate) fn register(font_map: &pango::FontMap, font: &Path) -> Result<(), gtk::glib::Error> {
     font_map.add_font_file(font)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The font this interface is typeset in, from the tree rather than an install.
+    fn rubik() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../data/fonts/rubik/Rubik%5Bwght%5D.ttf")
+    }
+
+    /// A context on a private FreeType map with Rubik added, or `None` where cairo has
+    /// no FreeType back end. Deliberately not the process-wide default: these
+    /// measurements must not depend on, or disturb, whatever else the test binary is
+    /// drawing. No display is needed — a font map is not a window.
+    fn typeset() -> Option<pango::Context> {
+        let map = freetype_font_map()?;
+        register(map.upcast_ref::<pango::FontMap>(), &rubik()).expect("Rubik loads");
+        Some(map.create_context())
+    }
+
+    /// The advances one string is drawn with at one weight, in Pango units.
+    fn advances(context: &pango::Context, weight: pango::Weight, text: &str) -> Vec<i32> {
+        let mut description = pango::FontDescription::from_string("Rubik 26");
+        description.set_weight(weight);
+        context.set_font_description(&description);
+        let layout = pango::Layout::new(context);
+        layout.set_text(text);
+
+        let mut runs = layout.iter();
+        let mut widths = Vec::new();
+        loop {
+            if let Some(run) = runs.run_readonly() {
+                widths.extend(
+                    run.glyph_string()
+                        .glyph_info()
+                        .iter()
+                        .map(|glyph| glyph.geometry().width()),
+                );
+            }
+            if !runs.next_run() {
+                break;
+            }
+        }
+        widths
+    }
+
+    /// The bug the headline percentage showed: GDI hands out the light instance's
+    /// advances whatever weight it draws, so `.title-1` at weight 800 overlapped its
+    /// own digits. A back end that reads the variable font's `HVAR` gives every weight
+    /// its own, and they grow.
+    #[test]
+    fn a_heavier_weight_is_given_more_room() {
+        let Some(context) = typeset() else {
+            eprintln!("skipped: cairo has no FreeType back end");
+            return;
+        };
+        let light = advances(&context, pango::Weight::Light, "41%");
+        let heavy = advances(&context, pango::Weight::Heavy, "41%");
+
+        assert_eq!(light.len(), 3, "one advance per digit and the sign");
+        assert_eq!(heavy.len(), light.len());
+        assert!(
+            std::iter::zip(&light, &heavy).all(|(light, heavy)| heavy > light),
+            "every glyph must widen with the weight axis, got {light:?} then {heavy:?}"
+        );
+    }
+
+    /// The same bug stated as what the user saw: at the weight the card's percentage is
+    /// drawn in, no glyph may be wider than the room it is placed in. Measured one
+    /// glyph at a time, because a total that fits can still hide a collision.
+    #[test]
+    fn the_heaviest_digits_fit_the_room_they_are_given() {
+        let Some(context) = typeset() else {
+            eprintln!("skipped: cairo has no FreeType back end");
+            return;
+        };
+        let mut description = pango::FontDescription::from_string("Rubik 26");
+        description.set_weight(pango::Weight::Heavy);
+        context.set_font_description(&description);
+
+        for glyph in ["4", "1", "%"] {
+            let layout = pango::Layout::new(&context);
+            layout.set_text(glyph);
+            let (ink, logical) = layout.extents();
+            assert!(
+                ink.width() <= logical.width(),
+                "{glyph:?} inks {} into an advance of {}",
+                ink.width(),
+                logical.width()
+            );
+        }
+    }
+
+    /// Rubik has no U+2192, and a provider's credential hint uses one: "Deepgram
+    /// console → API keys". Under GDI a privately added font gets no substitution and
+    /// the arrow came out as the missing-glyph box; fontconfig borrows it from a font
+    /// the machine already has.
+    #[test]
+    fn a_character_rubik_lacks_is_borrowed_from_another_font() {
+        let Some(context) = typeset() else {
+            eprintln!("skipped: cairo has no FreeType back end");
+            return;
+        };
+        context.set_font_description(&pango::FontDescription::from_string("Rubik 12"));
+        let layout = pango::Layout::new(&context);
+        layout.set_text("console \u{2192} keys");
+
+        let mut runs = layout.iter();
+        loop {
+            if let Some(run) = runs.run_readonly() {
+                for glyph in run.glyph_string().glyph_info() {
+                    // PANGO_GLYPH_UNKNOWN_FLAG marks the box drawn in place of a glyph
+                    // no font in the chain had.
+                    assert_eq!(
+                        glyph.glyph() & 0x1000_0000,
+                        0,
+                        "no character in the hint may be drawn as a missing-glyph box"
+                    );
+                }
+            }
+            if !runs.next_run() {
+                break;
+            }
+        }
+    }
+
+    /// That the map measured above is the one the program will draw with. The default
+    /// font map is process-wide and this test moves it — the same move `main` makes
+    /// before GTK starts, so a widget test that runs after this one sits nearer to
+    /// production than one that runs before it.
+    #[test]
+    fn the_freetype_map_becomes_the_default() {
+        let Some(expected) = freetype_font_map() else {
+            eprintln!("skipped: cairo has no FreeType back end");
+            return;
+        };
+        use_freetype_rasterizer();
+
+        assert_eq!(
+            pangocairo::FontMap::default().type_(),
+            expected.type_(),
+            "GTK must build its contexts from the FreeType font map"
+        );
+    }
 }

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -59,6 +59,11 @@ where
 }
 
 fn main() -> glib::ExitCode {
+    // Before GTK exists, because it replaces the font map every later Pango
+    // context is made from. See `font` for what the Windows default gets wrong.
+    #[cfg(windows)]
+    font::use_freetype_rasterizer();
+
     #[cfg(windows)]
     let sink = file_log::init()
         .map(file_log::Sink::File)

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -3,10 +3,11 @@
 //! Everything that libadwaita already names is used by name — `card`, `title-1`, `heading`,
 //! `caption`, `dim-label`, `warning`, `error` — so the window follows the system's accent
 //! colour, dark mode and font scaling without being told to. On Windows only, the bundled
-//! Rubik is selected after it has been registered with Pango for this process. What is left is the three
-//! things Adwaita has no class for: the pill around a state chip, the padding inside a
-//! card, which `.card` deliberately does not set because it does not know what is going in
-//! it, and the padding around the credential pill, for the same reason.
+//! Rubik is selected after `font` has put Pango on a back end that can read it and
+//! registered it for this process. What is left is the three things Adwaita has no class
+//! for: the pill around a state chip, the padding inside a card, which `.card`
+//! deliberately does not set because it does not know what is going in it, and the
+//! padding around the credential pill, for the same reason.
 //!
 //! # The hover, and the lift
 //!
@@ -40,9 +41,11 @@ const PLATFORM_STYLE: &str = "
     font-family: Rubik;
 }
 
-/* GTK's Windows text rasterizer is softer than the Linux FreeType path at
-   caption sizes. Keep captions one logical step larger everywhere, so GDK
-   still applies each display's own DPI and scale. */
+/* Windows' system font is 9pt where the desktops libadwaita is designed
+   against use 10 or 11, and `.caption` takes 0.8em of it. Keep captions one
+   logical step larger everywhere, so GDK still applies each display's own DPI
+   and scale. (The rasterizer is no longer part of this: `font` puts Windows on
+   the same FreeType path Linux uses.) */
 .caption {
     font-size: 0.9em;
 }

--- a/data/packaging/windows/README.md
+++ b/data/packaging/windows/README.md
@@ -15,9 +15,12 @@ shortcut, and every installed file. Nothing machine-wide, no elevation.
 - `stage-gtk-runtime.sh` — walks the full PE import closure of both release
   executables and all MSYS2 gdk-pixbuf loaders, then assembles
   `build/nsis-staging/gtk/` with those UCRT64 DLLs, a relative-path
-  `loaders.cache`, compiled GLib schemas, fontconfig data and icon themes. It
-  also places the pinned Rubik font beside the runtime. Tidemark registers
-  it privately at launch, never as a Windows system font.
+  `loaders.cache`, compiled GLib schemas, fontconfig data and configuration,
+  and icon themes. It also places the pinned Rubik font beside the runtime.
+  Tidemark registers it privately at launch, never as a Windows system font,
+  and draws through Pango's FreeType back end rather than the GDI one — which
+  is why `etc/fonts` is staged and not only `share/fontconfig`. See
+  `crates/tidemark/src/font.rs` for what the GDI back end gets wrong.
 - `msys2-runtime-packages.txt` — exact package versions and package-archive
   SHA-256 hashes for every staged DLL/data owner. The release workflow
   downloads and verifies these archives before it builds, so linked and

--- a/data/packaging/windows/stage-gtk-runtime.sh
+++ b/data/packaging/windows/stage-gtk-runtime.sh
@@ -107,6 +107,21 @@ cp -r "$PREFIX/share/icons/Adwaita" "$DST/share/icons/"
 cp -r "$PREFIX/share/icons/hicolor" "$DST/share/icons/"
 cp -r "$PREFIX/share/fontconfig" "$DST/share/"
 
+# fontconfig's configuration, which the client now depends on rather than merely
+# links: it selects Pango's FreeType back end at startup (crates/tidemark/src/font.rs),
+# and that back end asks fontconfig for every substitution. On Windows fontconfig reads
+# its configuration from etc/fonts beside the directory its own DLL sits in, and expands
+# WINDOWSFONTDIR there to the system font directory.
+#
+# Without this the program still runs — fontconfig's built-in Windows fallback finds the
+# installed families anyway — but conf.d is what chooses among them: measured on a cold
+# cache, the glyphs Rubik lacks came from Verdana and Arial with the configuration staged
+# and from MingLiU-ExtB without it, and the hinting and antialias defaults live in the
+# same directory.
+mkdir -p "$DST/etc"
+cp -r "$PREFIX/etc/fonts" "$DST/etc/"
+test -f "$DST/etc/fonts/fonts.conf" || { echo "fontconfig configuration not staged" >&2; exit 1; }
+
 # Tidemark's own artwork rides the prefix-relative lookup GTK already uses for the
 # staged sets above: the provider marks merge into hicolor (see
 # crates/tidemark/src/mark.rs — the theme lookup is what recolours them), and the


### PR DESCRIPTION
Three complaints from the v0.4.0 Windows build, one cause.

## What was wrong

Rubik ships as a single variable font with a `wght` axis from 300 to 900, and the
client draws through `PangoCairoWin32FontMap` — Pango's GDI back end, which
`pango_cairo_font_map_get_default()` returns on Windows. GDI reads the default
instance's `hmtx` and never looks at `HVAR`, the table that says how advances move
along the axis. Measured on the bundled font at 26pt:

```
              advances       ink of each glyph
  Light       20, 14, 26     20, 12, 24
  Bold        20, 14, 26     23, 16, 27
  Heavy       20, 14, 26     25, 19, 29
```

Every glyph past Medium is drawn wider than the box it is placed in, so the headline
percentage on a card — `.title-1`, which libadwaita sets at weight 800 — came out with
its digits overlapping. No stylesheet can fix that; the advances are wrong before CSS
is consulted.

The same back end does no substitution for a font added privately to the process, so
every character Rubik does not have was drawn as the missing-glyph box. The reported
one is the arrow in Deepgram's credential hint, `Deepgram console → API keys`; other
providers' hints use the same arrow. Families Windows itself has installed fall back
normally, which is what made this look like a Rubik problem rather than a back-end one.

## What this does

Asks cairo for its FreeType font type at startup and installs it as Pango's default
font map, before GTK builds its first context. That is the same path the Linux build
has always taken, so: advances follow the weight axis, fontconfig borrows `→` from
Arial, and FreeType hints at the style GTK asks for — which is also why the smallest
labels come out crisper rather than washed.

`data/packaging/windows/stage-gtk-runtime.sh` now stages `etc/fonts` beside the DLLs.
Without it the program still starts — fontconfig's built-in Windows fallback finds the
installed families anyway — but `conf.d` is what chooses among them: on a cold cache
the glyphs Rubik lacks came from Verdana and Arial with the configuration staged and
from MingLiU-ExtB without it, and the hinting and antialias defaults live in the same
directory. It is 130 KiB, and `fontconfig` was already a pinned runtime package.

The one stylesheet change is a comment: `.caption { font-size: 0.9em }` was justified
as compensation for a soft Windows rasterizer, which is no longer the reason it is
there. Windows' system font is 9pt where the desktops libadwaita is designed against
use 10 or 11, and that reason still holds, so the rule stays and the comment now says
the true thing.

## Tests

Three, one per symptom, each of which fails when pointed at the GDI font map:

- `a_heavier_weight_is_given_more_room` — `[20480, 14336, 26624]` at both Light and
  Heavy on GDI.
- `the_heaviest_digits_fit_the_room_they_are_given` — `"4" inks 26223 into an advance
  of 21504` on GDI, a 22% overflow.
- `a_character_rubik_lacks_is_borrowed_from_another_font` — glyph
  `0x10000000` (`PANGO_GLYPH_UNKNOWN_FLAG`) on GDI.

They build a private font map rather than moving the process-wide default, so they need
no display and disturb nothing else in the binary. A fourth asserts that the map they
measure is the one `main` installs.

## Verified

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
  `scripts/check-layering.sh`, `cargo test --workspace` (green except the pre-existing
  local "GTK from two different threads" crasher in `browser_auth`, which fails the same
  way on `main` and passes in CI, and `tidemarkd`'s singleton test, which cannot pass on
  a machine where an installed daemon holds the named mutex).
- Staged the full runtime and ran the release test binary from
  `build/nsis-staging/gtk/` with MSYS2 off `PATH` and a cold fontconfig cache: four
  font tests pass, `→` resolves to Arial, Rubik loads from `share/fonts/`.
- Rendered the card's own labels through the real GSK renderer from that staged tree:
  `41%`, `88% 100% 17%`, the chip, the balance and the two caption rows all correct,
  arrow included. 1.65 s cold, so building the fontconfig cache costs nothing visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
