### PR TITLE
fix(windows): stop leaking GDI objects on card motion

### DIFF
--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -53,17 +53,28 @@ const PLATFORM_STYLE: &str = "
 .quota-card .quota-footer {
     font-size: 1em;
 }
+
+/* GskCairoRenderer leaks one Win32 memory DC and bitmap for each intermediate
+   box-shadow frame. Keep the lift animated, but change its shadow in one frame.
+   The leak is in GTK's Windows cairo path rather than this widget: the same
+   transition on an otherwise empty box grows the process GDI count linearly. */
+.quota-card {
+    transition: transform 150ms ease-out;
+}
 ";
 
 #[cfg(not(windows))]
-const PLATFORM_STYLE: &str = "";
+const PLATFORM_STYLE: &str = "
+.quota-card {
+    transition: transform 150ms ease-out, box-shadow 150ms ease-out;
+}
+";
 
 pub(crate) const STYLE: &str = "
 .quota-card {
     /* Less room under the footer than over the title: the last line sits low in the card,
        where a timestamp belongs, rather than floating in the middle of its own margin. */
     padding: 16px 16px 10px;
-    transition: transform 150ms ease-out, box-shadow 150ms ease-out;
 }
 
 .nested-account-connector {
@@ -222,4 +233,14 @@ pub fn load() {
         &provider,
         gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
     );
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    #[test]
+    fn windows_does_not_animate_card_shadows() {
+        assert!(!super::STYLE.contains("box-shadow 150ms"));
+        assert!(!super::PLATFORM_STYLE.contains("box-shadow 150ms"));
+        assert!(super::PLATFORM_STYLE.contains("transition: transform 150ms ease-out;"));
+    }
 }


### PR DESCRIPTION
On Windows, every animated card shadow left GDI resources behind in GTK's cairo renderer. Repeated hover and drag interactions eventually reached the per-process 10,000-object quota and crashed in `libcairo-2.dll`; the leaked objects were almost exactly paired memory DCs and bitmaps.

Keep the card's 150 ms lift animation on Windows, but apply its shadow immediately. Linux retains the existing transform and shadow transition. A standalone GTK reproduction grew by 1,996 GDI objects over 40 shadow transitions, while an immediate shadow change grew by 4 and then stayed flat.

Validation:

- installed release build, 40 hover cycles: 102 -> 102 GDI objects
- installed release build, 20 drag cycles: 102 -> 107, with no linear growth
- `cargo fmt --all --check`
- `cargo clippy --target x86_64-pc-windows-gnu --workspace --all-targets -- -D warnings`
- `GDK_BACKEND=wayland cargo test --target x86_64-pc-windows-gnu --workspace`
