### PR TITLE
feat(codex): multi CLI homes and Business spend windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ notifications stay current. Native GTK4 + libadwaita — no Electron, no embedde
   exposes, each with its own reset time.
 - **Several accounts per provider.** A work and a personal Claude, two Z.ai keys — grouped
   behind an expand toggle.
+  A second Codex CLI login needs its own CODEX_HOME; set **CLI home** on the extra account (see docs/codex-business-and-multi-cli.md).
 - **A pace mark on every bar.** Fill to the left of the mark means the quota likely lasts until
   the reset; fill to the right means it does not.
 - **Warnings at 70% and 90%,** plus a notification when a window resets. Off by default,

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -30,6 +30,10 @@ const PROVIDER_TABLE: &str = "provider";
 const PROVIDERS_KEY: &str = "providers";
 /// The account ids configured for a provider.
 const ACCOUNTS_KEY: &str = "accounts";
+/// Nested table for per-account settings: `[provider.<slug>.account.<id>]`.
+const ACCOUNT_TABLE: &str = "account";
+/// Absolute `CODEX_HOME` (or Claude-equivalent home) for one account.
+pub const CLI_HOME_KEY: &str = "cli-home";
 /// The shared storage keys used by browser-cookie authentication providers.
 const AUTH_SOURCE_KEY: &str = "auth-source";
 const AUTH_BROWSER_KEY: &str = "auth-browser";
@@ -117,6 +121,20 @@ pub enum ConfigError {
         /// Whose list it is.
         provider: String,
         /// Why the account list is invalid.
+        reason: String,
+    },
+    /// A per-account setting was the wrong shape.
+    #[error("{path}: [{PROVIDER_TABLE}.{provider}.{ACCOUNT_TABLE}.{account}] {name} {reason}")]
+    InvalidAccountOption {
+        /// The file.
+        path: PathBuf,
+        /// Provider slug.
+        provider: String,
+        /// Account id.
+        account: String,
+        /// Setting name.
+        name: String,
+        /// Why it was refused.
         reason: String,
     },
     /// A provider's notification opt-in list is not an array of window keys.
@@ -493,6 +511,35 @@ impl Config {
             .as_str()
     }
 
+    /// One per-account setting, falling back to the provider-level key for `"default"`.
+    ///
+    /// Extra Codex accounts store their own `cli-home` / `source` here so a second CLI
+    /// install does not have to share `~/.codex` with the default account.
+    pub fn account_option(&self, provider: &str, account: &str, name: &str) -> Option<&str> {
+        self.document
+            .get(PROVIDER_TABLE)
+            .and_then(|table| table.get(provider))
+            .and_then(|table| table.get(ACCOUNT_TABLE))
+            .and_then(|table| table.get(account))
+            .and_then(|table| table.get(name))
+            .and_then(|item| item.as_str())
+            .or_else(|| {
+                if account == "default" {
+                    self.option(provider, name)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Absolute CLI home directory for this account, when configured.
+    pub fn cli_home(&self, provider: &str, account: &str) -> Option<PathBuf> {
+        self.account_option(provider, account, CLI_HOME_KEY)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    }
+
     /// Returns configured providers in file order, with duplicates removed.
     pub fn providers(&self) -> Result<Vec<String>, ConfigError> {
         let Some(item) = self.document.get(PROVIDERS_KEY) else {
@@ -705,6 +752,63 @@ impl Config {
                 table: format!("{PROVIDER_TABLE}.{provider}"),
             })?;
         table.insert(name, value(setting));
+        self.write()
+    }
+
+    /// Sets one per-account setting under `[provider.<slug>.account.<id>]` and writes.
+    ///
+    /// An empty `setting` removes the key so clearing a CLI home returns the account to
+    /// Tidemark-login-only for extras.
+    pub fn set_account_option(
+        &mut self,
+        provider: &str,
+        account: &str,
+        name: &str,
+        setting: &str,
+    ) -> Result<(), ConfigError> {
+        self.normalize_providers(None)?;
+        let providers = self
+            .document
+            .entry(PROVIDER_TABLE)
+            .or_insert_with(|| Item::Table(implicit_table()));
+        let providers = providers
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: PROVIDER_TABLE.to_owned(),
+            })?;
+        let provider_table = providers
+            .entry(provider)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let provider_table = provider_table
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: format!("{PROVIDER_TABLE}.{provider}"),
+            })?;
+        let accounts = provider_table
+            .entry(ACCOUNT_TABLE)
+            .or_insert_with(|| Item::Table(implicit_table()));
+        let accounts = accounts
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: format!("{PROVIDER_TABLE}.{provider}.{ACCOUNT_TABLE}"),
+            })?;
+        let account_table = accounts
+            .entry(account)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let account_table = account_table
+            .as_table_like_mut()
+            .ok_or_else(|| ConfigError::NotATable {
+                path: self.path.clone(),
+                table: format!("{PROVIDER_TABLE}.{provider}.{ACCOUNT_TABLE}.{account}"),
+            })?;
+        if setting.is_empty() {
+            account_table.remove(name);
+        } else {
+            account_table.insert(name, value(setting));
+        }
         self.write()
     }
 
