### PR TITLE
fix(windows): let a daemon take back the endpoint a killed one left

### DIFF
--- a/crates/tidemarkd/src/peer.rs
+++ b/crates/tidemarkd/src/peer.rs
@@ -262,6 +262,62 @@ fn endpoint_path() -> std::io::Result<PathBuf> {
         .join("d.sock"))
 }
 
+/// Binds the endpoint, clearing whatever a killed daemon left on it.
+///
+/// A socket file outlives the process that bound it — Windows unlinks it no more than
+/// Unix does — and `bind` over one that is still on disk fails, so a daemon killed
+/// outright would otherwise be the last one this user ever starts.
+///
+/// The leftover cannot be recognised by asking the filesystem about it. `Path::exists`
+/// opens the file to answer, and an `AF_UNIX` socket refuses to be opened: on a machine
+/// whose socket namespace has been disturbed the open fails outright (`ERROR_CANT_ACCESS_FILE`,
+/// os error 1920) and `exists()` reports `false` about a socket plainly listed in its own
+/// directory. Gating the cleanup on that answer is what left this daemon binding over a
+/// file it had just been told was not there, to fail with a bare `os error 10022` in
+/// `daemon.log` and a client waiting forever.
+///
+/// So the question is put to the socket rather than to the filesystem, and only the one
+/// answer that means "live daemon" is honoured: a connection that is *accepted*. Every
+/// other outcome — a refusal, a socket whose file is unopenable, no file at all (Windows
+/// answers `ConnectionRefused` for a path that does not exist, not `NotFound`) — is a
+/// leftover or nothing, and the path is cleared unconditionally before the bind. Removing
+/// what is not there is not an error; failing to remove what is there is not fatal on its
+/// own, because the bind that follows is the one that decides, but it is the likeliest
+/// reason that bind fails and so it is carried into the message.
+#[cfg(windows)]
+fn take_endpoint(endpoint: &std::path::Path) -> std::io::Result<UnixListener> {
+    if UnixStream::connect(endpoint).is_ok() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!(
+                "another tidemarkd already answers at {}; this one is not needed",
+                endpoint.display()
+            ),
+        ));
+    }
+    let unremoved = match fs::remove_file(endpoint) {
+        Ok(()) => {
+            tracing::info!(
+                endpoint = %endpoint.display(),
+                "cleared the socket a previous daemon left behind"
+            );
+            None
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => Some(error),
+    };
+    UnixListener::bind(endpoint).map_err(|error| {
+        let reason = match unremoved {
+            Some(unremoved) => format!(
+                "cannot serve {}: {error}; the socket left there could not be removed either: {unremoved}",
+                endpoint.display()
+            ),
+            None => format!("cannot serve {}: {error}", endpoint.display()),
+        };
+        std::io::Error::new(error.kind(), reason)
+    })
+}
+
 /// Accepts p2p peers forever, one zbus connection per peer.
 ///
 /// Returns the accept task's handle so shutdown can stop handing out new connections.
@@ -276,26 +332,7 @@ pub(crate) async fn listen(
     if let Some(parent) = endpoint.parent() {
         fs::create_dir_all(parent)?;
     }
-    // A previous daemon killed outright leaves its socket file behind. Only a file that
-    // refuses a connection is stale: one that accepts belongs to a live daemon, and
-    // binding over it would be a hostile takeover.
-    if endpoint.exists() {
-        match UnixStream::connect(&endpoint) {
-            Ok(_stream) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::AddrInUse,
-                    format!(
-                        "another tidemarkd already answers at {}; this one is not needed",
-                        endpoint.display()
-                    ),
-                ));
-            }
-            Err(_) => {
-                fs::remove_file(&endpoint)?;
-            }
-        }
-    }
-    let listener = UnixListener::bind(&endpoint)?;
+    let listener = take_endpoint(&endpoint)?;
 
     let (accepted, mut incoming) = mpsc::unbounded_channel();
     thread::Builder::new()
