### PR TITLE
feat(preferences): add theme selection

### DIFF
--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -46,6 +46,7 @@ const NOTIFY_WINDOWS_KEY: &str = "windows";
 
 const GENERAL_TABLE: &str = "general";
 const MINIMIZE_ON_CLOSE_KEY: &str = "minimize_on_close";
+const THEME_KEY: &str = "theme";
 const STARTUP_KEY: &str = "startup";
 const UPDATES_TABLE: &str = "updates";
 const RELEASE_CHECK_KEY: &str = "check";
@@ -208,6 +209,17 @@ impl Config {
                 format!("has unknown value {startup_mode:?}"),
             ));
         }
+        let theme = self
+            .preference_string(GENERAL_TABLE, THEME_KEY)?
+            .unwrap_or(Preferences::THEME_SYSTEM)
+            .to_owned();
+        if !Preferences::valid_theme(&theme) {
+            return Err(self.invalid_preference(
+                GENERAL_TABLE,
+                THEME_KEY,
+                format!("has unknown value {theme:?}"),
+            ));
+        }
         let proxy_mode = self
             .preference_string(PROXY_TABLE, PROXY_MODE_KEY)?
             .unwrap_or(defaults.proxy_mode.as_str())
@@ -254,6 +266,7 @@ impl Config {
             minimize_on_close: self
                 .preference_bool(GENERAL_TABLE, MINIMIZE_ON_CLOSE_KEY)?
                 .unwrap_or(defaults.minimize_on_close),
+            theme: Some(theme),
             startup_mode,
             history_retention,
             proxy_mode,
@@ -284,6 +297,17 @@ impl Config {
 
     pub fn set_minimize_on_close(&mut self, enabled: bool) -> Result<(), ConfigError> {
         self.set_preference(GENERAL_TABLE, MINIMIZE_ON_CLOSE_KEY, value(enabled))
+    }
+
+    pub fn set_theme(&mut self, theme: &str) -> Result<(), ConfigError> {
+        if !Preferences::valid_theme(theme) {
+            return Err(self.invalid_preference(
+                GENERAL_TABLE,
+                THEME_KEY,
+                format!("has unknown value {theme:?}"),
+            ));
+        }
+        self.set_preference(GENERAL_TABLE, THEME_KEY, value(theme))
     }
 
     pub fn set_startup_mode(&mut self, mode: &str) -> Result<(), ConfigError> {
@@ -1726,6 +1750,35 @@ mod tests {
     }
 
     #[test]
+    fn a_theme_choice_round_trips_without_changing_an_unset_config() {
+        let path = scratch("preferences-theme");
+        std::fs::write(&path, "# stays intact\n[general]\nstartup = \"app\"\n").expect("seeded");
+        let mut config = Config::at(path.clone()).expect("loaded");
+
+        assert_eq!(
+            config
+                .preferences()
+                .expect("default theme")
+                .theme
+                .as_deref(),
+            Some("system")
+        );
+        config.set_theme("light").expect("light theme");
+
+        let reread = Config::at(path.clone()).expect("reloaded");
+        assert_eq!(
+            reread.preferences().expect("stored theme").theme.as_deref(),
+            Some("light")
+        );
+        assert!(
+            std::fs::read_to_string(&path)
+                .expect("read back")
+                .contains("# stays intact")
+        );
+        assert!(config.set_theme("night").is_err());
+    }
+
+    #[test]
     fn application_preferences_survive_a_round_trip_without_rewriting_the_file() {
         let path = scratch("preferences-roundtrip");
         std::fs::write(&path, "# belongs to the user\nproviders = []\n").expect("seeded");
@@ -1733,6 +1786,7 @@ mod tests {
         let preferences = tidemark_types::Preferences {
             release_check: false,
             minimize_on_close: false,
+            theme: Some("light".into()),
             startup_mode: "daemon".into(),
             history_retention: "six-months".into(),
             proxy_mode: "socks5".into(),
@@ -1744,6 +1798,7 @@ mod tests {
 
         config.set_release_check(false).expect("release setting");
         config.set_minimize_on_close(false).expect("close setting");
+        config.set_theme("light").expect("theme setting");
         config.set_startup_mode("daemon").expect("startup mode");
         config
             .set_history_retention("six-months")

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -460,6 +460,9 @@ pub struct Preferences {
     pub release_check: bool,
     /// Whether the window's close button hides it when a tray icon can bring it back.
     pub minimize_on_close: bool,
+    /// `system`, `light`, or `dark`: whether the client follows the desktop or forces a theme.
+    /// Absent means system, so a newer client can still read an older daemon's dictionary.
+    pub theme: Option<String>,
     /// `app`, `daemon`, or `off`: the one coherent login-start behavior.
     pub startup_mode: String,
     /// `forever`, `six-months`, or `one-year`.
@@ -488,6 +491,10 @@ impl Preferences {
     pub const STARTUP_DAEMON: &'static str = "daemon";
     pub const STARTUP_OFF: &'static str = "off";
 
+    pub const THEME_SYSTEM: &'static str = "system";
+    pub const THEME_LIGHT: &'static str = "light";
+    pub const THEME_DARK: &'static str = "dark";
+
     pub const RETENTION_FOREVER: &'static str = "forever";
     pub const RETENTION_SIX_MONTHS: &'static str = "six-months";
     pub const RETENTION_ONE_YEAR: &'static str = "one-year";
@@ -505,6 +512,14 @@ impl Preferences {
         matches!(
             value,
             Self::STARTUP_APP | Self::STARTUP_DAEMON | Self::STARTUP_OFF
+        )
+    }
+
+    /// Whether this build knows the named appearance choice.
+    pub fn valid_theme(value: &str) -> bool {
+        matches!(
+            value,
+            Self::THEME_SYSTEM | Self::THEME_LIGHT | Self::THEME_DARK
         )
     }
 
@@ -542,6 +557,7 @@ impl Default for Preferences {
         Self {
             release_check: true,
             minimize_on_close: true,
+            theme: Some(Self::THEME_SYSTEM.into()),
             startup_mode: Self::STARTUP_APP.into(),
             history_retention: Self::RETENTION_FOREVER.into(),
             proxy_mode: Self::PROXY_OFF.into(),
@@ -1190,6 +1206,7 @@ mod tests {
         let original = Preferences {
             release_check: false,
             minimize_on_close: false,
+            theme: Some("dark".into()),
             startup_mode: "daemon".into(),
             history_retention: "one-year".into(),
             proxy_mode: "socks5".into(),
@@ -1202,6 +1219,20 @@ mod tests {
         let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
         let (decoded, _): (Preferences, _) = encoded.deserialize().expect("decodes again");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn an_older_preferences_dictionary_without_theme_still_decodes() {
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &Preferences::default())
+            .expect("the current dictionary encodes");
+        let (mut old_dict, _): (HashMap<String, OwnedValue>, _) =
+            encoded.deserialize().expect("decodes as a dictionary");
+        assert!(old_dict.remove("theme").is_some());
+        let old_encoded =
+            to_bytes(Context::new_dbus(LE, 0), &old_dict).expect("the old dictionary encodes");
+
+        let (decoded, _): (Preferences, _) = old_encoded.deserialize().expect("still decodes");
+        assert_eq!(decoded.theme, None);
     }
 
     #[test]
@@ -1229,5 +1260,19 @@ mod tests {
         }
         assert!(!Preferences::valid_proxy_mode("socks4"));
         assert!(!Preferences::valid_proxy_mode(""));
+    }
+
+    #[test]
+    fn only_system_light_and_dark_themes_are_known() {
+        for theme in [
+            Preferences::THEME_SYSTEM,
+            Preferences::THEME_LIGHT,
+            Preferences::THEME_DARK,
+        ] {
+            assert!(Preferences::valid_theme(theme), "{theme}");
+        }
+        assert!(!Preferences::valid_theme("night"));
+        assert!(!Preferences::valid_theme(""));
+        assert_eq!(Preferences::default().theme.as_deref(), Some("system"));
     }
 }

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -130,6 +130,7 @@ pub trait Daemon {
 
     fn set_release_check(&self, enabled: bool) -> zbus::Result<()>;
     fn set_minimize_on_close(&self, enabled: bool) -> zbus::Result<()>;
+    fn set_theme(&self, theme: &str) -> zbus::Result<()>;
     fn set_startup_mode(&self, mode: &str) -> zbus::Result<()>;
     fn set_history_retention(&self, retention: &str) -> zbus::Result<()>;
 

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -37,6 +37,7 @@ mod provider_settings;
 #[cfg(windows)]
 mod single_instance;
 mod style;
+mod theme;
 mod tray;
 #[cfg(windows)]
 mod tray_icon_rgba;
@@ -164,6 +165,22 @@ mod tests {
     #[test]
     fn ordinary_launch_requests_a_visible_start() {
         assert!(!background_requested(["tidemark"]));
+    }
+
+    #[test]
+    fn every_theme_choice_maps_to_its_libadwaita_scheme() {
+        assert_eq!(
+            crate::theme::color_scheme("system"),
+            adw::ColorScheme::Default
+        );
+        assert_eq!(
+            crate::theme::color_scheme("light"),
+            adw::ColorScheme::ForceLight
+        );
+        assert_eq!(
+            crate::theme::color_scheme("dark"),
+            adw::ColorScheme::ForceDark
+        );
     }
 
     #[cfg(windows)]

--- a/crates/tidemark/src/preferences.rs
+++ b/crates/tidemark/src/preferences.rs
@@ -27,6 +27,15 @@ const STARTUP_VALUES: [&str; 3] = [
 /// What the startup values above are called on screen, in the same order.
 const STARTUP_LABELS: [&str; 3] = ["App and tray", "Daemon only", "Off"];
 
+const THEME_VALUES: [&str; 3] = [
+    Preferences::THEME_SYSTEM,
+    Preferences::THEME_LIGHT,
+    Preferences::THEME_DARK,
+];
+
+/// What the appearance choices above are called on screen, in the same order.
+const THEME_LABELS: [&str; 3] = ["System", "Light", "Dark"];
+
 const PROXY_VALUES: [&str; 4] = [
     Preferences::PROXY_OFF,
     Preferences::PROXY_HTTP,
@@ -62,6 +71,7 @@ pub struct PreferencesDialog {
     minimize_on_close: adw::SwitchRow,
     refresh_auto: adw::SwitchRow,
     refresh_minutes: adw::SpinRow,
+    theme: adw::ComboRow,
     startup: adw::ComboRow,
     retention: adw::ComboRow,
     proxy_mode: adw::ComboRow,
@@ -107,10 +117,24 @@ impl PreferencesDialog {
             .use_subtitle(true)
             .build();
 
+        let theme = adw::ComboRow::builder()
+            .title("Theme")
+            .subtitle("Choose whether Tidemark follows your system appearance.")
+            .model(&gtk::StringList::new(&THEME_LABELS))
+            .expression(gtk::PropertyExpression::new(
+                gtk::StringObject::static_type(),
+                None::<gtk::Expression>,
+                "string",
+            ))
+            .use_subtitle(true)
+            .build();
+
         let behavior = adw::PreferencesGroup::builder().title("Behavior").build();
         behavior.add(&minimize_on_close);
         let startup = adw::PreferencesGroup::builder().title("Startup").build();
         startup.add(&startup_mode);
+        let theme_group = adw::PreferencesGroup::builder().title("Theme").build();
+        theme_group.add(&theme);
         // The subtitle stays vague on purpose: which zone buys which pace is the daemon's
         // business, and a number here would be a second truth to keep in step with
         // `CONTEXT.md`.
@@ -136,6 +160,7 @@ impl PreferencesDialog {
             .build();
         general.add(&behavior);
         general.add(&startup);
+        general.add(&theme_group);
         general.add(&refresh_group);
         dialog.add(&general);
 
@@ -252,6 +277,7 @@ impl PreferencesDialog {
             minimize_on_close,
             refresh_auto,
             refresh_minutes,
+            theme,
             startup: startup_mode,
             retention,
             proxy_mode,
@@ -270,6 +296,7 @@ impl PreferencesDialog {
         settings.connect_switch(&settings.release_check, SwitchKind::ReleaseCheck);
         settings.connect_switch(&settings.minimize_on_close, SwitchKind::MinimizeOnClose);
         settings.connect_switch(&settings.refresh_auto, SwitchKind::RefreshAuto);
+        settings.connect_theme();
         settings.connect_startup();
         settings.connect_retention();
         settings.connect_proxy();
@@ -301,6 +328,20 @@ impl PreferencesDialog {
             .set_active(preferences.refresh_mode == Preferences::REFRESH_AUTO);
         self.refresh_minutes
             .set_value(f64::from(preferences.refresh_minutes));
+        apply_named_choice(
+            &self.theme,
+            &THEME_LABELS,
+            theme_index(
+                preferences
+                    .theme
+                    .as_deref()
+                    .unwrap_or(Preferences::THEME_SYSTEM),
+            ),
+            preferences
+                .theme
+                .as_deref()
+                .unwrap_or(Preferences::THEME_SYSTEM),
+        );
         apply_named_choice(
             &self.startup,
             &STARTUP_LABELS,
@@ -479,6 +520,37 @@ impl PreferencesDialog {
                         settings.toast(&error.to_string());
                     } else {
                         settings.preferences.borrow_mut().startup_mode = mode;
+                    }
+                    row.set_sensitive(true);
+                });
+            }
+        });
+    }
+
+    fn connect_theme(self: &Rc<Self>) {
+        self.theme.connect_selected_notify({
+            let weak = Rc::downgrade(self);
+            move |row| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                if settings.suppress.get() {
+                    return;
+                }
+                let Some(theme) = THEME_VALUES.get(row.selected() as usize) else {
+                    return;
+                };
+                let theme = (*theme).to_owned();
+                row.set_sensitive(false);
+                let row = row.clone();
+                glib::spawn_future_local(async move {
+                    if let Err(error) = settings.proxy.set_theme(&theme).await {
+                        let preferences = settings.preferences.borrow().clone();
+                        let data = settings.data.borrow().clone();
+                        settings.apply(&preferences, &data);
+                        settings.toast(&error.to_string());
+                    } else {
+                        settings.preferences.borrow_mut().theme = Some(theme);
                     }
                     row.set_sensitive(true);
                 });
@@ -747,6 +819,13 @@ fn startup_index(value: &str) -> Option<u32> {
         .map(|index| index as u32)
 }
 
+fn theme_index(value: &str) -> Option<u32> {
+    THEME_VALUES
+        .iter()
+        .position(|candidate| *candidate == value)
+        .map(|index| index as u32)
+}
+
 fn proxy_index(value: &str) -> Option<u32> {
     PROXY_VALUES
         .iter()
@@ -808,6 +887,14 @@ mod tests {
         assert_eq!(startup_index(Preferences::STARTUP_DAEMON), Some(1));
         assert_eq!(startup_index(Preferences::STARTUP_OFF), Some(2));
         assert_eq!(startup_index("everything"), None);
+    }
+
+    #[test]
+    fn every_theme_selects_its_named_row() {
+        assert_eq!(theme_index(Preferences::THEME_SYSTEM), Some(0));
+        assert_eq!(theme_index(Preferences::THEME_LIGHT), Some(1));
+        assert_eq!(theme_index(Preferences::THEME_DARK), Some(2));
+        assert_eq!(theme_index("night"), None);
     }
 
     #[test]

--- a/crates/tidemark/src/theme.rs
+++ b/crates/tidemark/src/theme.rs
@@ -1,0 +1,18 @@
+//! The user's appearance choice, applied to libadwaita's process-wide style manager.
+
+use tidemark_types::Preferences;
+
+/// Applies the stored appearance choice to every current and future application surface.
+pub(crate) fn apply(theme: &str) {
+    adw::StyleManager::default().set_color_scheme(color_scheme(theme));
+}
+
+/// The libadwaita policy corresponding to one stored choice.
+pub(crate) fn color_scheme(theme: &str) -> adw::ColorScheme {
+    match theme {
+        Preferences::THEME_LIGHT => adw::ColorScheme::ForceLight,
+        Preferences::THEME_DARK => adw::ColorScheme::ForceDark,
+        Preferences::THEME_SYSTEM => adw::ColorScheme::Default,
+        _ => adw::ColorScheme::Default,
+    }
+}

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -656,6 +656,12 @@ impl MainWindow {
 
     fn apply_preferences(&self, preferences: AppPreferences) {
         self.minimize_on_close.set(preferences.minimize_on_close);
+        crate::theme::apply(
+            preferences
+                .theme
+                .as_deref()
+                .unwrap_or(AppPreferences::THEME_SYSTEM),
+        );
         *self.preferences.borrow_mut() = preferences;
         if let Some(dialog) = self.preferences_dialog.get() {
             dialog.apply(&self.preferences.borrow(), &self.data_info.borrow());

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -61,6 +61,7 @@ pub enum Publication {
 pub enum Preference {
     ReleaseCheck(bool),
     MinimizeOnClose(bool),
+    Theme(String),
     StartupMode(String),
     HistoryRetention(String),
     RefreshMode(String),
@@ -1270,6 +1271,7 @@ impl Engine {
         match preference {
             Preference::ReleaseCheck(enabled) => config.set_release_check(enabled),
             Preference::MinimizeOnClose(enabled) => config.set_minimize_on_close(enabled),
+            Preference::Theme(theme) => config.set_theme(&theme),
             Preference::StartupMode(mode) => config.set_startup_mode(&mode),
             Preference::HistoryRetention(retention) => config.set_history_retention(&retention),
             Preference::RefreshMode(mode) => config.set_refresh_mode(&mode),
@@ -4806,6 +4808,7 @@ mod tests {
             Preferences {
                 release_check: false,
                 minimize_on_close: false,
+                theme: Some(Preferences::THEME_SYSTEM.into()),
                 startup_mode: Preferences::STARTUP_DAEMON.into(),
                 history_retention: Preferences::RETENTION_SIX_MONTHS.into(),
                 proxy_mode: Preferences::PROXY_OFF.into(),
@@ -4821,6 +4824,28 @@ mod tests {
                 .preferences()
                 .expect("readable"),
             preferences
+        );
+    }
+
+    #[tokio::test]
+    async fn a_theme_change_is_serialized_through_the_engine() {
+        let mut harness = Harness::empty("application-theme").await;
+
+        let preferences = harness
+            .engine
+            .set_preference(Preference::Theme(Preferences::THEME_DARK.into()))
+            .await
+            .expect("theme changed");
+
+        assert_eq!(preferences.theme.as_deref(), Some("dark"));
+        assert_eq!(
+            Config::at(harness.config_path)
+                .expect("reloaded")
+                .preferences()
+                .expect("readable")
+                .theme
+                .as_deref(),
+            Some("dark")
         );
     }
 

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -1332,6 +1332,22 @@ impl Daemon {
         self.publish_preferences(&emitter, preferences).await
     }
 
+    /// Chooses whether the client follows the system appearance or forces a theme.
+    async fn set_theme(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        theme: &str,
+    ) -> fdo::Result<()> {
+        if !Preferences::valid_theme(theme) {
+            return Err(fdo::Error::InvalidArgs(format!("unknown theme {theme:?}")));
+        }
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::Theme(theme.into()))
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
     /// Chooses the one coherent login-start mode: app, daemon only, or off.
     async fn set_startup_mode(
         &self,
@@ -4436,6 +4452,37 @@ mod tests {
             panic!("unexpected command");
         };
         assert!(matches!(preference, Preference::RefreshMinutes(30)));
+        reply
+            .send(Ok(Preferences::default()))
+            .expect("caller waits for reply");
+        changing
+            .await
+            .expect("task did not panic")
+            .expect("accepted");
+    }
+
+    #[tokio::test]
+    async fn a_theme_change_reaches_the_engine_and_publishes_the_dict() {
+        let (daemon, _secrets, mut commands) = daemon_over(Vec::new()).await;
+        let daemon = Arc::new(daemon);
+        let Ok(connection) = zbus::Connection::session().await else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+        let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH).expect("a valid path");
+
+        let changing = {
+            let daemon = Arc::clone(&daemon);
+            tokio::spawn(async move { daemon.set_theme(emitter, "dark").await })
+        };
+        let Command::SetPreference { preference, reply } = commands
+            .recv()
+            .await
+            .expect("the change reaches the engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert!(matches!(preference, Preference::Theme(theme) if theme == "dark"));
         reply
             .send(Ok(Preferences::default()))
             .expect("caller waits for reply");


### PR DESCRIPTION
## Summary
- add System, Light, and Dark theme choices under Preferences > General > Theme
- persist the setting through the existing daemon-backed config and D-Bus preferences stream
- apply the selected libadwaita appearance immediately across Linux and Windows
- preserve compatibility with older daemons that omit the new dictionary key

## Verification
- cargo fmt --all --check`n- cargo clippy --workspace --all-targets -- -D warnings`n- targeted theme/config/D-Bus/UI tests
- scripts/check-layering.sh`n- cargo test --workspace -q (all relevant suites pass; the known daemon singleton test conflicts with the running installed daemon on this machine)