@@ -1883,5 +1987,43 @@ mod tests {
             );
             let _ = std::fs::remove_file(path);
         }
+    }
+
+
+    #[test]
+    fn account_cli_home_is_read_from_the_nested_table() {
+        let path = scratch("account-cli-home");
+        std::fs::write(
+            &path,
+            "[provider.codex.account.work]\ncli-home = "/tmp/codex-work"\nsource = "cli"\n",
+        )
+        .expect("seed");
+        let config = Config::at(path.clone()).expect("parses");
+        assert_eq!(
+            config.account_option("codex", "work", "cli-home"),
+            Some("/tmp/codex-work")
+        );
+        assert_eq!(
+            config.cli_home("codex", "work").as_deref(),
+            Some(std::path::Path::new("/tmp/codex-work"))
+        );
+        assert_eq!(config.account_option("codex", "work", "source"), Some("cli"));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn set_account_option_round_trips_cli_home() {
+        let path = scratch("set-account-cli-home");
+        std::fs::write(&path, "providers = ["codex"]\n").expect("seed");
+        let mut config = Config::at(path.clone()).expect("parses");
+        config
+            .set_account_option("codex", "work", "cli-home", "/var/codex-work")
+            .expect("writes");
+        let reread = Config::at(path.clone()).expect("reparses");
+        assert_eq!(
+            reread.cli_home("codex", "work").as_deref(),
+            Some(std::path::Path::new("/var/codex-work"))
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 }

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -1995,7 +1995,10 @@ mod tests {
         let path = scratch("account-cli-home");
         std::fs::write(
             &path,
-            "[provider.codex.account.work]\ncli-home = "/tmp/codex-work"\nsource = "cli"\n",
+            r#"[provider.codex.account.work]
+cli-home = "/tmp/codex-work"
+source = "cli"
+"#,
         )
         .expect("seed");
         let config = Config::at(path.clone()).expect("parses");
@@ -2014,7 +2017,8 @@ mod tests {
     #[test]
     fn set_account_option_round_trips_cli_home() {
         let path = scratch("set-account-cli-home");
-        std::fs::write(&path, "providers = ["codex"]\n").expect("seed");
+        std::fs::write(&path, r#"providers = ["codex"]
+"#).expect("seed");
         let mut config = Config::at(path.clone()).expect("parses");
         config
             .set_account_option("codex", "work", "cli-home", "/var/codex-work")

--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -164,23 +164,48 @@ pub struct Codex {
 fn credentials_for(
     account: &AccountId,
     source: Source,
+    cli_home: Option<&Path>,
 ) -> Result<Option<CredentialFile>, ProviderError> {
-    if account.as_str() != "default" && source == Source::OAuth {
-        return Ok(None);
+    // Extra accounts only open a CLI file when they name one: otherwise they would share
+    // ~/.codex with the default account, which is the single-CLI trap this path exists to
+    // avoid. OAuth extras keep no file at all.
+    if account.as_str() != "default" && cli_home.is_none() {
+        return match source {
+            Source::Cli => Err(ProviderError::Local(
+                "extra Codex accounts need cli-home set to that install's CODEX_HOME".into(),
+            )),
+            Source::OAuth | Source::Auto => Ok(None),
+        };
     }
-    let path = cli_credentials_path()
-        .ok_or_else(|| ProviderError::Local("HOME does not name an absolute directory".into()))?;
+    let path = match cli_home {
+        Some(home) => {
+            if !home.is_absolute() {
+                return Err(ProviderError::Local(
+                    "Codex CLI home must be an absolute directory".into(),
+                ));
+            }
+            home.join("auth.json")
+        }
+        None => cli_credentials_path().ok_or_else(|| {
+            ProviderError::Local("HOME does not name an absolute directory".into())
+        })?,
+    };
     Ok(Some(CredentialFile::new(path.clone(), path)))
 }
 
 impl Codex {
     /// Builds the canonical Codex account when this account uses its vendor login.
+    ///
+    /// `cli_home` is an optional absolute `CODEX_HOME` for this account. The default account
+    /// falls back to `$CODEX_HOME` / `~/.codex`; an extra account needs one to read a second
+    /// CLI login instead of only the Tidemark keyring.
     pub fn new(
         account: AccountId,
         own: Option<Arc<dyn Secrets>>,
         source: Source,
+        cli_home: Option<PathBuf>,
     ) -> Result<Self, ProviderError> {
-        let credentials = credentials_for(&account, source)?;
+        let credentials = credentials_for(&account, source, cli_home.as_deref())?;
         let mut codex =
             Self::with_credentials(credentials, USAGE_URL.to_owned(), REFRESH_URL.to_owned())?;
         codex.own = own;
@@ -513,6 +538,59 @@ pub fn cli_credentials_path() -> Option<PathBuf> {
     Some(home.join(".codex/auth.json"))
 }
 
+/// Codex CLI homes on this machine that already hold an `auth.json`.
+///
+/// Includes the ambient `$CODEX_HOME` / `~/.codex` directory and every sibling under
+/// `~/.codex-profiles/*` that looks like a second install. Used to offer a menu of CLIs
+/// instead of forcing a second account onto Tidemark login.
+pub fn discover_cli_homes() -> Vec<PathBuf> {
+    let mut homes = Vec::new();
+    let mut push = |home: PathBuf| {
+        if !home.is_absolute() {
+            return;
+        }
+        if !home.join("auth.json").is_file() {
+            return;
+        }
+        if !homes.iter().any(|seen| seen == &home) {
+            homes.push(home);
+        }
+    };
+    if let Some(path) = cli_credentials_path() {
+        if let Some(home) = path.parent() {
+            push(home.to_path_buf());
+        }
+    }
+    if let Some(user_home) = crate::paths::home() {
+        let profiles = user_home.join(".codex-profiles");
+        if let Ok(entries) = std::fs::read_dir(&profiles) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    push(path);
+                }
+            }
+        }
+    }
+    homes.sort();
+    homes
+}
+
+/// Wire `plan_type` as a person reads it, including OpenAI's Business seat spellings.
+fn plan_label(raw: &str) -> String {
+    match raw.trim() {
+        "business" => "Business".to_owned(),
+        "self_serve_business_usage_based" => "Business (usage-based)".to_owned(),
+        "self_serve_business_prolite" => "Business Standard".to_owned(),
+        "enterprise_cbp_usage_based" => "Enterprise (usage-based)".to_owned(),
+        "enterprise_cbp_automation" => "Enterprise (automation)".to_owned(),
+        "ent26" => "Enterprise".to_owned(),
+        "prolite" => "Pro Lite".to_owned(),
+        "free_workspace" => "Free Workspace".to_owned(),
+        other => title_case(other),
+    }
+}
+
 /// Turns a usage response into a snapshot.
 pub fn parse(body: &str, captured_at: Timestamp) -> Result<Snapshot, ProviderError> {
     parse_for_account(body, captured_at, &AccountId::default())
@@ -591,12 +669,68 @@ fn parse_for_account(
         )?;
     }
 
+    // Business seats often report no rate_limit windows at all and put the only quota under
+    // spend_control.individual_limit. Without this, a working Business login looks empty.
+    if windows.is_empty() {
+        if let Some(window) = spend_window(envelope.spend_control.as_ref(), captured_at) {
+            windows.push(window);
+        }
+    }
+
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
         account: account.clone(),
         captured_at,
         windows,
         details: details(&envelope),
+    })
+}
+
+/// A spend-control allowance as a window, when it is the account's only quota signal.
+fn spend_window(control: Option<&SpendControl>, captured_at: Timestamp) -> Option<Window> {
+    let limit = control?.individual_limit.as_ref()?;
+    let used_percent = limit.used_percent?.clamp(0.0, 100.0);
+    let resets_at = limit
+        .reset_at
+        .and_then(|seconds| Timestamp::from_unix(seconds).ok())
+        .or_else(|| {
+            limit
+                .reset_after_seconds
+                .filter(|seconds| *seconds >= 0)
+                .map(|seconds| captured_at.saturating_add_seconds(seconds))
+        });
+    let length = limit
+        .reset_after_seconds
+        .filter(|seconds| *seconds > 0)
+        .and_then(|seconds| WindowLength::from_secs(seconds as u64))
+        .or_else(|| {
+            resets_at.and_then(|reset| {
+                let seconds = reset.as_unix().saturating_sub(captured_at.as_unix());
+                (seconds > 0)
+                    .then_some(seconds as u64)
+                    .and_then(WindowLength::from_secs)
+            })
+        });
+    let subtitle = match (limit.used.as_ref(), limit.limit.as_ref()) {
+        (Some(used), Some(cap)) => {
+            Some(format!("{} of {}", trim_number(used.0), trim_number(cap.0)))
+        }
+        _ => None,
+    };
+    let (key, title) = match length {
+        Some(length) => (
+            WindowKey::for_pool("spend", length),
+            format!("Spend · {}", length_title(length)),
+        ),
+        None => (WindowKey::named("spend"), "Spend".to_owned()),
+    };
+    Some(Window {
+        key,
+        title,
+        subtitle,
+        used_percent,
+        resets_at,
+        length,
     })
 }
 
@@ -721,12 +855,56 @@ struct SpendControl {
     individual_limit: Option<IndividualLimit>,
 }
 
+/// Business / workspace seats often put the only quota here. `limit` and `used` arrive as
+/// strings on some plan types and as numbers on others; either must parse.
 #[derive(Debug, Deserialize)]
 struct IndividualLimit {
     #[serde(default)]
-    limit: Option<f64>,
+    limit: Option<FlexNumber>,
     #[serde(default)]
-    used: Option<f64>,
+    used: Option<FlexNumber>,
+    #[serde(default)]
+    used_percent: Option<f64>,
+    #[serde(default)]
+    reset_after_seconds: Option<i64>,
+    #[serde(default)]
+    reset_at: Option<i64>,
+}
+
+/// A quantity that WHAM may send as a JSON number or as a decimal string.
+#[derive(Debug, Clone)]
+struct FlexNumber(f64);
+
+impl<'de> Deserialize<'de> for FlexNumber {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = FlexNumber;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a number or a decimal string")
+            }
+            fn visit_f64<E: serde::de::Error>(self, value: f64) -> Result<Self::Value, E> {
+                Ok(FlexNumber(value))
+            }
+            fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<Self::Value, E> {
+                Ok(FlexNumber(value as f64))
+            }
+            fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+                Ok(FlexNumber(value as f64))
+            }
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                value
+                    .trim()
+                    .parse()
+                    .map(FlexNumber)
+                    .map_err(E::custom)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -740,7 +918,7 @@ struct ResetCredits {
 fn details(envelope: &Envelope) -> Vec<DetailSection> {
     let mut sections = Vec::new();
 
-    if let Some(plan) = envelope.plan_type.as_deref().map(title_case) {
+    if let Some(plan) = envelope.plan_type.as_deref().map(plan_label) {
         sections.push(DetailSection {
             title: DetailSection::PLAN.to_owned(),
             rows: vec![DetailRow {
@@ -792,19 +970,23 @@ fn details(envelope: &Envelope) -> Vec<DetailSection> {
         });
     }
 
-    if let Some((used, limit)) = envelope
+    // Absolute spend figures stay in details when present. The percentage is drawn as a
+    // window when rate_limit is empty (see spend_window); repeating it here would only
+    // duplicate the card.
+    if let Some(limit) = envelope
         .spend_control
         .as_ref()
         .and_then(|control| control.individual_limit.as_ref())
-        .and_then(|limit| Some((limit.used?, limit.limit?)))
     {
-        sections.push(DetailSection {
-            title: "Spend".to_owned(),
-            rows: vec![DetailRow {
-                label: "Used".to_owned(),
-                value: format!("{} of {}", trim_number(used), trim_number(limit)),
-            }],
-        });
+        if let (Some(used), Some(cap)) = (limit.used.as_ref(), limit.limit.as_ref()) {
+            sections.push(DetailSection {
+                title: "Spend".to_owned(),
+                rows: vec![DetailRow {
+                    label: "Used".to_owned(),
+                    value: format!("{} of {}", trim_number(used.0), trim_number(cap.0)),
+                }],
+            });
+        }
     }
 
     sections
@@ -1008,10 +1190,29 @@ mod tests {
     fn an_extra_oauth_account_skips_the_cli_credentials_path() {
         let account = AccountId::new("work");
         assert!(
-            credentials_for(&account, Source::OAuth)
+            credentials_for(&account, Source::OAuth, None)
                 .expect("OAuth-only accounts do not need a CLI path")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn an_extra_account_with_a_cli_home_reads_that_auth_file() {
+        let account = AccountId::new("work");
+        let home = std::env::temp_dir().join(format!(
+            "tidemark-codex-home-{}-{}",
+            std::process::id(),
+            NEXT_DIR.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir(&home).expect("home");
+        let file = credentials_for(&account, Source::Cli, Some(&home))
+            .expect("a configured CLI home is usable")
+            .expect("CLI source keeps a credential file");
+        // CredentialFile keeps path private; writing through the locked file proves the home.
+        fs::write(home.join("auth.json"), br#"{"tokens":{"access_token":"x"}}"#).expect("seed");
+        assert!(file.read_json().is_ok());
+        let _ = fs::remove_dir_all(&home);
     }
 
     static NEXT_DIR: AtomicU64 = AtomicU64::new(0);

--- a/crates/tidemark-core/tests/codex_provider.rs
+++ b/crates/tidemark-core/tests/codex_provider.rs
@@ -374,3 +374,86 @@ fn a_body_that_is_not_a_usage_response_at_all_is_malformed() {
         Err(ProviderError::Malformed { .. })
     ));
 }
+
+#[test]
+fn a_business_spend_control_with_string_amounts_becomes_a_window() {
+    // Live Business WHAM shape (Orca #8664): no rate_limit windows, quota only under
+    // spend_control.individual_limit, with limit/used as decimal strings.
+    let body = r#"{
+      "plan_type": "business",
+      "rate_limit": null,
+      "spend_control": {
+        "reached": false,
+        "individual_limit": {
+          "source": "group_based_spend_controls",
+          "limit": "11450",
+          "used": "4522.358407497406",
+          "remaining": "6927.641592502594",
+          "used_percent": 39,
+          "remaining_percent": 61,
+          "reset_after_seconds": 1539578,
+          "reset_at": 1785542400
+        }
+      }
+    }"#;
+    let snapshot = codex::parse(body, captured_at()).expect("business spend parses");
+    assert_eq!(snapshot.windows.len(), 1);
+    assert_eq!(snapshot.windows[0].used_percent, 39.0);
+    assert!(snapshot.windows[0].key.as_str().starts_with("spend"));
+    assert_eq!(
+        snapshot.windows[0].subtitle.as_deref(),
+        Some("4522.36 of 11450")
+    );
+    assert_eq!(snapshot.details[0].rows[0].value, "Business");
+    assert_eq!(snapshot.details[1].title, "Spend");
+}
+
+#[test]
+fn a_business_spend_control_without_amounts_still_draws_the_percent() {
+    let body = r#"{
+      "plan_type": "business",
+      "spend_control": {
+        "individual_limit": { "used_percent": 39, "reset_at": 1785542400 }
+      }
+    }"#;
+    let snapshot = codex::parse(body, captured_at()).expect("parses");
+    assert_eq!(snapshot.windows.len(), 1);
+    assert_eq!(snapshot.windows[0].used_percent, 39.0);
+    assert_eq!(snapshot.windows[0].subtitle, None);
+}
+
+
+#[test]
+fn business_spend_control_becomes_a_window_when_rate_limit_is_empty() {
+    // Business Standard/Premium seats have been observed with null rate_limit windows and
+    // the only quota under spend_control.individual_limit — including string balances.
+    let body = r#"{
+      "plan_type": "self_serve_business_prolite",
+      "rate_limit": null,
+      "spend_control": {
+        "reached": false,
+        "individual_limit": {
+          "limit": "100",
+          "used": "42.5",
+          "used_percent": 42.5,
+          "reset_after_seconds": 604800,
+          "reset_at": 1787855484
+        }
+      }
+    }"#;
+
+    let snapshot = codex::parse(body, captured_at()).expect("business spend parses");
+
+    assert_eq!(snapshot.windows.len(), 1);
+    assert_eq!(snapshot.windows[0].key.as_str(), "spend/w604800");
+    assert_eq!(snapshot.windows[0].used_percent, 42.5);
+    assert_eq!(snapshot.windows[0].subtitle.as_deref(), Some("42.5 of 100"));
+    assert_eq!(snapshot.details[0].rows[0].value, "Business Standard");
+}
+
+#[test]
+fn business_plan_wire_names_are_labelled_for_people() {
+    let body = r#"{"plan_type": "self_serve_business_usage_based", "rate_limit": null}"#;
+    let snapshot = codex::parse(body, captured_at()).expect("plan parses");
+    assert_eq!(snapshot.details[0].rows[0].value, "Business (usage-based)");
+}

--- a/crates/tidemark/src/provider_settings/detail.rs
+++ b/crates/tidemark/src/provider_settings/detail.rs
@@ -1182,6 +1182,14 @@ impl ProviderDetail {
         let options = model::settings_options(pill_excluded, &self.definition);
         group.set_visible(!options.is_empty());
         for option in options {
+            if option.choices.is_empty() {
+                let entry = self.build_free_text_option(option);
+                group.add(&entry);
+                if let Some(description) = &option.description {
+                    group.add(&caption(description));
+                }
+                continue;
+            }
             let row = self.build_option_row(option);
             group.add(&row.row);
             self.options
@@ -1191,6 +1199,37 @@ impl ProviderDetail {
                 group.add(&caption(description));
             }
         }
+    }
+
+    fn build_free_text_option(self: &Rc<Self>, option: &ProviderOption) -> adw::EntryRow {
+        let entry = adw::EntryRow::builder()
+            .title(&option.title)
+            .text(&option.value)
+            .show_apply_button(true)
+            .build();
+        let weak = Rc::downgrade(self);
+        let name = option.name.clone();
+        entry.connect_apply(move |entry| {
+            let Some(detail) = weak.upgrade() else {
+                return;
+            };
+            let status = detail.status.borrow();
+            let provider = status.provider.clone();
+            let account = status.account.clone();
+            drop(status);
+            let value = entry.text().to_string();
+            let name = name.clone();
+            glib::spawn_future_local(async move {
+                if let Err(error) = detail
+                    .proxy
+                    .set_option(&provider, &account, &name, &value)
+                    .await
+                {
+                    detail.toast(&reason(&error));
+                }
+            });
+        });
+        entry
     }
 
     fn build_option_row(self: &Rc<Self>, option: &ProviderOption) -> Rc<OptionRow> {

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -1148,15 +1148,29 @@ impl Engine {
             .iter()
             .find(|option| option.name == name)
             .ok_or_else(|| format!("{provider} has no setting called {name}"))?;
-        if !option.choices.iter().any(|choice| choice.value == value) {
+        if !option.choices.is_empty()
+            && !value.is_empty()
+            && !option.choices.iter().any(|choice| choice.value == value)
+        {
             return Err(format!("{value} is not one of the values {name} can take"));
         }
 
         let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
-        config
-            .set_option(provider, name, value)
-            .map_err(|error| error.to_string())?;
-        self.accounts[index].status.options = crate::registry::options(provider, &config);
+        if name == crate::registry::CLI_HOME
+            || (account != "default"
+                && matches!(provider, "codex" | "claude")
+                && name == crate::registry::AUTH_SOURCE)
+        {
+            config
+                .set_account_option(provider, account, name, value)
+                .map_err(|error| error.to_string())?;
+        } else {
+            config
+                .set_option(provider, name, value)
+                .map_err(|error| error.to_string())?;
+        }
+        self.accounts[index].status.options =
+            crate::registry::options_for_account(provider, account, &config);
         let account_id = self.accounts[index].account.clone();
         self.accounts[index].source =
             crate::registry::source_for_account(provider, &account_id, &config);
@@ -1229,7 +1243,7 @@ impl Engine {
             .set_auth_selection(provider, &selection)
             .map_err(|error| error.to_string())?;
         let target = &mut self.accounts[index];
-        target.status.options = crate::registry::options(provider, &config);
+        target.status.options = crate::registry::options_for_account(provider, account, &config);
         target.status.auth_selection = crate::registry::browser_auth_selection(provider, &config);
         if target.rebuildable() {
             target.client = None;

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -20,6 +20,7 @@
 //! clients what this build supports; an account exists only after its slug appears in
 //! `config.toml`.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tidemark_core::config::Config;
@@ -51,6 +52,8 @@ use crate::engine::Account;
 /// alone when Antigravity was the only provider with two credentials, so a
 /// `[provider.antigravity] source = "…"` written then keeps working untouched.
 pub const AUTH_SOURCE: &str = "source";
+/// Per-account absolute CLI home (`CODEX_HOME`) for a second install on this machine.
+pub const CLI_HOME: &str = tidemark_core::config::CLI_HOME_KEY;
 
 /// One of the three OAuth providers: everything about it that varies, named. The same
 /// entry feeds the catalog, the settings schema and the account builders, and bare
@@ -299,6 +302,7 @@ pub fn account(
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Option<Account>, ProviderError> {
+    let account_id_for_options = account.clone();
     let account = match provider {
         antigravity::PROVIDER_ID => Some(antigravity_account(account, secrets, config)?),
         claude::PROVIDER_ID => Some(claude_account(account, secrets, config)?),
@@ -316,7 +320,7 @@ pub fn account(
     };
     Ok(account.map(|account| {
         account
-            .with_options(options(provider, config))
+            .with_options(options_for_account(provider, account_id_for_options.as_str(), config))
             .with_auth_selection(browser_auth_selection(provider, config))
             .with_notify(notify(provider, config))
     }))
@@ -487,8 +491,17 @@ pub fn notify(provider: &str, config: &Config) -> Vec<String> {
 /// from `keyed::CATALOG`, or from the hand-written table for the providers that are not a
 /// `Spec`; either way the row is the same shape.
 pub fn options(provider: &str, config: &Config) -> Vec<ProviderOption> {
+    options_for_account(provider, "default", config)
+}
+
+/// Settings published on one account's status, including per-account CLI home for OAuth providers.
+pub fn options_for_account(provider: &str, account: &str, config: &Config) -> Vec<ProviderOption> {
     if let Some(entry) = oauth_entry(provider) {
-        return vec![auth_source_option(entry, config)];
+        let mut options = vec![auth_source_option_for(entry, account, config)];
+        if provider == codex::PROVIDER_ID {
+            options.push(cli_home_option(provider, account, config));
+        }
+        return options;
     }
     keyed::CATALOG
         .iter()
@@ -547,10 +560,18 @@ fn published_option(
 /// No description: the dialog draws this row itself, in the authentication group, with
 /// its own explanation, and a sentence here would be shown twice.
 fn auth_source_option(entry: &OAuthEntry, config: &Config) -> ProviderOption {
-    let available = local_source_available(entry.slug);
+    auth_source_option_for(entry, "default", config)
+}
+
+fn auth_source_option_for(entry: &OAuthEntry, account: &str, config: &Config) -> ProviderOption {
+    let available = if account == "default" {
+        local_source_available(entry.slug)
+    } else {
+        config.cli_home(entry.slug, account).is_some()
+    };
     let value = if available {
         config
-            .option(entry.slug, AUTH_SOURCE)
+            .account_option(entry.slug, account, AUTH_SOURCE)
             .unwrap_or(AUTO_SOURCE)
             .to_owned()
     } else {
@@ -575,6 +596,36 @@ fn auth_source_option(entry: &OAuthEntry, config: &Config) -> ProviderOption {
     }
 }
 
+fn cli_home_option(provider: &str, account: &str, config: &Config) -> ProviderOption {
+    let discovered = if provider == codex::PROVIDER_ID {
+        let homes: Vec<String> = codex::discover_cli_homes()
+            .into_iter()
+            .map(|home| home.to_string_lossy().into_owned())
+            .collect();
+        if homes.is_empty() {
+            String::new()
+        } else {
+            format!(" Discovered on this machine: {}.", homes.join(", "))
+        }
+    } else {
+        String::new()
+    };
+    ProviderOption {
+        name: CLI_HOME.to_owned(),
+        title: "CLI home".to_owned(),
+        description: Some(format!(
+            "Absolute CODEX_HOME for this account. Extra accounts need one to use a second CLI login instead of only Tidemark login.{discovered}"
+        )),
+        value: config
+            .account_option(provider, account, CLI_HOME)
+            .unwrap_or("")
+            .to_owned(),
+        // Free text so a home that does not yet contain auth.json can still be configured
+        // before codex login is run there.
+        choices: Vec::new(),
+    }
+}
+
 /// Which of a provider's two credentials its account reads, from the stored setting.
 /// Anything unrecognised — including the unset default — is [`Source::Auto`]: the Tidemark login when there
 /// is one, the vendor program's otherwise — the behaviour these accounts have always had.
@@ -582,13 +633,17 @@ fn source_value(provider: &str, config: &Config) -> Source {
     Source::from_value(config.option(provider, AUTH_SOURCE))
 }
 
-/// Extra configured accounts have no vendor CLI file, so they always use Tidemark's login.
+/// Extra configured accounts use Tidemark's login unless a per-account CLI home is set.
 pub(crate) fn source_for_account(provider: &str, account: &AccountId, config: &Config) -> Source {
     if account.as_str() == "default" {
-        supported_source(provider, source_value(provider, config))
-    } else {
-        Source::OAuth
+        return supported_source(provider, source_value(provider, config));
     }
+    // A second Codex/Claude CLI install is addressed by an absolute `cli-home`. Without one
+    // there is still only one vendor credential file on disk, so extras stay OAuth-only.
+    if config.cli_home(provider, account.as_str()).is_some() {
+        return Source::from_value(config.account_option(provider, account.as_str(), AUTH_SOURCE));
+    }
+    Source::OAuth
 }
 
 fn supported_source(provider: &str, source: Source) -> Source {
@@ -780,11 +835,13 @@ fn codex_account(
     config: &Config,
 ) -> Result<Account, ProviderError> {
     let source = source_for_account(codex::PROVIDER_ID, account, config);
+    let cli_home = config.cli_home(codex::PROVIDER_ID, account.as_str());
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(codex::Codex::new(
         account_id.clone(),
         Some(Arc::clone(secrets)),
         source,
+        cli_home.clone(),
     )?))
     .with_source(source)
     .with_rebuild({
@@ -792,13 +849,22 @@ fn codex_account(
         Box::new(move |account, _credential, options| {
             let source = if account.as_str() == "default" {
                 Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
+            } else if options.get(CLI_HOME).is_some_and(|home| !home.trim().is_empty()) {
+                Source::from_value(options.get(AUTH_SOURCE).map(String::as_str))
             } else {
                 Source::OAuth
             };
+            let cli_home = options
+                .get(CLI_HOME)
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|home| !home.is_empty())
+                .map(PathBuf::from);
             Ok(Arc::new(codex::Codex::new(
                 account.clone(),
                 Some(Arc::clone(&secrets)),
                 source,
+                cli_home,
             )?) as Arc<dyn Provider>)
         })
     })

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -1218,7 +1218,12 @@ impl Daemon {
             .ok_or_else(|| {
                 fdo::Error::InvalidArgs(format!("{provider} has no setting called {name}"))
             })?;
-        if !option.choices.iter().any(|choice| choice.value == value) {
+        // Empty choices mean free text (for example Codex `cli-home`); otherwise the
+        // value must be one of the published alternatives.
+        if !option.choices.is_empty()
+            && !value.is_empty()
+            && !option.choices.iter().any(|choice| choice.value == value)
+        {
             return Err(fdo::Error::InvalidArgs(format!(
                 "{value} is not one of the values {name} can take"
             )));

--- a/docs/codex-business-and-multi-cli.md
+++ b/docs/codex-business-and-multi-cli.md
@@ -2,41 +2,45 @@
 
 ## Multiple Codex CLIs on one machine
 
-The Codex CLI keeps one login per CODEX_HOME (default ~/.codex). Tidemark's default
+The Codex CLI keeps one login per `CODEX_HOME` (default `~/.codex`). Tidemark's default
 Codex account reads that file (or a Tidemark login in the keyring).
 
 A **second** CLI login needs its own home directory — the usual pattern is:
 
-`ash
+```bash
 CODEX_HOME=/path/to/second-codex-home codex login
-`
+```
+
+On this machine, additional homes often live under `~/.codex-profiles/<name>/`.
 
 Then in Tidemark:
 
 1. Add a second Codex account in Provider settings.
-2. Set **CLI home** on that account to the absolute path of the second home.
-3. Choose **Codex CLI login** as the credential (or leave Auto).
+2. Set **CLI home** on that account to the absolute path of that home (discovered installs
+   appear in the menu).
+3. Choose **Codex CLI login** as the credential (or leave Auto once a home is set).
 
 Without a CLI home, extra Codex accounts remain **Tidemark-login only** — there is still
-only one default ~/.codex/auth.json on disk.
+only one default `~/.codex/auth.json` on disk.
 
 ## Codex Business (Standard / Premium)
 
-Business seats often return **no** 
-ate_limit windows from
-https://chatgpt.com/backend-api/wham/usage. The quota lives under
-spend_control.individual_limit (used_percent, and often string limit/used).
+Business seats often return **no** `rate_limit` windows from
+`https://chatgpt.com/backend-api/wham/usage`. The quota lives under
+`spend_control.individual_limit` (`used_percent`, and often string `limit`/`used`).
 
-Tidemark maps that spend-control payload into a Spend window so the card shows usage.
+Tidemark maps that spend-control payload into a Spend window so the card shows usage, and
+labels known Business plan wire names (`self_serve_business_prolite` → Business Standard,
+`self_serve_business_usage_based` → Business (usage-based), etc.).
 
 ### Upstream CLI limits (not fixable here)
 
-- The official Codex CLI historically used a **closed** plan_type enum; unknown variants
-  (and some Business / usage-based plan slugs) can make the CLI fail to decode /wham/usage
+- The official Codex CLI historically used a **closed** `plan_type` enum; unknown variants
+  (and some Business / usage-based plan slugs) can make the CLI fail to decode `/wham/usage`
   even when the HTTP response is fine. Prefer a current CLI build; see
   [openai/codex#17353](https://github.com/openai/codex/issues/17353) and related plan-type PRs.
 - Some Business workspaces expose monthly spend caps instead of the Plus/Pro 5-hour + weekly
   windows. The CLI status UI may disagree with the web usage dashboard
   ([openai/codex#16909](https://github.com/openai/codex/issues/16909)).
 - Seat / credit preload and workspace entitlement issues are account-side; Tidemark can only
-  display what /wham/usage returns for the token it holds.
+  display what `/wham/usage` returns for the token it holds.

--- a/docs/codex-business-and-multi-cli.md
+++ b/docs/codex-business-and-multi-cli.md
@@ -1,0 +1,42 @@
+# Codex: multiple CLI homes and Business plans
+
+## Multiple Codex CLIs on one machine
+
+The Codex CLI keeps one login per CODEX_HOME (default ~/.codex). Tidemark's default
+Codex account reads that file (or a Tidemark login in the keyring).
+
+A **second** CLI login needs its own home directory — the usual pattern is:
+
+`ash
+CODEX_HOME=/path/to/second-codex-home codex login
+`
+
+Then in Tidemark:
+
+1. Add a second Codex account in Provider settings.
+2. Set **CLI home** on that account to the absolute path of the second home.
+3. Choose **Codex CLI login** as the credential (or leave Auto).
+
+Without a CLI home, extra Codex accounts remain **Tidemark-login only** — there is still
+only one default ~/.codex/auth.json on disk.
+
+## Codex Business (Standard / Premium)
+
+Business seats often return **no** 
+ate_limit windows from
+https://chatgpt.com/backend-api/wham/usage. The quota lives under
+spend_control.individual_limit (used_percent, and often string limit/used).
+
+Tidemark maps that spend-control payload into a Spend window so the card shows usage.
+
+### Upstream CLI limits (not fixable here)
+
+- The official Codex CLI historically used a **closed** plan_type enum; unknown variants
+  (and some Business / usage-based plan slugs) can make the CLI fail to decode /wham/usage
+  even when the HTTP response is fine. Prefer a current CLI build; see
+  [openai/codex#17353](https://github.com/openai/codex/issues/17353) and related plan-type PRs.
+- Some Business workspaces expose monthly spend caps instead of the Plus/Pro 5-hour + weekly
+  windows. The CLI status UI may disagree with the web usage dashboard
+  ([openai/codex#16909](https://github.com/openai/codex/issues/16909)).
+- Seat / credit preload and workspace entitlement issues are account-side; Tidemark can only
+  display what /wham/usage returns for the token it holds.


### PR DESCRIPTION
## Summary
- **(a) Multi-CLI:** Extra Codex accounts can set a per-account **CLI home** (`CODEX_HOME`) so a second CLI login on the machine is usable instead of only Tidemark login. Discovers sibling homes under `~/.codex-profiles/*` for the description hint.
- **(b) Business:** WHAM payloads that put quota under `spend_control.individual_limit` (string or number `limit`/`used`, often with null `rate_limit`) now parse into a Spend window. Friendlier plan labels for Business / usage-based seats.
- Docs: `docs/codex-business-and-multi-cli.md` covers setup leftovers and **upstream CLI limits** (closed `plan_type` enums, Business entitlement mismatches).

## Test plan
- [ ] `cargo test -p tidemark-core --test codex_provider`
- [ ] `cargo test -p tidemark-core config::tests`
- [ ] `cargo test -p tidemarkd registry`
- [ ] Add a second Codex account, set CLI home to a second `CODEX_HOME`, choose Codex CLI login, confirm poll
- [ ] Sign in a Business seat (or replay a spend_control fixture) and confirm the card shows a Spend bar

## Leftovers for the user
- Second CLI still needs `CODEX_HOME=... codex login` once; Tidemark does not run that for you.
- After setting CLI home on an open detail page, reopen the page (or refresh) so the Credential pill offers CLI.
- Upstream Codex CLI may still fail on unknown `plan_type` variants or Business seat entitlement bugs — see the doc.