@@ -324,6 +361,95 @@ pub(crate) async fn listen(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A directory of this test's own under the temp dir, named for the test and the
+    /// process, so a parallel run and a leftover from a previous one cannot collide.
+    #[cfg(windows)]
+    fn a_directory_for(test: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("tidemark-endpoint-{test}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("a directory under the temp dir");
+        dir
+    }
+
+    /// Whether the directory still lists the file — the one question about a socket the
+    /// filesystem answers reliably, and the reason [`take_endpoint`] does not ask
+    /// `Path::exists`, which opens the file to answer and can be refused.
+    #[cfg(windows)]
+    fn listed(path: &std::path::Path) -> bool {
+        fs::read_dir(path.parent().expect("the endpoint has a directory"))
+            .expect("the directory is readable")
+            .flatten()
+            .any(|entry| entry.file_name() == path.file_name().expect("the endpoint is a file"))
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn the_socket_a_killed_daemon_left_behind_does_not_stop_the_next_one() {
+        let endpoint = a_directory_for("killed").join("d.sock");
+        drop(UnixListener::bind(&endpoint).expect("the first daemon binds"));
+        assert!(
+            listed(&endpoint),
+            "a closed socket still occupies its path; without that this test proves nothing"
+        );
+
+        let listener = take_endpoint(&endpoint).expect("the next daemon takes the endpoint over");
+        assert!(
+            UnixStream::connect(&endpoint).is_ok(),
+            "the endpoint the next daemon bound is the one clients reach"
+        );
+        drop(listener);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn an_endpoint_a_live_daemon_answers_is_left_to_it() {
+        let endpoint = a_directory_for("live").join("d.sock");
+        let live = UnixListener::bind(&endpoint).expect("the running daemon binds");
+
+        let refused = take_endpoint(&endpoint).expect_err("a second daemon must not take it over");
+        assert_eq!(refused.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            UnixStream::connect(&endpoint).is_ok(),
+            "the running daemon still answers on the endpoint it owns"
+        );
+        drop(live);
+    }
+
+    /// The real blocker is a socket the filesystem will not let go of, which cannot be
+    /// manufactured in a test; a directory in the endpoint's place is the same shape —
+    /// something that cannot be removed and cannot be bound over — and it is what the
+    /// message has to survive. `daemon.log` used to carry the bare errno and nothing else,
+    /// which is a fatal error with no way to act on it.
+    #[cfg(windows)]
+    #[test]
+    fn an_endpoint_that_cannot_be_taken_says_which_one_and_why() {
+        let endpoint = a_directory_for("blocked").join("d.sock");
+        fs::create_dir(&endpoint).expect("something in the endpoint's place");
+
+        let refused = take_endpoint(&endpoint).expect_err("nothing can be bound there");
+        let reason = refused.to_string();
+        assert!(
+            reason.contains(&endpoint.display().to_string()),
+            "the failure must name the endpoint, got {reason}"
+        );
+        assert!(
+            reason.contains("could not be removed"),
+            "the failure must say what is in the way, got {reason}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_first_run_binds_an_endpoint_nothing_has_ever_used() {
+        let endpoint = a_directory_for("first-run").join("d.sock");
+        assert!(!listed(&endpoint));
+
+        let listener = take_endpoint(&endpoint).expect("the first daemon of a fresh install binds");
+        assert!(UnixStream::connect(&endpoint).is_ok());
+        drop(listener);
+    }
 
     /// Whether the announcement would be recognisable to a test, without demanding full
     /// wire equality in the queue-level tests.


### PR DESCRIPTION
A daemon killed outright — which on Windows is the ordinary ending, since the
client's job object terminates it — leaves its socket file on disk, and `bind`
over a socket file that is still there fails. The daemon already cleaned that
up, but only inside `if endpoint.exists()`, and that is the wrong question to
ask about a socket.

`Path::exists` opens the file to answer, and an AF_UNIX socket refuses to be
opened. Measured against a live listener on the reporting machine: the open
fails with `ERROR_CANT_ACCESS_FILE` (os error 1920) and `exists()` returns
false about a socket the directory plainly lists. The cleanup branch is then
dead, the bind goes ahead onto the occupied path, and the whole record of it is
one line in `daemon.log`:

```
ERROR tidemarkd: shutting down after a fatal error error=... (os error 10022)
```

The client, meanwhile, sees nothing serving the endpoint, spawns another
daemon, and that one dies the same way — "Waiting for Tidemark", indefinitely.

## The change

The question goes to the socket rather than to the filesystem. Only the answer
that means a live daemon is honoured — a connection that is *accepted* — and
everything else is a leftover or nothing at all, so the path is cleared before
the bind. Windows answers `ConnectionRefused` for a path that does not exist
rather than `NotFound`, so those two cannot be told apart and do not need to
be: removing what is not there is not an error.

What makes clearing it safe is that the caller already holds the
single-instance mutex (`run()` takes it before any shared state is opened), so
no second daemon of this build can be alive to own the file. The connect probe
stays as the belt to that braces.

Failing to remove what *is* there is not fatal on its own — the bind that
follows is what decides — but it is the likeliest reason that bind fails, so it
is carried into the message. Both failures now name the endpoint.

## Tests

Three of the four pin the contract rather than the defect, and pass on the old
code too: a killed daemon's socket does not stop the next one, a live daemon's
endpoint is left to it, a fresh install binds. A socket the filesystem refuses
to describe cannot be manufactured in-process — it took a machine whose AF_UNIX
namespace had been disturbed by repeated hard kills.

The fourth does fail on the old code, with exactly the shape that was reported:

```
the failure must name the endpoint, got Отказано в доступе. (os error 5)
```

A directory in the endpoint's place stands in for the unremovable socket — same
shape: cannot be removed, cannot be bound over — and the assertion is that the
error says which path and what was in the way.

## Verifying

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`
and `cargo test -p tidemarkd` on `x86_64-pc-windows-gnu`, MSYS2 UCRT64: 224
passed, 1 failed. The failure is `lifecycle::the_singleton_is_exclusive_within_this_session`,
which acquires the daemon's session-local named mutex and therefore cannot pass
on a machine where the installed daemon is running. Unrelated to this change,
and CI does not run one.

Left alone deliberately: the daemon does not unlink the endpoint on a clean
shutdown. It would not help the case this fixes, because the path that produces
the leftovers is the job object terminating the process, where no cleanup code
runs at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
