### PR TITLE
feat(cli): add tidemarkctl and shared D-Bus client contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,17 @@
 **Branch:** main
 
 ## OVERVIEW
-Tidemark tracks AI-provider quota windows and pace. Four Rust crates separate daemon state, provider I/O, shared vocabulary, and GTK presentation; Rust edition 2024, MSRV 1.92, GTK 4.22, libadwaita 1.9.
+Tidemark tracks AI-provider quota windows and pace. Six Rust crates separate daemon state, provider I/O, shared vocabulary, the generated D-Bus proxy, GTK presentation, and `tidemarkctl`; Rust edition 2024, MSRV 1.92, GTK 4.22, libadwaita 1.9.
 
 ## STRUCTURE
 ```text
 tidemark/
 |-- crates/
 |   |-- tidemark/        # GTK GUI; consumes IPC, never core
+|   |-- tidemark-cli/    # tidemarkctl; D-Bus client, no core/display/Tokio
 |   |-- tidemarkd/       # Polling, history, secrets and IPC ownership
 |   |-- tidemark-core/   # External I/O and provider implementations
+|   |-- tidemark-ipc/    # Single generated D-Bus client proxy
 |   `-- tidemark-types/  # Shared domain and wire vocabulary
 |-- data/               # Desktop assets, user service, packaging payloads
 |-- scripts/            # Layering, integration, packaging and release checks
@@ -28,6 +30,8 @@ tidemark/
 |------|----------|-------|
 | Add a provider | `crates/tidemark-core/src/providers/`, `crates/tidemarkd/src/registry.rs` | Core implementation plus daemon registration; simple catalog and hand-written descriptors coexist |
 | Change IPC vocabulary | `crates/tidemark-types/src/wire.rs` | Keep daemon and GUI compatible |
+| Change the D-Bus proxy | `crates/tidemark-ipc/src/lib.rs` | Keep the one generated client contract synchronized with the daemon interface |
+| Change the CLI | `crates/tidemark-cli/` | Preserve JSON/Waybar shapes, exit codes, secret input and layering |
 | Polling or mutation ordering | `crates/tidemarkd/src/engine.rs`, `service.rs` | Owned state and published mirror |
 | GUI or daemon reconnect | `crates/tidemark/src/window.rs`, `bus.rs` | Presentation and IPC client |
 | Credentials or browser sources | `crates/tidemark-core/src/oauth_file.rs`, `secrets.rs`, `browser/` | Ownership and explicit source selection matter |
@@ -59,7 +63,7 @@ On the GUI side, `bus::watch` drives `DaemonProxy` on `glib::spawn_future_local`
 **D-Bus contract:** name `io.github.zbndev.Tidemark.Daemon`, path `/io/github/zbndev/Tidemark`, interface `io.github.zbndev.Tidemark.Daemon1`; method `GetStatus`, signal `ProviderChanged`. App ID: `io.github.zbndev.Tidemark`. Activation uses `data/dbus-1/services/` and the systemd user unit `tidemarkd.service`. Published `a{sv}` dictionaries are extensible; absent values stay absent.
 
 ## CONVENTIONS
-- Layering is enforced by `scripts/check-layering.sh`: types have no runtime I/O; core has no GTK/GDK/adwaita; GUI has no core/HTTP/SQLite. Types may use zvariant, not zbus.
+- Layering is enforced by `scripts/check-layering.sh`: types have no runtime I/O; IPC has no policy; CLI has no core/HTTP/SQLite/GTK/runtime; core has no GTK/GDK/adwaita; GUI has no core/HTTP/SQLite. Types may use zvariant, not zbus.
 - Cargo sets `unsafe_code = "deny"`, not `forbid`; audited Windows exceptions exist. Clippy warns on `all`, `todo` and `dbg_macro`.
 - Missing provider values stay missing. Window identity is its length, not the vendor field name; slugs are persistent storage keys.
 - Config stores preferences, not secrets; preserve TOML decoration and reject present-but-invalid values. Provider/account array order determines UI order.
@@ -91,6 +95,7 @@ On the GUI side, `bus::watch` drives `DaemonProxy` on `glib::spawn_future_local`
 ```bash
 cargo run -p tidemarkd
 cargo run -p tidemark
+tidemarkctl usage --format json
 # Full local gate (plain workspace tests):
 cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh
 scripts/check-desktop-integration.sh

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,10 +83,11 @@ uses is the user's choice, not a rule hidden in the daemon. It is stored as
 `[provider.<slug>] source = "oauth" | "cli"`, published with the provider so a client can
 draw it without knowing what either credential is, and drawn in the authentication group
 as a two-part control — Tidemark's own login on the left, the local program's on the right.
-**A pinned credential that is not there is `no-credential`, never a quiet fall back to the
-other one**: falling back would show quota for an account the user did not choose. An
-account whose `source` has never been set behaves exactly as it always did — the daemon
-publishes which credential that resolves to, so the control still shows the truth.
+A freshly added provider stores `source = "oauth"` before its first credential probe, so
+adding one never silently adopts a vendor CLI login; `auth select <slug> --mode cli` is the
+explicit opt-in. **A pinned credential that is not there is `no-credential`, never a quiet
+fall back to the other one**. An existing account whose `source` was never set keeps the
+legacy automatic rule, so this cutover does not switch an installed account.
 
 Codex reports `rate_limit.primary_window` / `secondary_window` — slots rather than lanes,
 each declaring its own length — plus a `code_review_rate_limit` of the same shape and named
@@ -183,6 +184,11 @@ blanking a card because one request timed out would be less honest, not more.
 `tidemarkctl` is the third client, and the reason the interface was shaped as it was.
 It generates its proxy from `tidemark-ipc`, the same crate the window uses, so a method
 that changes shape breaks the build rather than a user's panel.
+
+Commands that act on one existing account default `--account` to `default`; a named
+account stays explicit. Collection commands are deliberately different: omitting the
+filter from `usage`, `guard` or `watch` continues to mean every matching account, which is
+the shape panel plugins need.
 
 Three output formats, and two of them are contracts. `text` is for a person and may be
 reworded. `json` is an object with an `accounts` key — not a bare array, so a key can be

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,8 +109,8 @@ Daemon plus client, split over D-Bus.
   notifications. Runs whether or not the window is open, because a warning that only
   arrives when you are already looking is not a warning.
 - **GUI** — a thin viewer. Never performs network I/O.
-- **CLI** — not in v1, but the D-Bus interface is designed so `tidemark usage --json`
-  is a third consumer rather than a bolt-on. Waybar is the obvious client.
+- **CLI** — `tidemarkctl`. The third client, and the one the interface was shaped for:
+  one round trip draws a window, a Waybar module, or a line of output.
 
 Language is Rust; GUI is GTK4 + libadwaita. Rust was chosen for packaging above all —
 `deb`/`rpm`/`PKGBUILD` from a single binary is the cheap path — and for `serde`, which
@@ -119,15 +119,17 @@ named field in an error.
 
 ### Crate layout
 
-Four crates, not three. The extra one exists to make the "GUI never performs network I/O"
-rule checkable rather than aspirational.
+Six crates, and two of them exist to make a rule checkable rather than aspirational: the
+GUI never performs network I/O, and there is exactly one definition of the D-Bus contract.
 
 | crate | holds | must never reach |
 |---|---|---|
 | `tidemark-types` | vocabulary, identity constants, D-Bus wire shapes | anything with I/O |
+| `tidemark-ipc` | the generated D-Bus proxy | providers, storage, the display |
 | `tidemark-core` | provider clients, history, secrets | GTK, GDK, libadwaita |
 | `tidemarkd` | scheduler, D-Bus service, notifications | — |
 | `tidemark` | the interface | `tidemark-core`, HTTP, SQLite |
+| `tidemark-cli` | `tidemarkctl` | `tidemark-core`, GTK, a runtime |
 
 The GUI depends on `tidemark-types` and D-Bus only. Folding the vocabulary into
 `tidemark-core` and feature-gating the network out of it does not work: Cargo unifies
@@ -175,6 +177,37 @@ Failure is part of the published shape, not an absence of it: an account carries
 `credential-rejected`, `rate-limited`, `unreachable`, `malformed` — and keeps its **last
 good reading underneath it**. A failed poll changes the chip on the card, not the numbers;
 blanking a card because one request timed out would be less honest, not more.
+
+### Command line
+
+`tidemarkctl` is the third client, and the reason the interface was shaped as it was.
+It generates its proxy from `tidemark-ipc`, the same crate the window uses, so a method
+that changes shape breaks the build rather than a user's panel.
+
+Three output formats, and two of them are contracts. `text` is for a person and may be
+reworded. `json` is an object with an `accounts` key — not a bare array, so a key can be
+added later — carrying `ProviderStatus` as serde renders it, absent values still absent.
+`waybar` is `{text, tooltip, class, percentage}`, where `class` is **always an array** so
+its shape does not change when a second class applies: the zone (`ok`, `warning`, `danger`,
+at the same 70/90 the bar uses) and `stale` when the account's state is not `ok`.
+
+`watch` streams NDJSON: a `snapshot` first, then one line per signal, a `waiting` line when
+the daemon leaves the bus, and a fresh `snapshot` after every reconnect — what the daemon
+published while nothing was listening was announced to nobody.
+
+Exit codes are the point of `guard`: `0` safe, `1` below the threshold, `64` an argument
+this build cannot act on, `69` nothing trustworthy to judge, `70` the daemon refused. A
+command line clap itself rejects exits `2`, clap's own code. Only an `ok` account's reading
+is judged; a last-good number behind a rejected credential would otherwise say "safe"
+about quota nobody can spend.
+
+Secrets are read from stdin or `--key-file`, never from argv: `/proc/<pid>/cmdline` is
+readable by every process of the same user. stdin is a file descriptor rather than a
+terminal, so a plugin with its own UI writes into a pipe without opening a console.
+
+Windows is out of scope for the CLI: there the daemon serves zbus p2p over AF_UNIX, and the
+endpoint discovery lives in the window's own reconnect module. The binary still compiles
+there; it is packaged only on Linux.
 
 ### Provider contract
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,6 +3939,7 @@ version = "0.4.1"
 dependencies = [
  "async-io",
  "clap",
+ "clap_complete",
  "futures-lite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ version = "0.4.1"
 dependencies = [
  "async-io",
  "clap",
+ "futures-lite",
  "serde",
  "serde_json",
  "tidemark-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,6 +3799,7 @@ dependencies = [
  "pango 0.22.8",
  "pangocairo",
  "semver",
+ "tidemark-ipc",
  "tidemark-types",
  "tracing",
  "tracing-subscriber",
@@ -3839,6 +3840,15 @@ dependencies = [
  "windows",
  "wreq",
  "wreq-util",
+]
+
+[[package]]
+name = "tidemark-ipc"
+version = "0.4.1"
+dependencies = [
+ "async-io",
+ "tidemark-types",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "antidote"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +682,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +735,12 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2058,6 +2154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2721,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oo7"
@@ -3588,6 +3696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3807,6 +3921,19 @@ dependencies = [
  "uds_windows",
  "webbrowser",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tidemark-cli"
+version = "0.4.1"
+dependencies = [
+ "async-io",
+ "clap",
+ "serde",
+ "serde_json",
+ "tidemark-ipc",
+ "tidemark-types",
  "zbus",
 ]
 
@@ -4325,6 +4452,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/tidemark-types",
+    "crates/tidemark-ipc",
     "crates/tidemark-core",
     "crates/tidemarkd",
     "crates/tidemark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/tidemark-core",
     "crates/tidemarkd",
     "crates/tidemark",
+    "crates/tidemark-cli",
 ]
 
 [workspace.package]

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -48,6 +48,7 @@ package() {
 
     install -Dm755 "$bin/tidemark" "$pkgdir/usr/bin/tidemark"
     install -Dm755 "$bin/tidemarkd" "$pkgdir/usr/bin/tidemarkd"
+    install -Dm755 "$bin/tidemarkctl" "$pkgdir/usr/bin/tidemarkctl"
 
     # The unit's ExecStart is /usr/bin/tidemarkd, which is where the line above puts it.
     install -Dm644 data/tidemarkd.service "$pkgdir/usr/lib/systemd/user/tidemarkd.service"

--- a/README.md
+++ b/README.md
@@ -111,6 +111,50 @@ Antigravity can sign in through Tidemark, or reuse the login their own CLI alrea
 
 Removing a provider deletes its credentials and its card but keeps the quota history.
 
+## From the command line
+
+`tidemarkctl` talks to the same daemon the window does, so anything the interface can do is
+scriptable — and a panel widget needs no D-Bus code of its own.
+
+```bash
+tidemarkctl usage                      # every account, for a person
+tidemarkctl usage --format json        # {"accounts": [...]}, for a program
+tidemarkctl guard --min-remaining 20 --window w604800 || echo "not this week"
+tidemarkctl watch                      # one JSON object per change, until you stop it
+```
+
+`guard` exits `0` when the quota is there, `1` when it is not, and `69` when there is no
+trustworthy reading to judge — a rejected credential never answers "safe".
+
+Secrets are read from stdin, never from the command line:
+
+```bash
+printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai default
+```
+
+A Waybar module is two files. In `~/.config/waybar/config.jsonc`:
+
+```jsonc
+"custom/tidemark": {
+    "exec": "tidemarkctl watch --format waybar",
+    "return-type": "json",
+    "on-click": "tidemark"
+}
+```
+
+and in your stylesheet, the classes it sets — `ok`, `warning`, `danger` at the same 70% and
+90% the app's own bar changes colour at, plus `stale` when the reading is not fresh:
+
+```css
+#custom-tidemark.warning { color: @warning_color; }
+#custom-tidemark.danger  { color: @error_color; }
+#custom-tidemark.stale   { opacity: 0.5; }
+```
+
+`tidemarkctl completions zsh > ~/.zfunc/_tidemarkctl` installs completions;
+`tidemarkctl --help` lists the rest — `provider`, `account`, `auth`, `notify`, `config`,
+`history`.
+
 ## Reporting a wrong reading
 
 If a card shows a number the provider's own dashboard disagrees with, the useful evidence

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ quota*.
 Keys are stored in your desktop keyring, never in a config file. Claude, Codex and
 Antigravity can sign in through Tidemark, or reuse the login their own CLI already has.
 
-Removing a provider deletes its credentials and its card but keeps the quota history.
+Removing a provider deletes its Tidemark-owned credentials and its card but keeps the quota
+history. A vendor CLI's own credential file remains owned by that CLI and is never removed.
 
 ## From the command line
 
@@ -129,7 +130,22 @@ trustworthy reading to judge — a rejected credential never answers "safe".
 Secrets are read from stdin, never from the command line:
 
 ```bash
-printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai default
+printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai
+```
+
+Commands that act on one existing account use `default` unless `--account work` says
+otherwise. Aggregate commands keep their broader meaning: `usage`, `guard` and `watch`
+still include every matching account when no account filter is given.
+
+A newly added Claude, Codex or Antigravity account starts pinned to Tidemark OAuth; adding
+it never silently adopts the vendor CLI's login:
+
+```bash
+tidemarkctl provider add codex
+tidemarkctl auth login codex
+
+# Or explicitly use the Codex CLI login that already exists:
+tidemarkctl auth select codex --mode cli
 ```
 
 A Waybar module is two files. In `~/.config/waybar/config.jsonc`:

--- a/crates/tidemark-cli/AGENTS.md
+++ b/crates/tidemark-cli/AGENTS.md
@@ -1,0 +1,42 @@
+# COMMAND-LINE CLIENT KNOWLEDGE BASE
+
+## OVERVIEW
+`tidemarkctl`: the third consumer of the daemon's interface, after the window and `busctl`. It prints what the daemon published — no provider I/O, no database, no display, no second async runtime — and its `json`, `waybar` and exit-code shapes are a published contract that panels and scripts parse.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Argument grammar, subcommand names | `src/cli.rs` | Grouped by entity (`provider`, `account`, `auth`, `config`, `history`), not flattened verbs; `Switch` is `on`/`off` |
+| Dispatch and process exit | `src/main.rs` | One `async_io::block_on`; every body lives in the library beside it |
+| Exit codes | `src/exit.rs` | `Exit`, `Failure`, and the `zbus::Error` split between "refused" and "not there" |
+| A daemon method's command body | `src/commands/{provider,account,auth,config}.rs` | Each takes the proxy; a fake daemon can be passed in |
+| Output shapes | `src/format/{text,json,waybar}.rs`, `mod.rs` | `payload` peels the `a{sv}` envelope; `select` and `dominant` are shared |
+| The event stream | `src/watch/mod.rs`, `watch/mirror.rs` | NDJSON events, reconnect, and the client-side mirror Waybar re-renders from |
+| `guard`'s verdict | `src/guard.rs` | `Selection`, `Verdict`, and why only `ok` accounts are judged |
+| Secret input | `src/secret.rs` | stdin or `--key-file`, one trailing newline trimmed |
+| Provider spelling | `src/titles.rs` | Catalog title first, `provider_label` as the fallback |
+| The one connection | `src/connect.rs` | Session bus, D-Bus activation, no `systemctl` inspection |
+
+## CONVENTIONS
+- The library holds every command body and the binary is parsing plus an exit code, so `tests/` drives the real bodies against `tests/fake/` — a served daemon, not the machine's.
+- Command functions take `&DaemonProxy`; nothing but `connect::daemon` builds one, and no environment variable redirects the bus name.
+- `text` is for a person and may be reworded. `json` is `{"accounts": [...]}`; `waybar` is `{text, tooltip, class, percentage}` with `class` always an array (zone `ok`/`warning`/`danger` at `WARNING_AT`/`DANGER_AT`, then `stale`).
+- Percentages, spans and window titles come from `tidemark_types::present` and the daemon's own text, so a number here cannot drift from the same number on a card.
+- Every published value passes through `format::payload`: `SerializeDict` renders `{"signature", "value"}` under `serde_json`, and events and snapshots must peel identically.
+- `watch` opens with a `snapshot`, prints `waiting` when the daemon leaves the bus, and re-reads a fresh `snapshot` after every reconnect; lines are flushed one at a time because a pipe is block-buffered.
+- Account order is the daemon's published order — the user's — and is never re-sorted here.
+- `zbus` without `p2p`: the CLI is a session-bus client. Windows compiles the crate but packages nothing.
+
+## ANTI-PATTERNS
+- Do not add an argv slot for a secret; `/proc/<pid>/cmdline` is readable by every process of the same user. stdin or `--key-file` only.
+- Do not format a percentage, a duration or an icon name outside `tidemark_types::present`.
+- Do not invent a value the daemon did not send: no `null`, no zero, no "0%" placeholder where a provider withheld a reading. An absent key stays absent.
+- Do not rename or remove a key in `json`/`waybar` or renumber an exit code — add keys instead. A panel widget parses these.
+- Do not let `guard` judge a non-`ok` account's last-good reading: exit `69`, never a "safe" answer about quota nobody can spend.
+- Do not add provider I/O, storage, a display dependency, or `tokio`; `scripts/check-layering.sh` forbids `tidemark-core`, `reqwest`, `hyper`, `rusqlite`, `libsqlite3-sys`, `gtk4`, `gtk4-sys`, `libadwaita` and `tokio`.
+- Do not re-derive which window matters: `format::dominant` calls `Snapshot::dominant_window`, the same rule the card and the tray use.
+
+## CHECKS
+- `cargo test -p tidemark-cli` covers the grammar, formats, `guard` verdicts and the mirror; the command integration suites serve a fake daemon on the session bus, while completion generation needs none.
+- Exit codes are observable: `0` ok, `1` below threshold, `64` an argument this build cannot act on, `69` unreachable or nothing to judge, `70` the daemon refused, `2` from clap's own parse failure.
+- `tidemarkctl completions <shell>` is generated from the same `clap` command; `tests/completions.rs` pins that the shipped shells generate.

--- a/crates/tidemark-cli/AGENTS.md
+++ b/crates/tidemark-cli/AGENTS.md
@@ -25,6 +25,11 @@
 - Every published value passes through `format::payload`: `SerializeDict` renders `{"signature", "value"}` under `serde_json`, and events and snapshots must peel identically.
 - `watch` opens with a `snapshot`, prints `waiting` when the daemon leaves the bus, and re-reads a fresh `snapshot` after every reconnect; lines are flushed one at a time because a pipe is block-buffered.
 - Account order is the daemon's published order — the user's — and is never re-sorted here.
+- Commands targeting one existing account expose `--account` with `default` as the
+  default. `usage`, `guard` and `watch` keep omission as an all-account filter; `account
+  add` and `account order` keep explicit ids because those ids are the operation's value.
+- `auth select --mode oauth|cli` chooses the static source of a dual-source provider;
+  dynamic browser/profile choices still use the mode and candidate ids from `auth sources`.
 - `zbus` without `p2p`: the CLI is a session-bus client. Windows compiles the crate but packages nothing.
 
 ## ANTI-PATTERNS

--- a/crates/tidemark-cli/Cargo.toml
+++ b/crates/tidemark-cli/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/main.rs"
 [dependencies]
 async-io = "2.6.0"
 clap = { version = "4.6.6", features = ["derive"] }
+clap_complete = "4.6.9"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 tidemark-ipc = { path = "../tidemark-ipc" }

--- a/crates/tidemark-cli/Cargo.toml
+++ b/crates/tidemark-cli/Cargo.toml
@@ -11,6 +11,12 @@ authors.workspace = true
 [lints]
 workspace = true
 
+# The library holds every command body; the binary is argument parsing and an exit code.
+# The integration tests link the library and drive those bodies against a fake daemon.
+[lib]
+name = "tidemark_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "tidemarkctl"
 path = "src/main.rs"
@@ -27,3 +33,6 @@ serde_json = "1.0.151"
 tidemark-ipc = { path = "../tidemark-ipc" }
 tidemark-types = { path = "../tidemark-types" }
 zbus = "5.13.2"
+
+[dev-dependencies]
+futures-lite = "2.6.1"

--- a/crates/tidemark-cli/Cargo.toml
+++ b/crates/tidemark-cli/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tidemark-cli"
+description = "Tidemark command-line client"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "tidemarkctl"
+path = "src/main.rs"
+
+# NOTE: this crate prints what the daemon publishes and nothing else: no provider I/O, no
+# database, no display, and no second async runtime — zbus's async-io backend drives the
+# one connection this program makes. scripts/check-layering.sh enforces this.
+# No `p2p`: the CLI only ever talks to a session bus.
+[dependencies]
+async-io = "2.6.0"
+clap = { version = "4.6.6", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+tidemark-ipc = { path = "../tidemark-ipc" }
+tidemark-types = { path = "../tidemark-types" }
+zbus = "5.13.2"

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -20,6 +20,24 @@ pub enum Command {
     Usage(Usage),
     /// Exit 0 when enough quota is left to start something, 1 when there is not.
     Guard(Guard),
+    /// Print the daemon's changes as they arrive, one JSON object per line.
+    Watch(Watch),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct Watch {
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// `json` prints one event per line; `waybar` prints a card after every change.
+    #[arg(long, value_enum, default_value_t = StreamFormat::Json)]
+    pub format: StreamFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum StreamFormat {
+    Json,
+    Waybar,
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -22,6 +22,54 @@ pub enum Command {
     Guard(Guard),
     /// Print the daemon's changes as they arrive, one JSON object per line.
     Watch(Watch),
+    /// The provider catalog, the configured set, and what is in it.
+    Provider {
+        #[command(subcommand)]
+        command: ProviderCommand,
+    },
+    /// The accounts one provider carries.
+    Account {
+        #[command(subcommand)]
+        command: AccountCommand,
+    },
+    /// Poll now: one provider, or everything.
+    Refresh {
+        /// A provider slug. Omitted, every configured account is polled.
+        provider: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProviderCommand {
+    /// Every provider this build knows how to configure.
+    Catalog,
+    /// Every configured account, with its state.
+    List,
+    /// Configure a provider, creating its default account.
+    Add { provider: String },
+    /// Remove one configured account, its credentials and its card.
+    Rm { provider: String, account: String },
+    /// Rewrite the order the cards go in. Must name every configured provider.
+    Order { providers: Vec<String> },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AccountCommand {
+    /// Add one more account to a provider the config already has.
+    Add { provider: String, account: String },
+    /// Remove one account. The same call as `provider rm`.
+    Rm { provider: String, account: String },
+    /// Rename an account, carrying its credential and history to the new id.
+    Rename {
+        provider: String,
+        account: String,
+        new: String,
+    },
+    /// Rewrite one provider's account order.
+    Order {
+        provider: String,
+        accounts: Vec<String>,
+    },
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -1,0 +1,36 @@
+//! The argument grammar, grouped by the entity a subcommand acts on rather than flattened
+//! into thirty verbs: a person reading `--help` should find `provider add` under
+//! `provider`, and a plugin author should be able to guess the next one.
+
+use clap::{Parser, Subcommand};
+
+/// The command-line client for the Tidemark daemon.
+#[derive(Debug, Parser)]
+#[command(name = "tidemarkctl", version, about, arg_required_else_help = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// This client's version, and the daemon's.
+    Version,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn the_grammar_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn version_takes_no_arguments() {
+        let cli = Cli::parse_from(["tidemarkctl", "version"]);
+        assert!(matches!(cli.command, Command::Version));
+    }
+}

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -45,6 +45,8 @@ pub enum Command {
     /// One of a provider's own settings.
     Option {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         name: String,
         value: String,
@@ -52,6 +54,8 @@ pub enum Command {
     /// Notifications for one window of one account.
     Notify {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         window: String,
         enabled: Switch,
@@ -133,6 +137,8 @@ pub enum HistoryCommand {
     /// The stored points of one window's current segment, oldest first.
     Segment {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         window: String,
     },
@@ -148,6 +154,8 @@ pub enum AuthCommand {
     /// Store an API key. The key is read from stdin, or from --key-file.
     SetKey {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         /// Read the key from this file instead of stdin.
         #[arg(long)]
@@ -156,24 +164,48 @@ pub enum AuthCommand {
     /// Store a browser session header. Read like a key.
     SetSession {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         /// Read the session from this file instead of stdin.
         #[arg(long)]
         key_file: Option<std::path::PathBuf>,
     },
     /// Remove whatever credential Tidemark holds for an account.
-    SignOut { provider: String, account: String },
+    SignOut {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Print the authorize URL, then wait for the browser to come back.
-    Login { provider: String, account: String },
+    Login {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Abandon a login that is waiting.
-    CancelLogin { provider: String, account: String },
-    /// The local authentication sources the daemon can see, without their credentials.
-    Sources { provider: String, account: String },
-    /// Record which local source this account uses.
+    CancelLogin {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
+    /// The dynamic local authentication sources the daemon can see, without credentials.
+    Sources {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
+    /// Record which authentication source this account uses.
     Select {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
-        /// The mode value from `auth sources`.
+        /// `oauth` or `cli`, or a dynamic mode value from `auth sources`.
         #[arg(long)]
         mode: String,
         /// The candidate id, for a mode that offers a choice.
@@ -191,7 +223,12 @@ pub enum ProviderCommand {
     /// Configure a provider, creating its default account.
     Add { provider: String },
     /// Remove one configured account, its credentials and its card.
-    Rm { provider: String, account: String },
+    Rm {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Rewrite the order the cards go in. Must name every configured provider.
     Order { providers: Vec<String> },
 }
@@ -201,10 +238,17 @@ pub enum AccountCommand {
     /// Add one more account to a provider the config already has.
     Add { provider: String, account: String },
     /// Remove one account. The same call as `provider rm`.
-    Rm { provider: String, account: String },
+    Rm {
+        provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Rename an account, carrying its credential and history to the new id.
     Rename {
         provider: String,
+        /// Another account id; defaults to `default`.
+        #[arg(long, default_value = "default")]
         account: String,
         new: String,
     },
@@ -286,5 +330,154 @@ mod tests {
     fn version_takes_no_arguments() {
         let cli = Cli::parse_from(["tidemarkctl", "version"]);
         assert!(matches!(cli.command, Command::Version));
+    }
+
+    #[test]
+    fn provider_and_account_mutations_default_to_the_default_account() {
+        let provider = Cli::try_parse_from(["tidemarkctl", "provider", "rm", "codex"])
+            .expect("provider removal defaults the account");
+        assert!(matches!(
+            provider.command,
+            Command::Provider {
+                command: ProviderCommand::Rm {
+                    provider,
+                    account
+                }
+            } if provider == "codex" && account == "default"
+        ));
+
+        let remove = Cli::try_parse_from(["tidemarkctl", "account", "rm", "codex"])
+            .expect("account removal defaults the account");
+        assert!(matches!(
+            remove.command,
+            Command::Account {
+                command: AccountCommand::Rm {
+                    provider,
+                    account
+                }
+            } if provider == "codex" && account == "default"
+        ));
+
+        let rename = Cli::try_parse_from(["tidemarkctl", "account", "rename", "codex", "personal"])
+            .expect("account rename defaults the old account");
+        assert!(matches!(
+            rename.command,
+            Command::Account {
+                command: AccountCommand::Rename {
+                    provider,
+                    account,
+                    new
+                }
+            } if provider == "codex" && account == "default" && new == "personal"
+        ));
+    }
+
+    #[test]
+    fn authentication_commands_default_to_the_default_account() {
+        for verb in ["sign-out", "login", "cancel-login", "sources"] {
+            let parsed = Cli::try_parse_from(["tidemarkctl", "auth", verb, "codex"])
+                .unwrap_or_else(|error| panic!("{verb} should default the account: {error}"));
+            let account = match parsed.command {
+                Command::Auth {
+                    command:
+                        AuthCommand::SignOut { account, .. }
+                        | AuthCommand::Login { account, .. }
+                        | AuthCommand::CancelLogin { account, .. }
+                        | AuthCommand::Sources { account, .. },
+                } => account,
+                other => panic!("unexpected command: {other:?}"),
+            };
+            assert_eq!(account, "default", "{verb}");
+        }
+
+        let key = Cli::try_parse_from(["tidemarkctl", "auth", "set-key", "zai"])
+            .expect("set-key defaults the account");
+        assert!(matches!(
+            key.command,
+            Command::Auth {
+                command: AuthCommand::SetKey { account, .. }
+            } if account == "default"
+        ));
+
+        let session = Cli::try_parse_from(["tidemarkctl", "auth", "set-session", "t3chat"])
+            .expect("set-session defaults the account");
+        assert!(matches!(
+            session.command,
+            Command::Auth {
+                command: AuthCommand::SetSession { account, .. }
+            } if account == "default"
+        ));
+
+        let select =
+            Cli::try_parse_from(["tidemarkctl", "auth", "select", "codex", "--mode", "oauth"])
+                .expect("select defaults the account");
+        assert!(matches!(
+            select.command,
+            Command::Auth {
+                command: AuthCommand::Select { account, .. }
+            } if account == "default"
+        ));
+    }
+
+    #[test]
+    fn option_notification_and_history_default_to_the_default_account() {
+        let option = Cli::try_parse_from(["tidemarkctl", "option", "zai", "region", "china"])
+            .expect("option defaults the account");
+        assert!(matches!(
+            option.command,
+            Command::Option { account, .. } if account == "default"
+        ));
+
+        let notify = Cli::try_parse_from(["tidemarkctl", "notify", "codex", "w604800", "on"])
+            .expect("notify defaults the account");
+        assert!(matches!(
+            notify.command,
+            Command::Notify { account, .. } if account == "default"
+        ));
+
+        let history =
+            Cli::try_parse_from(["tidemarkctl", "history", "segment", "codex", "w604800"])
+                .expect("history defaults the account");
+        assert!(matches!(
+            history.command,
+            Command::History {
+                command: HistoryCommand::Segment { account, .. }
+            } if account == "default"
+        ));
+    }
+
+    #[test]
+    fn an_explicit_account_overrides_the_default() {
+        let parsed =
+            Cli::try_parse_from(["tidemarkctl", "auth", "login", "codex", "--account", "work"])
+                .expect("an account override is accepted");
+        assert!(matches!(
+            parsed.command,
+            Command::Auth {
+                command: AuthCommand::Login { account, .. }
+            } if account == "work"
+        ));
+    }
+
+    #[test]
+    fn aggregate_filters_still_include_every_account_by_default() {
+        let usage = Cli::parse_from(["tidemarkctl", "usage", "--provider", "codex"]);
+        assert!(matches!(
+            usage.command,
+            Command::Usage(Usage { account: None, .. })
+        ));
+
+        let guard = Cli::parse_from([
+            "tidemarkctl",
+            "guard",
+            "--min-remaining",
+            "20",
+            "--provider",
+            "codex",
+        ]);
+        assert!(matches!(
+            guard.command,
+            Command::Guard(Guard { account: None, .. })
+        ));
     }
 }

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -70,6 +70,11 @@ pub enum Command {
     Data,
     /// A newer published release, if the daemon knows of one.
     Update,
+    /// Print a shell completion script on stdout.
+    Completions {
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 /// `on` and `off` rather than `true` and `false`: the settings pages call these switches,

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -32,10 +32,57 @@ pub enum Command {
         #[command(subcommand)]
         command: AccountCommand,
     },
+    /// Credentials: keys, pasted sessions, logins and local sources.
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
     /// Poll now: one provider, or everything.
     Refresh {
         /// A provider slug. Omitted, every configured account is polled.
         provider: Option<String>,
+    },
+}
+
+/// A secret is never a positional argument: `/proc/<pid>/cmdline` is readable by every
+/// process of the same user, and a key typed once lands in shell history. There is
+/// deliberately no slot to put one in — see `secret.rs`.
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Store an API key. The key is read from stdin, or from --key-file.
+    SetKey {
+        provider: String,
+        account: String,
+        /// Read the key from this file instead of stdin.
+        #[arg(long)]
+        key_file: Option<std::path::PathBuf>,
+    },
+    /// Store a browser session header. Read like a key.
+    SetSession {
+        provider: String,
+        account: String,
+        /// Read the session from this file instead of stdin.
+        #[arg(long)]
+        key_file: Option<std::path::PathBuf>,
+    },
+    /// Remove whatever credential Tidemark holds for an account.
+    SignOut { provider: String, account: String },
+    /// Print the authorize URL, then wait for the browser to come back.
+    Login { provider: String, account: String },
+    /// Abandon a login that is waiting.
+    CancelLogin { provider: String, account: String },
+    /// The local authentication sources the daemon can see, without their credentials.
+    Sources { provider: String, account: String },
+    /// Record which local source this account uses.
+    Select {
+        provider: String,
+        account: String,
+        /// The mode value from `auth sources`.
+        #[arg(long)]
+        mode: String,
+        /// The candidate id, for a mode that offers a choice.
+        #[arg(long)]
+        candidate: Option<String>,
     },
 }
 

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -42,6 +42,97 @@ pub enum Command {
         /// A provider slug. Omitted, every configured account is polled.
         provider: Option<String>,
     },
+    /// One of a provider's own settings.
+    Option {
+        provider: String,
+        account: String,
+        name: String,
+        value: String,
+    },
+    /// Notifications for one window of one account.
+    Notify {
+        provider: String,
+        account: String,
+        window: String,
+        enabled: Switch,
+    },
+    /// Application preferences the daemon keeps in config.toml.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+    /// Stored history.
+    History {
+        #[command(subcommand)]
+        command: HistoryCommand,
+    },
+    /// Paths and storage facts.
+    Data,
+    /// A newer published release, if the daemon knows of one.
+    Update,
+}
+
+/// `on` and `off` rather than `true` and `false`: the settings pages call these switches,
+/// and `config show` prints the same two words, so its output feeds straight back in.
+///
+/// A `ValueEnum` rather than a parser onto `bool`: clap derives a flag from a `bool`
+/// positional and refuses to take a value for it, and this way `--help` lists the two
+/// words instead of leaving them to prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Switch {
+    On,
+    Off,
+}
+
+impl From<Switch> for bool {
+    fn from(switch: Switch) -> Self {
+        matches!(switch, Switch::On)
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigCommand {
+    /// Every preference, as the daemon holds it.
+    Show,
+    /// The one proxy every request and every child process goes through.
+    Proxy {
+        /// off, http, https or socks5.
+        mode: String,
+        /// Required by every mode but `off`.
+        host: Option<String>,
+        /// Required by every mode but `off`.
+        port: Option<u16>,
+    },
+    /// How healthy accounts are paced.
+    Refresh {
+        /// auto or manual.
+        mode: String,
+        /// Minutes between polls in manual mode, 1 to 120.
+        #[arg(long)]
+        minutes: Option<u32>,
+    },
+    /// forever, six-months or one-year.
+    Retention { retention: String },
+    /// system, light or dark.
+    Theme { theme: String },
+    /// app, daemon or off.
+    Startup { mode: String },
+    /// Whether the daemon may ask GitHub for the latest release.
+    ReleaseCheck { enabled: Switch },
+    /// Whether the window's close button hides it.
+    MinimizeOnClose { enabled: Switch },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HistoryCommand {
+    /// The stored points of one window's current segment, oldest first.
+    Segment {
+        provider: String,
+        account: String,
+        window: String,
+    },
+    /// Delete every stored point, segment and notification record.
+    Clear,
 }
 
 /// A secret is never a positional argument: `/proc/<pid>/cmdline` is readable by every

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -38,6 +38,7 @@ pub struct Usage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Format {
     Text,
+    Json,
 }
 
 #[cfg(test)]

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -39,6 +39,7 @@ pub struct Usage {
 pub enum Format {
     Text,
     Json,
+    Waybar,
 }
 
 #[cfg(test)]

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -16,6 +16,28 @@ pub struct Cli {
 pub enum Command {
     /// This client's version, and the daemon's.
     Version,
+    /// What every configured account currently reports.
+    Usage(Usage),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct Usage {
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Only this account of that provider.
+    #[arg(long, requires = "provider")]
+    pub account: Option<String>,
+    /// How to print it.
+    #[arg(long, value_enum, default_value_t = Format::Text)]
+    pub format: Format,
+}
+
+/// The output shapes. `json` and `waybar` are contracts other programs parse; `text` is
+/// for a person and may be reworded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Format {
+    Text,
 }
 
 #[cfg(test)]

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -18,6 +18,27 @@ pub enum Command {
     Version,
     /// What every configured account currently reports.
     Usage(Usage),
+    /// Exit 0 when enough quota is left to start something, 1 when there is not.
+    Guard(Guard),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct Guard {
+    /// Fail when less than this percentage of the window is left.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub min_remaining: u8,
+    /// Judge this window key instead of the one a card leads with.
+    #[arg(long, conflicts_with = "any")]
+    pub window: Option<String>,
+    /// Judge every window, not just the leading one.
+    #[arg(long)]
+    pub any: bool,
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Only this account of that provider.
+    #[arg(long, requires = "provider")]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/tidemark-cli/src/commands/account.rs
+++ b/crates/tidemark-cli/src/commands/account.rs
@@ -1,0 +1,33 @@
+//! The accounts one provider carries.
+//!
+//! `account rm` is deliberately the same daemon call as `provider rm`: there is one
+//! removal, and which noun the user reached for does not change what happens to the
+//! credential, the history or the card.
+
+use tidemark_ipc::DaemonProxy;
+
+use crate::cli::AccountCommand;
+use crate::exit::{Exit, Failure};
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: AccountCommand) -> Result<Exit, Failure> {
+    match command {
+        AccountCommand::Add { provider, account } => proxy.add_account(&provider, &account).await?,
+        AccountCommand::Rm { provider, account } => {
+            proxy.remove_provider(&provider, &account).await?
+        }
+        AccountCommand::Rename {
+            provider,
+            account,
+            new,
+        } => proxy.rename_account(&provider, &account, &new).await?,
+        AccountCommand::Order { provider, accounts } => {
+            if accounts.is_empty() {
+                return Err(Failure::usage(
+                    "account order needs every account of that provider, in the order you want",
+                ));
+            }
+            proxy.set_account_order(&provider, accounts).await?
+        }
+    }
+    Ok(Exit::Ok)
+}

--- a/crates/tidemark-cli/src/commands/auth.rs
+++ b/crates/tidemark-cli/src/commands/auth.rs
@@ -1,0 +1,145 @@
+//! Credentials, from the outside.
+//!
+//! Nothing here reads a keyring, a cookie database or a token file: the daemon owns every
+//! credential, and this only hands it a value or asks it what it can see. What it prints
+//! back is exactly what the daemon published — titles and readiness, never a secret.
+
+use std::io::Write;
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::{AuthCandidate, AuthSelection};
+
+use crate::cli::AuthCommand;
+use crate::exit::{Exit, Failure};
+use crate::secret;
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: AuthCommand) -> Result<Exit, Failure> {
+    match command {
+        AuthCommand::SetKey {
+            provider,
+            account,
+            key_file,
+        } => {
+            let key = secret::read(source(key_file))?;
+            proxy.set_key(&provider, &account, &key).await?;
+        }
+        AuthCommand::SetSession {
+            provider,
+            account,
+            key_file,
+        } => {
+            let session = secret::read(source(key_file))?;
+            proxy.set_session(&provider, &account, &session).await?;
+        }
+        AuthCommand::SignOut { provider, account } => proxy.sign_out(&provider, &account).await?,
+        // The URL first and flushed, because the caller — a person or a plugin — cannot act
+        // on it until it is on the pipe, and `AwaitLogin` then blocks for as long as the
+        // browser takes. The daemon never opens a browser and neither does this: it may be
+        // running on a machine with no display.
+        AuthCommand::Login { provider, account } => {
+            let url = proxy.begin_login(&provider, &account).await?;
+            println!("{url}");
+            std::io::stdout().flush()?;
+            proxy.await_login(&provider, &account).await?;
+        }
+        AuthCommand::CancelLogin { provider, account } => {
+            proxy.cancel_login(&provider, &account).await?
+        }
+        AuthCommand::Sources { provider, account } => {
+            print!(
+                "{}",
+                sources(&proxy.get_auth_sources(&provider, &account).await?)
+            );
+        }
+        AuthCommand::Select {
+            provider,
+            account,
+            mode,
+            candidate,
+        } => {
+            proxy
+                .select_auth_source(&provider, &account, AuthSelection { mode, candidate })
+                .await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+
+fn source(key_file: Option<std::path::PathBuf>) -> secret::Source {
+    match key_file {
+        Some(path) => secret::Source::File(path),
+        None => secret::Source::Stdin,
+    }
+}
+
+/// The id first, because that is the word `auth select --candidate` takes, then the name a
+/// person recognises the source by. Never a cookie value, a token or a database path — the
+/// daemon does not publish those, and this prints exactly what it publishes.
+///
+/// A string rather than a `println!` per row so the shape can be tested without a daemon.
+fn sources(candidates: &[AuthCandidate]) -> String {
+    let mut out = String::new();
+    rows(&mut out, candidates, 0);
+    out
+}
+
+/// A profile inside a browser is a child, and its indent is what says so.
+fn rows(out: &mut String, candidates: &[AuthCandidate], depth: usize) {
+    for candidate in candidates {
+        out.push_str(&format!(
+            "{}{:<28} {:<24} {:<12} {}\n",
+            "  ".repeat(depth),
+            candidate.id,
+            candidate.title,
+            candidate.state,
+            candidate.subtitle.as_deref().unwrap_or("")
+        ));
+        rows(out, &candidate.children, depth + 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(id: &str, title: &str, children: Vec<AuthCandidate>) -> AuthCandidate {
+        AuthCandidate {
+            id: id.to_owned(),
+            title: title.to_owned(),
+            subtitle: None,
+            state: "ready".to_owned(),
+            children,
+        }
+    }
+
+    /// The nesting is the whole information in a browser with two usable profiles: which
+    /// id belongs to which browser, so `auth select --candidate` can name one.
+    #[test]
+    fn a_profile_inside_a_browser_is_indented_under_it() {
+        let out = sources(&[candidate(
+            "firefox",
+            "Firefox",
+            vec![candidate("firefox:default", "default", Vec::new())],
+        )]);
+        let mut lines = out.lines();
+        assert!(
+            lines.next().expect("a browser row").starts_with("firefox "),
+            "{out}"
+        );
+        assert!(
+            lines
+                .next()
+                .expect("a profile row")
+                .starts_with("  firefox:default "),
+            "{out}"
+        );
+    }
+
+    /// An absent subtitle prints as nothing, not as a word standing in for one.
+    #[test]
+    fn a_source_without_context_gets_no_invented_context() {
+        let out = sources(&[candidate("chrome", "Chrome", Vec::new())]);
+        assert_eq!(out.lines().count(), 1, "{out}");
+        assert!(out.trim_end().ends_with("ready"), "{out}");
+    }
+}

--- a/crates/tidemark-cli/src/commands/config.rs
+++ b/crates/tidemark-cli/src/commands/config.rs
@@ -1,0 +1,106 @@
+//! Application preferences, as the daemon holds them.
+//!
+//! Every named choice is a string the daemon validates, not an enum this client duplicates:
+//! a newer daemon may accept a value this build has never heard of, and refusing it here
+//! would make the client the thing that needs upgrading.
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::Preferences;
+
+use crate::cli::ConfigCommand;
+use crate::exit::{Exit, Failure};
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: ConfigCommand) -> Result<Exit, Failure> {
+    match command {
+        ConfigCommand::Show => print!("{}", show(&proxy.get_preferences().await?)),
+        // The daemon takes the three proxy values as one call because half a proxy is a
+        // proxy nothing can be reached through. Completing them here means the user gets a
+        // sentence instead of a refusal.
+        ConfigCommand::Proxy { mode, host, port } => {
+            if mode == Preferences::PROXY_OFF {
+                proxy.set_proxy(&mode, "", 0).await?;
+            } else {
+                let (Some(host), Some(port)) = (host, port) else {
+                    return Err(Failure::usage(format!(
+                        "the `{mode}` proxy mode needs a host and a port"
+                    )));
+                };
+                proxy.set_proxy(&mode, &host, port).await?;
+            }
+        }
+        // The interval first: `SetRefreshMode` polls every account immediately, so the
+        // other order would poll once at the pace the user is leaving behind.
+        ConfigCommand::Refresh { mode, minutes } => {
+            if let Some(minutes) = minutes {
+                proxy.set_refresh_minutes(minutes).await?;
+            }
+            proxy.set_refresh_mode(&mode).await?;
+        }
+        ConfigCommand::Retention { retention } => proxy.set_history_retention(&retention).await?,
+        ConfigCommand::Theme { theme } => proxy.set_theme(&theme).await?,
+        ConfigCommand::Startup { mode } => proxy.set_startup_mode(&mode).await?,
+        ConfigCommand::ReleaseCheck { enabled } => proxy.set_release_check(enabled.into()).await?,
+        ConfigCommand::MinimizeOnClose { enabled } => {
+            proxy.set_minimize_on_close(enabled.into()).await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+
+/// Named choices are printed as the daemon stores them, so what comes out of `show` is
+/// what goes back into the corresponding subcommand. Switches print `on` and `off` for the
+/// same reason: that is what `config release-check` takes.
+fn show(preferences: &Preferences) -> String {
+    let mut out = String::new();
+    let mut row = |name: &str, value: &str| out.push_str(&format!("{name:<20}{value}\n"));
+    row("release-check", switch(preferences.release_check));
+    row("minimize-on-close", switch(preferences.minimize_on_close));
+    row(
+        "theme",
+        preferences
+            .theme
+            .as_deref()
+            .unwrap_or(Preferences::THEME_SYSTEM),
+    );
+    row("startup", &preferences.startup_mode);
+    row("retention", &preferences.history_retention);
+    row("refresh", &preferences.refresh_mode);
+    row("refresh-minutes", &preferences.refresh_minutes.to_string());
+    row("proxy", &preferences.proxy_mode);
+    row("proxy-host", &preferences.proxy_host);
+    row("proxy-port", &preferences.proxy_port.to_string());
+    out
+}
+
+const fn switch(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `config show` and the subcommands must speak the same words, or the output cannot be
+    /// fed back in. `on`/`off` is what `value_parser = switch` takes in `cli.rs`.
+    #[test]
+    fn a_switch_prints_the_word_the_subcommand_accepts() {
+        let preferences = Preferences {
+            release_check: false,
+            ..Preferences::default()
+        };
+        let out = show(&preferences);
+        assert!(out.contains("release-check       off"), "{out}");
+        assert!(out.contains("minimize-on-close   on"), "{out}");
+    }
+
+    /// A daemon too old to publish a theme sends the field absent, which means system —
+    /// not "unknown", and not an empty column.
+    #[test]
+    fn an_absent_theme_reads_as_system() {
+        let preferences = Preferences {
+            theme: None,
+            ..Preferences::default()
+        };
+        assert!(show(&preferences).contains("theme               system"));
+    }
+}

--- a/crates/tidemark-cli/src/commands/mod.rs
+++ b/crates/tidemark-cli/src/commands/mod.rs
@@ -1,0 +1,5 @@
+//! One module per entity the daemon owns. Every function takes the proxy rather than
+//! building one, which is what makes them testable against a fake daemon.
+
+pub mod account;
+pub mod provider;

--- a/crates/tidemark-cli/src/commands/mod.rs
+++ b/crates/tidemark-cli/src/commands/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod account;
 pub mod auth;
+pub mod config;
 pub mod provider;

--- a/crates/tidemark-cli/src/commands/mod.rs
+++ b/crates/tidemark-cli/src/commands/mod.rs
@@ -2,4 +2,5 @@
 //! building one, which is what makes them testable against a fake daemon.
 
 pub mod account;
+pub mod auth;
 pub mod provider;

--- a/crates/tidemark-cli/src/commands/provider.rs
+++ b/crates/tidemark-cli/src/commands/provider.rs
@@ -1,0 +1,52 @@
+//! The provider catalog and the configured set.
+//!
+//! Nothing here decides anything: the daemon owns the config file, the credentials and the
+//! order, and a second opinion living in the client is a second opinion that goes stale.
+//! The one exception is an argument that cannot be a request at all — see `Order`.
+
+use tidemark_ipc::DaemonProxy;
+
+use crate::cli::ProviderCommand;
+use crate::exit::{Exit, Failure};
+use crate::titles::Titles;
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: ProviderCommand) -> Result<Exit, Failure> {
+    match command {
+        ProviderCommand::Catalog => {
+            for definition in proxy.list_providers().await? {
+                println!(
+                    "{:<20} {:<24} {}",
+                    definition.provider, definition.title, definition.credential
+                );
+            }
+        }
+        ProviderCommand::List => {
+            let titles = Titles::fetch(proxy).await?;
+            for status in proxy.get_status().await? {
+                println!(
+                    "{:<20} {:<12} {:<20} {}",
+                    status.provider,
+                    status.account,
+                    titles.name(&status.provider),
+                    status.state
+                );
+            }
+        }
+        ProviderCommand::Add { provider } => proxy.add_provider(&provider).await?,
+        ProviderCommand::Rm { provider, account } => {
+            proxy.remove_provider(&provider, &account).await?
+        }
+        // The daemon takes an order as a permutation of the configured set and refuses a
+        // partial one; refusing an empty list here keeps a mistyped shell glob from
+        // becoming a D-Bus error the user has to interpret.
+        ProviderCommand::Order { providers } => {
+            if providers.is_empty() {
+                return Err(Failure::usage(
+                    "provider order needs the whole configured set, in the order you want",
+                ));
+            }
+            proxy.set_order(&providers).await?
+        }
+    }
+    Ok(Exit::Ok)
+}

--- a/crates/tidemark-cli/src/connect.rs
+++ b/crates/tidemark-cli/src/connect.rs
@@ -1,0 +1,11 @@
+//! The one connection this program makes.
+//!
+//! Nothing here inspects `systemctl`: the daemon is D-Bus-activated, so asking for it is
+//! how it starts. A machine with no session bus fails as unreachable, which is the truth.
+
+use tidemark_ipc::DaemonProxy;
+
+pub async fn daemon() -> zbus::Result<DaemonProxy<'static>> {
+    let connection = zbus::Connection::session().await?;
+    DaemonProxy::new(&connection).await
+}

--- a/crates/tidemark-cli/src/exit.rs
+++ b/crates/tidemark-cli/src/exit.rs
@@ -10,10 +10,6 @@ pub enum Exit {
     /// `guard` only: less quota is left than was asked for.
     Below = 1,
     /// The arguments do not name a command this build can run (`EX_USAGE`).
-    #[expect(
-        dead_code,
-        reason = "for arguments this program rejects itself; clap's own errors exit 2"
-    )]
     Usage = 64,
     /// The daemon could not be reached, or there is no reading to judge (`EX_UNAVAILABLE`).
     Unavailable = 69,
@@ -35,10 +31,6 @@ pub struct Failure {
 }
 
 impl Failure {
-    #[expect(
-        dead_code,
-        reason = "the first self-rejected argument is in a later commit"
-    )]
     pub fn usage(message: impl Into<String>) -> Self {
         Self {
             exit: Exit::Usage,
@@ -46,10 +38,6 @@ impl Failure {
         }
     }
 
-    #[expect(
-        dead_code,
-        reason = "the first missing-reading path is in a later commit"
-    )]
     pub fn unavailable(message: impl Into<String>) -> Self {
         Self {
             exit: Exit::Unavailable,
@@ -78,6 +66,17 @@ impl From<serde_json::Error> for Failure {
         Self {
             exit: Exit::Daemon,
             message: format!("cannot serialize the daemon's answer: {error}"),
+        }
+    }
+}
+
+/// A stream whose reader went away — `head`, a killed panel plugin — is not the daemon's
+/// fault, and there is nowhere left to print anything about it.
+impl From<std::io::Error> for Failure {
+    fn from(error: std::io::Error) -> Self {
+        Self {
+            exit: Exit::Unavailable,
+            message: format!("cannot write the stream: {error}"),
         }
     }
 }

--- a/crates/tidemark-cli/src/exit.rs
+++ b/crates/tidemark-cli/src/exit.rs
@@ -1,0 +1,87 @@
+//! How the process ends. `guard`'s codes *are* its output, so every code is named once
+//! here and shared, and the two failures a script reacts to differently — nobody answered,
+//! versus the daemon refused — never collapse into the same number.
+
+/// Process exit codes, following sysexits where one applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Exit {
+    /// The command did what it was asked.
+    Ok = 0,
+    /// `guard` only: less quota is left than was asked for.
+    #[expect(
+        dead_code,
+        reason = "guard is the only caller, and it lands in a later commit"
+    )]
+    Below = 1,
+    /// The arguments do not name a command this build can run (`EX_USAGE`).
+    #[expect(
+        dead_code,
+        reason = "for arguments this program rejects itself; clap's own errors exit 2"
+    )]
+    Usage = 64,
+    /// The daemon could not be reached, or there is no reading to judge (`EX_UNAVAILABLE`).
+    Unavailable = 69,
+    /// The daemon answered with an error (`EX_SOFTWARE`).
+    Daemon = 70,
+}
+
+impl Exit {
+    pub const fn code(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Why a command stopped, in the form the process exits with.
+#[derive(Debug)]
+pub struct Failure {
+    pub exit: Exit,
+    pub message: String,
+}
+
+impl Failure {
+    #[expect(
+        dead_code,
+        reason = "the first self-rejected argument is in a later commit"
+    )]
+    pub fn usage(message: impl Into<String>) -> Self {
+        Self {
+            exit: Exit::Usage,
+            message: message.into(),
+        }
+    }
+
+    #[expect(
+        dead_code,
+        reason = "the first missing-reading path is in a later commit"
+    )]
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self {
+            exit: Exit::Unavailable,
+            message: message.into(),
+        }
+    }
+}
+
+/// An error *reply* is the daemon refusing something; anything else is the daemon not being
+/// there. A script retries one and gives up on the other.
+impl From<zbus::Error> for Failure {
+    fn from(error: zbus::Error) -> Self {
+        let exit = match &error {
+            zbus::Error::MethodError(..) | zbus::Error::FDO(_) => Exit::Daemon,
+            _ => Exit::Unavailable,
+        };
+        Self {
+            exit,
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Failure {
+    fn from(error: serde_json::Error) -> Self {
+        Self {
+            exit: Exit::Daemon,
+            message: format!("cannot serialize the daemon's answer: {error}"),
+        }
+    }
+}

--- a/crates/tidemark-cli/src/exit.rs
+++ b/crates/tidemark-cli/src/exit.rs
@@ -8,10 +8,6 @@ pub enum Exit {
     /// The command did what it was asked.
     Ok = 0,
     /// `guard` only: less quota is left than was asked for.
-    #[expect(
-        dead_code,
-        reason = "guard is the only caller, and it lands in a later commit"
-    )]
     Below = 1,
     /// The arguments do not name a command this build can run (`EX_USAGE`).
     #[expect(

--- a/crates/tidemark-cli/src/format/json.rs
+++ b/crates/tidemark-cli/src/format/json.rs
@@ -7,7 +7,6 @@
 //! produces no key at all, and no `null` invites a plugin to render it as zero.
 
 use serde::Serialize;
-use serde_json::Value;
 use tidemark_types::ProviderStatus;
 
 /// The published document.
@@ -18,37 +17,13 @@ struct Document<'a> {
 
 pub fn render(statuses: &[&ProviderStatus]) -> Result<String, serde_json::Error> {
     let document = serde_json::to_value(Document { accounts: statuses })?;
-    serde_json::to_string_pretty(&payload(document))
-}
-
-/// The values without their D-Bus envelope.
-///
-/// `tidemark-types` derives `SerializeDict`, which exists to encode `a{sv}`: every value
-/// carries its signature, so under `serde_json` `"provider"` arrives as
-/// `{"signature": "s", "value": "claude"}` and `details` nests three of those. A plugin
-/// wants the payload, and the alternative — a second serialization in `tidemark-types` —
-/// would mean two models of one wire shape and two sets of key names to keep in step.
-/// Stripping is safe because no published structure has `signature` and `value` as its
-/// only two fields; the envelope is the only thing that shape means.
-fn payload(value: Value) -> Value {
-    match value {
-        Value::Object(mut map) => {
-            if map.len() == 2
-                && map.contains_key("signature")
-                && let Some(inner) = map.remove("value")
-            {
-                return payload(inner);
-            }
-            Value::Object(map.into_iter().map(|(key, v)| (key, payload(v))).collect())
-        }
-        Value::Array(items) => Value::Array(items.into_iter().map(payload).collect()),
-        other => other,
-    }
+    serde_json::to_string_pretty(&super::payload(document))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
     use tidemark_types::{
         AccountId, DetailRow, DetailSection, ProviderId, ProviderState, WindowStatus,
     };

--- a/crates/tidemark-cli/src/format/json.rs
+++ b/crates/tidemark-cli/src/format/json.rs
@@ -1,0 +1,114 @@
+//! Usage as another program parses it.
+//!
+//! An object with one key rather than a bare array, so a later build can add a second key
+//! without breaking a plugin that already reads this one — the same reason every published
+//! D-Bus structure is a dictionary. The account objects are `ProviderStatus` under its own
+//! field names, which means **absent stays absent**: a provider that withheld a reset time
+//! produces no key at all, and no `null` invites a plugin to render it as zero.
+
+use serde::Serialize;
+use serde_json::Value;
+use tidemark_types::ProviderStatus;
+
+/// The published document.
+#[derive(Debug, Serialize)]
+struct Document<'a> {
+    accounts: &'a [&'a ProviderStatus],
+}
+
+pub fn render(statuses: &[&ProviderStatus]) -> Result<String, serde_json::Error> {
+    let document = serde_json::to_value(Document { accounts: statuses })?;
+    serde_json::to_string_pretty(&payload(document))
+}
+
+/// The values without their D-Bus envelope.
+///
+/// `tidemark-types` derives `SerializeDict`, which exists to encode `a{sv}`: every value
+/// carries its signature, so under `serde_json` `"provider"` arrives as
+/// `{"signature": "s", "value": "claude"}` and `details` nests three of those. A plugin
+/// wants the payload, and the alternative — a second serialization in `tidemark-types` —
+/// would mean two models of one wire shape and two sets of key names to keep in step.
+/// Stripping is safe because no published structure has `signature` and `value` as its
+/// only two fields; the envelope is the only thing that shape means.
+fn payload(value: Value) -> Value {
+    match value {
+        Value::Object(mut map) => {
+            if map.len() == 2
+                && map.contains_key("signature")
+                && let Some(inner) = map.remove("value")
+            {
+                return payload(inner);
+            }
+            Value::Object(map.into_iter().map(|(key, v)| (key, payload(v))).collect())
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(payload).collect()),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{
+        AccountId, DetailRow, DetailSection, ProviderId, ProviderState, WindowStatus,
+    };
+
+    #[test]
+    fn an_account_with_no_reading_publishes_no_reading_keys() {
+        let status =
+            ProviderStatus::pending(&ProviderId::new("zai".to_owned()), &AccountId::default());
+        let text = render(&[&status]).expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        let account = &value["accounts"][0];
+        assert_eq!(account["provider"], "zai");
+        assert_eq!(account["state"], "pending");
+        assert!(account.get("captured_at").is_none(), "{text}");
+        assert!(account.get("message").is_none(), "{text}");
+    }
+
+    #[test]
+    fn a_window_publishes_the_keys_a_plugin_parses() {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new("claude".to_owned()), &AccountId::default());
+        status.state = ProviderState::Ok.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = vec![WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: None,
+            used_percent: 72.0,
+            resets_at: Some(1_785_708_000),
+            length_secs: Some(18_000),
+        }];
+        let text = render(&[&status]).expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        let window = &value["accounts"][0]["windows"][0];
+        assert_eq!(window["key"], "w18000");
+        assert_eq!(window["used_percent"], 72.0);
+        assert_eq!(window["resets_at"], 1_785_708_000_i64);
+        assert_eq!(window["length_secs"], 18_000);
+        assert!(window.get("subtitle").is_none(), "{text}");
+    }
+
+    /// `details` is the deepest thing published: a list of sections, each with a list of
+    /// rows, and `SerializeDict` wraps the list *and* is the reason its contents need
+    /// unwrapping. A plugin reads `.details[0].rows[0].value`, not a signature.
+    #[test]
+    fn details_arrive_as_plain_objects_all_the_way_down() {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new("zai".to_owned()), &AccountId::default());
+        status.details = vec![DetailSection {
+            title: DetailSection::PLAN.to_owned(),
+            rows: vec![DetailRow {
+                label: "Level".to_owned(),
+                value: "pro".to_owned(),
+            }],
+        }];
+        let text = render(&[&status]).expect("serializes");
+        let value: Value = serde_json::from_str(&text).expect("valid json");
+        let section = &value["accounts"][0]["details"][0];
+        assert_eq!(section["title"], "Plan", "{text}");
+        assert_eq!(section["rows"][0]["label"], "Level", "{text}");
+        assert_eq!(section["rows"][0]["value"], "pro", "{text}");
+    }
+}

--- a/crates/tidemark-cli/src/format/mod.rs
+++ b/crates/tidemark-cli/src/format/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod json;
 pub mod text;
+pub mod waybar;
 
 use tidemark_types::{ProviderStatus, Window};
 
@@ -26,10 +27,6 @@ pub fn select<'a>(
 /// `Snapshot::dominant_window` is the shared rule — shortest window unless the provider
 /// names a lead one — and reusing it is what keeps the CLI, the card and the tray naming
 /// the same window.
-#[expect(
-    dead_code,
-    reason = "waybar and guard are its callers, in later commits"
-)]
 pub fn dominant(status: &ProviderStatus) -> Option<Window> {
     let snapshot = status.to_snapshot()?;
     snapshot.dominant_window().cloned()

--- a/crates/tidemark-cli/src/format/mod.rs
+++ b/crates/tidemark-cli/src/format/mod.rs
@@ -4,7 +4,36 @@ pub mod json;
 pub mod text;
 pub mod waybar;
 
+use serde_json::Value;
 use tidemark_types::{ProviderStatus, Window};
+
+/// The values without their D-Bus envelope.
+///
+/// `tidemark-types` derives `SerializeDict`, which exists to encode `a{sv}`: every value
+/// carries its signature, so under `serde_json` `"provider"` arrives as
+/// `{"signature": "s", "value": "claude"}` and `details` nests three of those. A plugin
+/// wants the payload, and the alternative — a second serialization in `tidemark-types` —
+/// would mean two models of one wire shape and two sets of key names to keep in step.
+/// Stripping is safe because no published structure has `signature` and `value` as its
+/// only two fields; the envelope is the only thing that shape means.
+///
+/// It lives here rather than in [`json`] because `watch`'s event lines publish the same
+/// wire types and need the same peeling: one rule, one place.
+pub fn payload(value: Value) -> Value {
+    match value {
+        Value::Object(mut map) => {
+            if map.len() == 2
+                && map.contains_key("signature")
+                && let Some(inner) = map.remove("value")
+            {
+                return payload(inner);
+            }
+            Value::Object(map.into_iter().map(|(key, v)| (key, payload(v))).collect())
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(payload).collect()),
+        other => other,
+    }
+}
 
 /// The accounts a `--provider` / `--account` pair names, in the daemon's published order.
 ///

--- a/crates/tidemark-cli/src/format/mod.rs
+++ b/crates/tidemark-cli/src/format/mod.rs
@@ -1,0 +1,73 @@
+//! Turning what the daemon published into what a caller asked for.
+
+pub mod text;
+
+use tidemark_types::{ProviderStatus, Window};
+
+/// The accounts a `--provider` / `--account` pair names, in the daemon's published order.
+///
+/// The order is the user's, kept by the daemon and never re-sorted here: a CLI that
+/// ordered by urgency would disagree with the grid about which card comes first.
+pub fn select<'a>(
+    statuses: &'a [ProviderStatus],
+    provider: Option<&str>,
+    account: Option<&str>,
+) -> Vec<&'a ProviderStatus> {
+    statuses
+        .iter()
+        .filter(|status| provider.is_none_or(|slug| status.provider == slug))
+        .filter(|status| account.is_none_or(|id| status.account == id))
+        .collect()
+}
+
+/// The window a card would lead with, cloned out of the rebuilt snapshot so it outlives it.
+///
+/// `Snapshot::dominant_window` is the shared rule — shortest window unless the provider
+/// names a lead one — and reusing it is what keeps the CLI, the card and the tray naming
+/// the same window.
+#[expect(
+    dead_code,
+    reason = "waybar and guard are its callers, in later commits"
+)]
+pub fn dominant(status: &ProviderStatus) -> Option<Window> {
+    let snapshot = status.to_snapshot()?;
+    snapshot.dominant_window().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId};
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(
+            &ProviderId::new(provider.to_owned()),
+            &AccountId::new(account.to_owned()),
+        )
+    }
+
+    #[test]
+    fn no_filter_keeps_every_account_in_published_order() {
+        let statuses = vec![status("codex", "default"), status("claude", "work")];
+        let selected = select(&statuses, None, None);
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].provider, "codex");
+    }
+
+    #[test]
+    fn a_provider_filter_keeps_all_of_its_accounts() {
+        let statuses = vec![
+            status("claude", "default"),
+            status("claude", "work"),
+            status("codex", "default"),
+        ];
+        assert_eq!(select(&statuses, Some("claude"), None).len(), 2);
+        assert_eq!(select(&statuses, Some("claude"), Some("work")).len(), 1);
+    }
+
+    #[test]
+    fn an_account_that_is_not_there_selects_nothing() {
+        let statuses = vec![status("claude", "default")];
+        assert!(select(&statuses, Some("claude"), Some("nope")).is_empty());
+    }
+}

--- a/crates/tidemark-cli/src/format/mod.rs
+++ b/crates/tidemark-cli/src/format/mod.rs
@@ -1,5 +1,6 @@
 //! Turning what the daemon published into what a caller asked for.
 
+pub mod json;
 pub mod text;
 
 use tidemark_types::{ProviderStatus, Window};

--- a/crates/tidemark-cli/src/format/text.rs
+++ b/crates/tidemark-cli/src/format/text.rs
@@ -1,0 +1,142 @@
+//! Usage as a person reads it.
+//!
+//! Percentages and spans come from `tidemark_types::present`, which is why a number here
+//! and the same number on a card cannot drift apart. Everything else on the line is the
+//! provider's own text, printed as it arrived.
+
+use tidemark_types::present::{duration, percent};
+use tidemark_types::{ProviderStatus, Timestamp, WindowStatus, provider_label};
+
+/// Every selected account, one block each, in the order the daemon published them.
+pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+    let mut out = String::new();
+    for status in statuses {
+        let label = status
+            .account_label
+            .as_deref()
+            .unwrap_or(status.account.as_str());
+        out.push_str(&format!(
+            "{} · {}  [{}]\n",
+            provider_label(&status.provider),
+            label,
+            status.state
+        ));
+        if let Some(plan) = status.plan() {
+            out.push_str(&format!("  plan {plan}\n"));
+        }
+        if let Some(balance) = status.balance() {
+            out.push_str(&format!("  balance {balance}\n"));
+        }
+        if let Some(message) = &status.message {
+            out.push_str(&format!("  {message}\n"));
+        }
+        for window in &status.windows {
+            out.push_str(&line(window, now));
+        }
+        if let Some(captured) = status.captured_at {
+            out.push_str(&format!(
+                "  read {} ago\n",
+                duration(now.as_unix() - captured)
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// One window. The reset span and the pace note appear only when the provider gave enough
+/// to compute them; a withheld value is drawn as withheld, never as zero.
+fn line(status: &WindowStatus, now: Timestamp) -> String {
+    let window = status.to_window();
+    let mut line = format!("  {:<20} {:>5}", status.title, percent(window.used_percent));
+    if let Some(seconds) = window.seconds_until_reset(now) {
+        line.push_str(&format!("  resets in {}", duration(seconds)));
+    }
+    match window.is_outpacing(now) {
+        Some(true) => line.push_str("  outpacing"),
+        Some(false) => line.push_str("  on pace"),
+        None => {}
+    }
+    if let Some(subtitle) = &status.subtitle {
+        line.push_str(&format!("  ({subtitle})"));
+    }
+    line.push('\n');
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, ProviderState};
+
+    fn status(state: ProviderState, windows: Vec<WindowStatus>) -> ProviderStatus {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new("claude".to_owned()), &AccountId::default());
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = windows;
+        status
+    }
+
+    fn window(resets_at: Option<i64>, used_percent: f64) -> WindowStatus {
+        WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: Some("72 / 100 prompts".to_owned()),
+            used_percent,
+            resets_at,
+            length_secs: Some(18_000),
+        }
+    }
+
+    /// 1785704400 + 3600.
+    const NOW: i64 = 1_785_708_000;
+
+    fn now() -> Timestamp {
+        Timestamp::from_unix(NOW).expect("plausible")
+    }
+
+    #[test]
+    fn a_window_without_a_reset_time_says_nothing_about_one() {
+        let status = status(ProviderState::Ok, vec![window(None, 72.0)]);
+        let out = render(&[&status], now());
+        assert!(out.contains("72%"), "{out}");
+        assert!(!out.contains("resets in"), "{out}");
+        assert!(!out.contains("pace"), "{out}");
+    }
+
+    /// Five hours long with one to go, so four fifths of it has elapsed and 72% consumed
+    /// is *behind* that pace: `Window::is_outpacing` answers `Some(false)`, which this
+    /// renderer words as `on pace`.
+    #[test]
+    fn a_reset_time_brings_the_span_and_the_pace() {
+        let status = status(ProviderState::Ok, vec![window(Some(NOW + 3_600), 72.0)]);
+        let out = render(&[&status], now());
+        assert!(out.contains("resets in 1 h"), "{out}");
+        assert!(out.contains("on pace"), "{out}");
+    }
+
+    /// The same window with the same hour left, consumed past the elapsed fraction.
+    #[test]
+    fn a_window_ahead_of_its_elapsed_fraction_is_outpacing() {
+        let status = status(ProviderState::Ok, vec![window(Some(NOW + 3_600), 95.0)]);
+        let out = render(&[&status], now());
+        assert!(out.contains("outpacing"), "{out}");
+    }
+
+    #[test]
+    fn a_failed_poll_keeps_the_last_reading_under_its_state() {
+        let mut status = status(ProviderState::Unreachable, vec![window(None, 72.0)]);
+        status.message = Some("connection timed out".to_owned());
+        let out = render(&[&status], now());
+        assert!(out.contains("unreachable"), "{out}");
+        assert!(out.contains("connection timed out"), "{out}");
+        assert!(out.contains("72%"), "{out}");
+    }
+
+    #[test]
+    fn a_barely_touched_window_never_reads_as_untouched() {
+        let status = status(ProviderState::Ok, vec![window(None, 0.2)]);
+        assert!(render(&[&status], now()).contains("<1%"));
+    }
+}

--- a/crates/tidemark-cli/src/format/text.rs
+++ b/crates/tidemark-cli/src/format/text.rs
@@ -5,10 +5,12 @@
 //! provider's own text, printed as it arrived.
 
 use tidemark_types::present::{duration, percent};
-use tidemark_types::{ProviderStatus, Timestamp, WindowStatus, provider_label};
+use tidemark_types::{ProviderStatus, Timestamp, WindowStatus};
+
+use crate::titles::Titles;
 
 /// Every selected account, one block each, in the order the daemon published them.
-pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+pub fn render(statuses: &[&ProviderStatus], titles: &Titles, now: Timestamp) -> String {
     let mut out = String::new();
     for status in statuses {
         let label = status
@@ -17,7 +19,7 @@ pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> String {
             .unwrap_or(status.account.as_str());
         out.push_str(&format!(
             "{} · {}  [{}]\n",
-            provider_label(&status.provider),
+            titles.name(&status.provider),
             label,
             status.state
         ));
@@ -67,7 +69,7 @@ fn line(status: &WindowStatus, now: Timestamp) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidemark_types::{AccountId, ProviderId, ProviderState};
+    use tidemark_types::{AccountId, ProviderDefinition, ProviderId, ProviderState};
 
     fn status(state: ProviderState, windows: Vec<WindowStatus>) -> ProviderStatus {
         let mut status =
@@ -99,7 +101,7 @@ mod tests {
     #[test]
     fn a_window_without_a_reset_time_says_nothing_about_one() {
         let status = status(ProviderState::Ok, vec![window(None, 72.0)]);
-        let out = render(&[&status], now());
+        let out = render(&[&status], &Titles::default(), now());
         assert!(out.contains("72%"), "{out}");
         assert!(!out.contains("resets in"), "{out}");
         assert!(!out.contains("pace"), "{out}");
@@ -111,7 +113,7 @@ mod tests {
     #[test]
     fn a_reset_time_brings_the_span_and_the_pace() {
         let status = status(ProviderState::Ok, vec![window(Some(NOW + 3_600), 72.0)]);
-        let out = render(&[&status], now());
+        let out = render(&[&status], &Titles::default(), now());
         assert!(out.contains("resets in 1 h"), "{out}");
         assert!(out.contains("on pace"), "{out}");
     }
@@ -120,7 +122,7 @@ mod tests {
     #[test]
     fn a_window_ahead_of_its_elapsed_fraction_is_outpacing() {
         let status = status(ProviderState::Ok, vec![window(Some(NOW + 3_600), 95.0)]);
-        let out = render(&[&status], now());
+        let out = render(&[&status], &Titles::default(), now());
         assert!(out.contains("outpacing"), "{out}");
     }
 
@@ -128,7 +130,7 @@ mod tests {
     fn a_failed_poll_keeps_the_last_reading_under_its_state() {
         let mut status = status(ProviderState::Unreachable, vec![window(None, 72.0)]);
         status.message = Some("connection timed out".to_owned());
-        let out = render(&[&status], now());
+        let out = render(&[&status], &Titles::default(), now());
         assert!(out.contains("unreachable"), "{out}");
         assert!(out.contains("connection timed out"), "{out}");
         assert!(out.contains("72%"), "{out}");
@@ -137,6 +139,25 @@ mod tests {
     #[test]
     fn a_barely_touched_window_never_reads_as_untouched() {
         let status = status(ProviderState::Ok, vec![window(None, 0.2)]);
-        assert!(render(&[&status], now()).contains("<1%"));
+        assert!(render(&[&status], &Titles::default(), now()).contains("<1%"));
+    }
+
+    /// The catalog's own spelling, not the capitalised slug: a person reading this and a
+    /// person reading the card must see the same provider name. `provider_label` would say
+    /// "Claude" here, so a title the label cannot produce is what proves which one won.
+    #[test]
+    fn a_provider_is_named_the_way_the_catalog_spells_it() {
+        let status = status(ProviderState::Ok, vec![window(None, 10.0)]);
+        let titles = Titles::index(&[ProviderDefinition {
+            provider: "claude".to_owned(),
+            title: "Claude Code".to_owned(),
+            credential: "oauth".to_owned(),
+            credential_hint: String::new(),
+            external: None,
+            browser_auth: None,
+            options: Vec::new(),
+        }]);
+        let out = render(&[&status], &titles, now());
+        assert!(out.starts_with("Claude Code · default"), "{out}");
     }
 }

--- a/crates/tidemark-cli/src/format/waybar.rs
+++ b/crates/tidemark-cli/src/format/waybar.rs
@@ -1,0 +1,192 @@
+//! Usage as a Waybar custom module consumes it.
+//!
+//! The number is the worst dominant window across the selected accounts — the same window
+//! a card leads with, so the panel and the grid never disagree about which limit matters.
+//! `class` is always an array: a rate-limited account at 95% is `["danger", "stale"]`, and
+//! a shape that changed with the situation would make somebody's CSS conditional.
+
+use serde::Serialize;
+use tidemark_types::present::{duration, percent};
+use tidemark_types::{
+    DANGER_AT, ProviderState, ProviderStatus, Timestamp, WARNING_AT, provider_label,
+};
+
+/// What a Waybar custom module reads.
+#[derive(Debug, Serialize)]
+struct Card {
+    text: String,
+    tooltip: String,
+    class: Vec<String>,
+    percentage: u8,
+}
+
+pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> Result<String, serde_json::Error> {
+    let worst = statuses
+        .iter()
+        .filter_map(|status| super::dominant(status))
+        .map(|window| window.used_percent)
+        .fold(None, |worst: Option<f64>, used| {
+            Some(worst.map_or(used, |worst| worst.max(used)))
+        });
+    let stale = statuses
+        .iter()
+        .any(|status| ProviderState::from_wire(&status.state) != Some(ProviderState::Ok));
+
+    let card = match worst {
+        Some(used) => Card {
+            text: percent(used),
+            tooltip: tooltip(statuses, now),
+            class: classes(Some(used), stale),
+            percentage: used.clamp(0.0, 100.0).round() as u8,
+        },
+        // An empty text hides the module, which is the honest rendering of "no reading
+        // yet": a zero would be a claim about quota nobody has measured.
+        None => Card {
+            text: String::new(),
+            tooltip: "Tidemark has no reading yet".to_owned(),
+            class: classes(None, true),
+            percentage: 0,
+        },
+    };
+    serde_json::to_string(&card)
+}
+
+/// The zone first, so a stylesheet keyed on `.danger` keeps working when a second class
+/// applies. The boundaries are the shared constants the bar recolours at.
+fn classes(used: Option<f64>, stale: bool) -> Vec<String> {
+    let mut classes = Vec::new();
+    if let Some(used) = used {
+        classes.push(
+            if used >= DANGER_AT {
+                "danger"
+            } else if used >= WARNING_AT {
+                "warning"
+            } else {
+                "ok"
+            }
+            .to_owned(),
+        );
+    }
+    if stale {
+        classes.push("stale".to_owned());
+    }
+    classes
+}
+
+fn tooltip(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+    statuses
+        .iter()
+        .map(|status| {
+            let mut line = format!(
+                "{} · {}",
+                provider_label(&status.provider),
+                status
+                    .account_label
+                    .as_deref()
+                    .unwrap_or(status.account.as_str())
+            );
+            if let Some(window) = super::dominant(status) {
+                line.push_str(&format!(
+                    " — {} {}",
+                    window.title,
+                    percent(window.used_percent)
+                ));
+                if let Some(seconds) = window.seconds_until_reset(now) {
+                    line.push_str(&format!(", resets in {}", duration(seconds)));
+                }
+            }
+            if ProviderState::from_wire(&status.state) != Some(ProviderState::Ok) {
+                line.push_str(&format!(" [{}]", status.state));
+            }
+            escape(&line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Waybar renders a tooltip as Pango markup, and a provider's own window title is text we
+/// did not write. Escaping the five predefined entities is the whole of it.
+fn escape(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '\'' => escaped.push_str("&apos;"),
+            '"' => escaped.push_str("&quot;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, WindowStatus};
+
+    const NOW: i64 = 1_785_708_000;
+
+    fn now() -> Timestamp {
+        Timestamp::from_unix(NOW).expect("plausible")
+    }
+
+    fn status(provider: &str, state: ProviderState, used_percent: f64) -> ProviderStatus {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new(provider.to_owned()), &AccountId::default());
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(NOW - 60);
+        status.windows = vec![WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: None,
+            used_percent,
+            resets_at: Some(NOW + 3_600),
+            length_secs: Some(18_000),
+        }];
+        status
+    }
+
+    fn card(text: &str) -> serde_json::Value {
+        serde_json::from_str(text).expect("valid json")
+    }
+
+    #[test]
+    fn the_worst_account_sets_the_number() {
+        let low = status("claude", ProviderState::Ok, 12.0);
+        let high = status("codex", ProviderState::Ok, 91.0);
+        let card = card(&render(&[&low, &high], now()).expect("serializes"));
+        assert_eq!(card["text"], "91%");
+        assert_eq!(card["percentage"], 91);
+        assert_eq!(card["class"][0], "danger");
+    }
+
+    #[test]
+    fn a_stale_account_keeps_its_zone() {
+        let status = status("claude", ProviderState::RateLimited, 95.0);
+        let card = card(&render(&[&status], now()).expect("serializes"));
+        assert_eq!(card["class"][0], "danger");
+        assert_eq!(card["class"][1], "stale");
+    }
+
+    #[test]
+    fn nothing_to_report_hides_the_module() {
+        let pending =
+            ProviderStatus::pending(&ProviderId::new("zai".to_owned()), &AccountId::default());
+        let card = card(&render(&[&pending], now()).expect("serializes"));
+        assert_eq!(card["text"], "");
+        assert_eq!(card["percentage"], 0);
+        assert_eq!(card["class"][0], "stale");
+    }
+
+    #[test]
+    fn a_tooltip_escapes_the_provider_own_text() {
+        let mut status = status("claude", ProviderState::Ok, 50.0);
+        status.windows[0].title = "Session & overage".to_owned();
+        let card = card(&render(&[&status], now()).expect("serializes"));
+        let tooltip = card["tooltip"].as_str().expect("a string");
+        assert!(tooltip.contains("&amp;"), "{tooltip}");
+        assert!(!tooltip.contains("Session & overage"), "{tooltip}");
+    }
+}

--- a/crates/tidemark-cli/src/format/waybar.rs
+++ b/crates/tidemark-cli/src/format/waybar.rs
@@ -7,9 +7,9 @@
 
 use serde::Serialize;
 use tidemark_types::present::{duration, percent};
-use tidemark_types::{
-    DANGER_AT, ProviderState, ProviderStatus, Timestamp, WARNING_AT, provider_label,
-};
+use tidemark_types::{DANGER_AT, ProviderState, ProviderStatus, Timestamp, WARNING_AT};
+
+use crate::titles::Titles;
 
 /// What a Waybar custom module reads.
 #[derive(Debug, Serialize)]
@@ -20,7 +20,11 @@ struct Card {
     percentage: u8,
 }
 
-pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> Result<String, serde_json::Error> {
+pub fn render(
+    statuses: &[&ProviderStatus],
+    titles: &Titles,
+    now: Timestamp,
+) -> Result<String, serde_json::Error> {
     let worst = statuses
         .iter()
         .filter_map(|status| super::dominant(status))
@@ -35,7 +39,7 @@ pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> Result<String, se
     let card = match worst {
         Some(used) => Card {
             text: percent(used),
-            tooltip: tooltip(statuses, now),
+            tooltip: tooltip(statuses, titles, now),
             class: classes(Some(used), stale),
             percentage: used.clamp(0.0, 100.0).round() as u8,
         },
@@ -73,13 +77,13 @@ fn classes(used: Option<f64>, stale: bool) -> Vec<String> {
     classes
 }
 
-fn tooltip(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+fn tooltip(statuses: &[&ProviderStatus], titles: &Titles, now: Timestamp) -> String {
     statuses
         .iter()
         .map(|status| {
             let mut line = format!(
                 "{} · {}",
-                provider_label(&status.provider),
+                titles.name(&status.provider),
                 status
                     .account_label
                     .as_deref()
@@ -156,7 +160,7 @@ mod tests {
     fn the_worst_account_sets_the_number() {
         let low = status("claude", ProviderState::Ok, 12.0);
         let high = status("codex", ProviderState::Ok, 91.0);
-        let card = card(&render(&[&low, &high], now()).expect("serializes"));
+        let card = card(&render(&[&low, &high], &Titles::default(), now()).expect("serializes"));
         assert_eq!(card["text"], "91%");
         assert_eq!(card["percentage"], 91);
         assert_eq!(card["class"][0], "danger");
@@ -165,7 +169,7 @@ mod tests {
     #[test]
     fn a_stale_account_keeps_its_zone() {
         let status = status("claude", ProviderState::RateLimited, 95.0);
-        let card = card(&render(&[&status], now()).expect("serializes"));
+        let card = card(&render(&[&status], &Titles::default(), now()).expect("serializes"));
         assert_eq!(card["class"][0], "danger");
         assert_eq!(card["class"][1], "stale");
     }
@@ -174,7 +178,7 @@ mod tests {
     fn nothing_to_report_hides_the_module() {
         let pending =
             ProviderStatus::pending(&ProviderId::new("zai".to_owned()), &AccountId::default());
-        let card = card(&render(&[&pending], now()).expect("serializes"));
+        let card = card(&render(&[&pending], &Titles::default(), now()).expect("serializes"));
         assert_eq!(card["text"], "");
         assert_eq!(card["percentage"], 0);
         assert_eq!(card["class"][0], "stale");
@@ -184,7 +188,7 @@ mod tests {
     fn a_tooltip_escapes_the_provider_own_text() {
         let mut status = status("claude", ProviderState::Ok, 50.0);
         status.windows[0].title = "Session & overage".to_owned();
-        let card = card(&render(&[&status], now()).expect("serializes"));
+        let card = card(&render(&[&status], &Titles::default(), now()).expect("serializes"));
         let tooltip = card["tooltip"].as_str().expect("a string");
         assert!(tooltip.contains("&amp;"), "{tooltip}");
         assert!(!tooltip.contains("Session & overage"), "{tooltip}");

--- a/crates/tidemark-cli/src/guard.rs
+++ b/crates/tidemark-cli/src/guard.rs
@@ -1,0 +1,174 @@
+//! "May I start a long run right now?", answered with an exit code.
+//!
+//! Only an `ok` account's reading is judged. A last-good number sitting behind a rejected
+//! credential or a rate limit would answer "safe" about quota that cannot be spent, so
+//! those exit 69 — unavailable — and a script can tell "no answer" from "no quota".
+
+use tidemark_types::{ProviderState, ProviderStatus};
+
+use crate::exit::Exit;
+use crate::format;
+
+/// Which window the verdict is about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selection {
+    /// The window a card leads with.
+    Dominant,
+    /// One window by its stable key.
+    Named(String),
+    /// Every window of every selected account; the fullest one decides.
+    Any,
+}
+
+/// What the guard concluded.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Verdict {
+    Safe {
+        remaining: f64,
+    },
+    Below {
+        remaining: f64,
+    },
+    /// Nothing trustworthy to judge, with the reason for stderr.
+    Unavailable(String),
+}
+
+impl Verdict {
+    pub const fn exit(&self) -> Exit {
+        match self {
+            Self::Safe { .. } => Exit::Ok,
+            Self::Below { .. } => Exit::Below,
+            Self::Unavailable(_) => Exit::Unavailable,
+        }
+    }
+}
+
+/// The fullest selected window against the threshold. Every selected account must be `ok`
+/// and must have the window asked for; anything else is unavailable rather than a guess.
+pub fn decide(statuses: &[&ProviderStatus], selection: &Selection, min_remaining: u8) -> Verdict {
+    if statuses.is_empty() {
+        return Verdict::Unavailable("no configured account matches".to_owned());
+    }
+
+    let mut fullest: Option<f64> = None;
+    for status in statuses {
+        if ProviderState::from_wire(&status.state) != Some(ProviderState::Ok) {
+            return Verdict::Unavailable(format!(
+                "{} · {} is {}",
+                status.provider, status.account, status.state
+            ));
+        }
+        let used = match selection {
+            Selection::Dominant => format::dominant(status).map(|window| window.used_percent),
+            Selection::Named(key) => status
+                .windows
+                .iter()
+                .find(|window| &window.key == key)
+                .map(|window| window.used_percent),
+            Selection::Any => status
+                .windows
+                .iter()
+                .map(|window| window.used_percent)
+                .fold(None, |worst: Option<f64>, used| {
+                    Some(worst.map_or(used, |worst| worst.max(used)))
+                }),
+        };
+        let Some(used) = used else {
+            return Verdict::Unavailable(match selection {
+                Selection::Named(key) => format!(
+                    "{} · {} reports no window {key}",
+                    status.provider, status.account
+                ),
+                _ => format!("{} · {} has no reading", status.provider, status.account),
+            });
+        };
+        fullest = Some(fullest.map_or(used, |worst: f64| worst.max(used)));
+    }
+
+    let remaining = 100.0 - fullest.unwrap_or(100.0);
+    if remaining >= f64::from(min_remaining) {
+        Verdict::Safe { remaining }
+    } else {
+        Verdict::Below { remaining }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, WindowStatus};
+
+    fn window(key: &str, used_percent: f64) -> WindowStatus {
+        WindowStatus {
+            key: key.to_owned(),
+            title: key.to_owned(),
+            subtitle: None,
+            used_percent,
+            resets_at: None,
+            length_secs: Some(18_000),
+        }
+    }
+
+    fn status(state: ProviderState, windows: Vec<WindowStatus>) -> ProviderStatus {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new("claude".to_owned()), &AccountId::default());
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = windows;
+        status
+    }
+
+    #[test]
+    fn enough_left_is_safe() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 40.0)]);
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict, Verdict::Safe { remaining: 60.0 });
+        assert_eq!(verdict.exit(), Exit::Ok);
+    }
+
+    #[test]
+    fn too_little_left_is_below() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 85.0)]);
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict, Verdict::Below { remaining: 15.0 });
+        assert_eq!(verdict.exit(), Exit::Below);
+    }
+
+    #[test]
+    fn a_named_window_that_is_not_there_is_unavailable_not_safe() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 5.0)]);
+        let verdict = decide(&[&status], &Selection::Named("w604800".to_owned()), 20);
+        assert_eq!(verdict.exit(), Exit::Unavailable);
+    }
+
+    #[test]
+    fn a_stale_reading_is_never_judged() {
+        let status = status(
+            ProviderState::CredentialRejected,
+            vec![window("w18000", 1.0)],
+        );
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict.exit(), Exit::Unavailable);
+    }
+
+    #[test]
+    fn any_window_judges_the_fullest_one() {
+        let status = status(
+            ProviderState::Ok,
+            vec![window("w18000", 10.0), window("w604800", 95.0)],
+        );
+        assert_eq!(decide(&[&status], &Selection::Any, 20).exit(), Exit::Below);
+        assert_eq!(
+            decide(&[&status], &Selection::Dominant, 20).exit(),
+            Exit::Ok
+        );
+    }
+
+    #[test]
+    fn selecting_no_account_is_unavailable() {
+        assert_eq!(
+            decide(&[], &Selection::Dominant, 20).exit(),
+            Exit::Unavailable
+        );
+    }
+}

--- a/crates/tidemark-cli/src/lib.rs
+++ b/crates/tidemark-cli/src/lib.rs
@@ -1,0 +1,18 @@
+//! `tidemarkctl`: the third consumer of the daemon's interface, after the window and
+//! `busctl`.
+//!
+//! It performs no provider I/O — every number it prints came off the bus — and it holds no
+//! runtime: zbus's async-io backend drives its own connection thread, so one `block_on` in
+//! the binary is the whole of this program's concurrency.
+//!
+//! The library exists so the integration tests can drive the real command bodies against a
+//! fake daemon they serve themselves. Testability comes from passing a proxy in, not from
+//! an environment variable that redirects the bus name — a back door a user could trip
+//! over.
+
+pub mod cli;
+pub mod connect;
+pub mod exit;
+pub mod format;
+pub mod guard;
+pub mod watch;

--- a/crates/tidemark-cli/src/lib.rs
+++ b/crates/tidemark-cli/src/lib.rs
@@ -11,8 +11,10 @@
 //! over.
 
 pub mod cli;
+pub mod commands;
 pub mod connect;
 pub mod exit;
 pub mod format;
 pub mod guard;
+pub mod titles;
 pub mod watch;

--- a/crates/tidemark-cli/src/lib.rs
+++ b/crates/tidemark-cli/src/lib.rs
@@ -16,5 +16,6 @@ pub mod connect;
 pub mod exit;
 pub mod format;
 pub mod guard;
+pub mod secret;
 pub mod titles;
 pub mod watch;

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -99,5 +99,74 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
             proxy.refresh(provider.as_deref().unwrap_or("")).await?;
             Ok(Exit::Ok)
         }
+        cli::Command::Option {
+            provider,
+            account,
+            name,
+            value,
+        } => {
+            let proxy = connect::daemon().await?;
+            proxy.set_option(&provider, &account, &name, &value).await?;
+            Ok(Exit::Ok)
+        }
+        cli::Command::Notify {
+            provider,
+            account,
+            window,
+            enabled,
+        } => {
+            let proxy = connect::daemon().await?;
+            proxy
+                .set_window_notify(&provider, &account, &window, enabled.into())
+                .await?;
+            Ok(Exit::Ok)
+        }
+        cli::Command::Config { command } => {
+            let proxy = connect::daemon().await?;
+            commands::config::run(&proxy, command).await
+        }
+        cli::Command::History { command } => {
+            let proxy = connect::daemon().await?;
+            match command {
+                cli::HistoryCommand::Segment {
+                    provider,
+                    account,
+                    window,
+                } => {
+                    for point in proxy.current_segment(&provider, &account, &window).await? {
+                        println!(
+                            "{} {}",
+                            point.captured_at,
+                            tidemark_types::present::percent(point.used_percent)
+                        );
+                    }
+                }
+                cli::HistoryCommand::Clear => proxy.clear_history().await?,
+            }
+            Ok(Exit::Ok)
+        }
+        cli::Command::Data => {
+            let proxy = connect::daemon().await?;
+            let data = proxy.get_data_info().await?;
+            println!("config              {}", data.config_path);
+            println!("history             {}", data.history_path);
+            println!("history-bytes       {}", data.history_bytes);
+            println!("key-schema          {}", data.key_schema);
+            println!("token-schema        {}", data.token_schema);
+            // Not the `release-check` of `config show`: that is the user's switch, this is
+            // whether the build has the checker at all.
+            println!("release-check-built {}", data.release_check_available);
+            Ok(Exit::Ok)
+        }
+        cli::Command::Update => {
+            let proxy = connect::daemon().await?;
+            let version = proxy.get_update().await?;
+            if version.is_empty() {
+                println!("no newer release is known");
+            } else {
+                println!("{version}");
+            }
+            Ok(Exit::Ok)
+        }
     }
 }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -45,6 +45,7 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                     "{}",
                     format::text::render(&selected, tidemark_types::Timestamp::now())
                 ),
+                cli::Format::Json => println!("{}", format::json::render(&selected)?),
             }
             Ok(Exit::Ok)
         }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -90,6 +90,10 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
             let proxy = connect::daemon().await?;
             commands::account::run(&proxy, command).await
         }
+        cli::Command::Auth { command } => {
+            let proxy = connect::daemon().await?;
+            commands::auth::run(&proxy, command).await
+        }
         cli::Command::Refresh { provider } => {
             let proxy = connect::daemon().await?;
             proxy.refresh(provider.as_deref().unwrap_or("")).await?;

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -9,6 +9,7 @@ mod cli;
 mod connect;
 mod exit;
 mod format;
+mod guard;
 
 use std::process::ExitCode;
 
@@ -52,6 +53,25 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                 ),
             }
             Ok(Exit::Ok)
+        }
+        cli::Command::Guard(args) => {
+            let proxy = connect::daemon().await?;
+            let statuses = proxy.get_status().await?;
+            let selected =
+                format::select(&statuses, args.provider.as_deref(), args.account.as_deref());
+            let selection = match (args.any, args.window) {
+                (true, _) => guard::Selection::Any,
+                (false, Some(key)) => guard::Selection::Named(key),
+                (false, None) => guard::Selection::Dominant,
+            };
+            let verdict = guard::decide(&selected, &selection, args.min_remaining);
+            match &verdict {
+                guard::Verdict::Safe { remaining } | guard::Verdict::Below { remaining } => {
+                    println!("{} left", tidemark_types::present::percent(*remaining));
+                }
+                guard::Verdict::Unavailable(reason) => eprintln!("{reason}"),
+            }
+            Ok(verdict.exit())
         }
     }
 }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -8,6 +8,7 @@
 mod cli;
 mod connect;
 mod exit;
+mod format;
 
 use std::process::ExitCode;
 
@@ -32,6 +33,19 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
             let proxy = connect::daemon().await?;
             println!("tidemarkctl {}", env!("CARGO_PKG_VERSION"));
             println!("tidemarkd {}", proxy.version().await?);
+            Ok(Exit::Ok)
+        }
+        cli::Command::Usage(args) => {
+            let proxy = connect::daemon().await?;
+            let statuses = proxy.get_status().await?;
+            let selected =
+                format::select(&statuses, args.provider.as_deref(), args.account.as_deref());
+            match args.format {
+                cli::Format::Text => print!(
+                    "{}",
+                    format::text::render(&selected, tidemark_types::Timestamp::now())
+                ),
+            }
             Ok(Exit::Ok)
         }
     }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -10,6 +10,7 @@ mod connect;
 mod exit;
 mod format;
 mod guard;
+mod watch;
 
 use std::process::ExitCode;
 

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -1,0 +1,38 @@
+//! `tidemarkctl`: the third consumer of the daemon's interface, after the window and
+//! `busctl`.
+//!
+//! It performs no provider I/O — every number it prints came off the bus — and it holds no
+//! runtime: zbus's async-io backend drives its own connection thread, so one `block_on` at
+//! the top is the whole of this program's concurrency.
+
+mod cli;
+mod connect;
+mod exit;
+
+use std::process::ExitCode;
+
+use clap::Parser;
+
+use crate::exit::{Exit, Failure};
+
+fn main() -> ExitCode {
+    let parsed = cli::Cli::parse();
+    match async_io::block_on(run(parsed)) {
+        Ok(exit) => ExitCode::from(exit.code()),
+        Err(failure) => {
+            eprintln!("{}", failure.message);
+            ExitCode::from(failure.exit.code())
+        }
+    }
+}
+
+async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
+    match cli.command {
+        cli::Command::Version => {
+            let proxy = connect::daemon().await?;
+            println!("tidemarkctl {}", env!("CARGO_PKG_VERSION"));
+            println!("tidemarkd {}", proxy.version().await?);
+            Ok(Exit::Ok)
+        }
+    }
+}

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -8,7 +8,8 @@ use std::process::ExitCode;
 use clap::Parser;
 
 use tidemark_cli::exit::{Exit, Failure};
-use tidemark_cli::{cli, connect, format, guard, watch};
+use tidemark_cli::titles::Titles;
+use tidemark_cli::{cli, commands, connect, format, guard, watch};
 
 fn main() -> ExitCode {
     let parsed = cli::Cli::parse();
@@ -37,12 +38,20 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
             match args.format {
                 cli::Format::Text => print!(
                     "{}",
-                    format::text::render(&selected, tidemark_types::Timestamp::now())
+                    format::text::render(
+                        &selected,
+                        &Titles::fetch(&proxy).await?,
+                        tidemark_types::Timestamp::now()
+                    )
                 ),
                 cli::Format::Json => println!("{}", format::json::render(&selected)?),
                 cli::Format::Waybar => println!(
                     "{}",
-                    format::waybar::render(&selected, tidemark_types::Timestamp::now())?
+                    format::waybar::render(
+                        &selected,
+                        &Titles::fetch(&proxy).await?,
+                        tidemark_types::Timestamp::now()
+                    )?
                 ),
             }
             Ok(Exit::Ok)
@@ -72,6 +81,19 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                 cli::StreamFormat::Waybar => watch::Sink::Waybar,
             };
             watch::run(sink, args.provider).await
+        }
+        cli::Command::Provider { command } => {
+            let proxy = connect::daemon().await?;
+            commands::provider::run(&proxy, command).await
+        }
+        cli::Command::Account { command } => {
+            let proxy = connect::daemon().await?;
+            commands::account::run(&proxy, command).await
+        }
+        cli::Command::Refresh { provider } => {
+            let proxy = connect::daemon().await?;
+            proxy.refresh(provider.as_deref().unwrap_or("")).await?;
+            Ok(Exit::Ok)
         }
     }
 }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -46,6 +46,10 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                     format::text::render(&selected, tidemark_types::Timestamp::now())
                 ),
                 cli::Format::Json => println!("{}", format::json::render(&selected)?),
+                cli::Format::Waybar => println!(
+                    "{}",
+                    format::waybar::render(&selected, tidemark_types::Timestamp::now())?
+                ),
             }
             Ok(Exit::Ok)
         }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -6,6 +6,7 @@
 use std::process::ExitCode;
 
 use clap::Parser;
+use clap_complete::Generator;
 
 use tidemark_cli::exit::{Exit, Failure};
 use tidemark_cli::titles::Titles;
@@ -167,6 +168,17 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                 println!("{version}");
             }
             Ok(Exit::Ok)
+        }
+        cli::Command::Completions { shell } => {
+            let mut command = <cli::Cli as clap::CommandFactory>::command();
+            command.set_bin_name("tidemarkctl");
+            command.build();
+            let mut stdout = std::io::stdout().lock();
+            match shell.try_generate(&command, &mut stdout) {
+                Ok(()) => Ok(Exit::Ok),
+                Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(Exit::Ok),
+                Err(error) => Err(error.into()),
+            }
         }
     }
 }

--- a/crates/tidemark-cli/src/main.rs
+++ b/crates/tidemark-cli/src/main.rs
@@ -1,22 +1,14 @@
-//! `tidemarkctl`: the third consumer of the daemon's interface, after the window and
-//! `busctl`.
+//! The `tidemarkctl` binary: parse, run one command, become its exit code.
 //!
-//! It performs no provider I/O — every number it prints came off the bus — and it holds no
-//! runtime: zbus's async-io backend drives its own connection thread, so one `block_on` at
-//! the top is the whole of this program's concurrency.
-
-mod cli;
-mod connect;
-mod exit;
-mod format;
-mod guard;
-mod watch;
+//! Everything it calls lives in the library beside it, where the integration tests can
+//! reach it. See `lib.rs` for why.
 
 use std::process::ExitCode;
 
 use clap::Parser;
 
-use crate::exit::{Exit, Failure};
+use tidemark_cli::exit::{Exit, Failure};
+use tidemark_cli::{cli, connect, format, guard, watch};
 
 fn main() -> ExitCode {
     let parsed = cli::Cli::parse();
@@ -73,6 +65,13 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
                 guard::Verdict::Unavailable(reason) => eprintln!("{reason}"),
             }
             Ok(verdict.exit())
+        }
+        cli::Command::Watch(args) => {
+            let sink = match args.format {
+                cli::StreamFormat::Json => watch::Sink::Events,
+                cli::StreamFormat::Waybar => watch::Sink::Waybar,
+            };
+            watch::run(sink, args.provider).await
         }
     }
 }

--- a/crates/tidemark-cli/src/secret.rs
+++ b/crates/tidemark-cli/src/secret.rs
@@ -1,0 +1,111 @@
+//! Where a secret is allowed to come from.
+//!
+//! stdin or a file, never an argv value: `/proc/<pid>/cmdline` is readable by every process
+//! of the same user, and a key typed once ends up in shell history. stdin is a file
+//! descriptor rather than a terminal, so a plugin with its own UI writes into a pipe and
+//! never opens a console.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use crate::exit::Failure;
+
+#[derive(Debug)]
+pub enum Source {
+    Stdin,
+    File(PathBuf),
+}
+
+/// One trailing newline is trimmed — `printf` users and `echo` users should get the same
+/// key — and nothing else is touched: a key with meaningful interior characters is the
+/// provider's business, not ours.
+pub fn read(source: Source) -> Result<String, Failure> {
+    let raw = match source {
+        Source::Stdin => {
+            let mut buffer = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buffer)
+                .map_err(|error| Failure::usage(format!("cannot read stdin: {error}")))?;
+            buffer
+        }
+        Source::File(path) => std::fs::read_to_string(&path)
+            .map_err(|error| Failure::usage(format!("cannot read {}: {error}", path.display())))?,
+    };
+    let trimmed = raw
+        .strip_suffix('\n')
+        .map(|value| value.strip_suffix('\r').unwrap_or(value))
+        .unwrap_or(&raw);
+    // An empty value is refused here rather than sent: `SetKey("")` is a request to store
+    // nothing, which the daemon refuses anyway, and this way the user gets a sentence
+    // saying what to do instead of a D-Bus error to interpret.
+    if trimmed.is_empty() {
+        return Err(Failure::usage(
+            "no value on stdin: pipe the key in, or pass --key-file",
+        ));
+    }
+    Ok(trimmed.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(name: &str, contents: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("tidemarkctl-secret-{}-{name}", std::process::id()));
+        std::fs::write(&path, contents).expect("writes");
+        path
+    }
+
+    #[test]
+    fn one_trailing_newline_is_trimmed() {
+        let path = file("echo", "sk-abc\n");
+        assert_eq!(read(Source::File(path.clone())).expect("reads"), "sk-abc");
+        std::fs::remove_file(path).ok();
+    }
+
+    /// `echo` adds one newline, so one is noise. A second one is a character somebody put
+    /// there, and a credential is not ours to tidy.
+    #[test]
+    fn a_second_trailing_newline_belongs_to_the_value() {
+        let path = file("twice", "sk-abcd\n\n");
+        assert_eq!(
+            read(Source::File(path.clone())).expect("reads"),
+            "sk-abcd\n"
+        );
+        std::fs::remove_file(path).ok();
+    }
+
+    /// A CRLF file is a Windows file, and the carriage return is the line ending rather
+    /// than part of the key.
+    #[test]
+    fn a_windows_line_ending_is_not_part_of_the_key() {
+        let path = file("crlf", "sk-abc\r\n");
+        assert_eq!(read(Source::File(path.clone())).expect("reads"), "sk-abc");
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn nothing_at_all_is_a_usage_error_not_a_cleared_key() {
+        let path = file("empty", "\n");
+        let failure = read(Source::File(path.clone())).expect_err("refuses");
+        assert_eq!(failure.exit, crate::exit::Exit::Usage);
+        std::fs::remove_file(path).ok();
+    }
+
+    /// The message names the path, because the usual cause is a typo in it.
+    #[test]
+    fn a_missing_file_says_which_one() {
+        let path = std::env::temp_dir().join("tidemarkctl-secret-does-not-exist");
+        std::fs::remove_file(&path).ok();
+        let failure = read(Source::File(path.clone())).expect_err("refuses");
+        assert_eq!(failure.exit, crate::exit::Exit::Usage);
+        assert!(
+            failure
+                .message
+                .contains("tidemarkctl-secret-does-not-exist"),
+            "{}",
+            failure.message
+        );
+    }
+}

--- a/crates/tidemark-cli/src/titles.rs
+++ b/crates/tidemark-cli/src/titles.rs
@@ -1,0 +1,78 @@
+//! What to call a provider in front of a person.
+//!
+//! The daemon's catalog spells each name — "DeepSeek", "OpenRouter", "ClinePass" — and
+//! `tidemark_types::provider_label` only capitalises a slug, so a client that printed the
+//! label alone would say "Deepseek" where the card, the tray menu and the notification all
+//! say "DeepSeek". The GTK window resolves this the same way in
+//! `crates/tidemark/src/model.rs`, and the daemon does it again in `notify.rs`: catalog
+//! first, label as the fallback for a provider newer than this build.
+
+use std::collections::BTreeMap;
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::ProviderDefinition;
+
+use crate::exit::Failure;
+
+/// The catalog's spelling of each provider's name, by slug.
+#[derive(Debug, Default)]
+pub struct Titles(BTreeMap<String, String>);
+
+impl Titles {
+    pub fn index(definitions: &[ProviderDefinition]) -> Self {
+        Self(
+            definitions
+                .iter()
+                .map(|definition| (definition.provider.clone(), definition.title.clone()))
+                .collect(),
+        )
+    }
+
+    /// One catalog read. Worth its round trip only for output a person reads: `--format
+    /// json` names providers by slug and asks for none of this.
+    pub async fn fetch(proxy: &DaemonProxy<'_>) -> Result<Self, Failure> {
+        Ok(Self::index(&proxy.list_providers().await?))
+    }
+
+    /// The catalog's title when this build's daemon published one, and the slug's
+    /// capitalisation when it did not — a newer daemon may watch a provider this client has
+    /// never heard of, and its line is still worth printing.
+    pub fn name(&self, slug: &str) -> String {
+        self.0
+            .get(slug)
+            .cloned()
+            .unwrap_or_else(|| tidemark_types::provider_label(slug))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn definition(provider: &str, title: &str) -> ProviderDefinition {
+        ProviderDefinition {
+            provider: provider.to_owned(),
+            title: title.to_owned(),
+            credential: "key".to_owned(),
+            credential_hint: String::new(),
+            external: None,
+            browser_auth: None,
+            options: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn the_catalog_spelling_wins_over_the_capitalised_slug() {
+        let titles = Titles::index(&[definition("deepseek", "DeepSeek")]);
+        assert_eq!(titles.name("deepseek"), "DeepSeek");
+    }
+
+    /// A daemon newer than this client watches providers whose titles it never sent, and a
+    /// line saying "Clinepass" beats no line at all.
+    #[test]
+    fn a_provider_the_catalog_never_mentioned_still_gets_a_name() {
+        let titles = Titles::default();
+        assert_eq!(titles.name("clinepass"), "Clinepass");
+        assert_eq!(titles.name("zai"), "Z.ai");
+    }
+}

--- a/crates/tidemark-cli/src/watch/mirror.rs
+++ b/crates/tidemark-cli/src/watch/mirror.rs
@@ -1,0 +1,131 @@
+//! The client-side copy of what the daemon published.
+//!
+//! `watch --format waybar` has to re-render one card from *every* account after each
+//! signal, so the stream keeps a mirror. The rules are the daemon's own: a change to a
+//! known `(provider, account)` replaces it where it stands, an unknown one goes on the end,
+//! and an order announcement is a permutation of provider slugs rather than a new set — a
+//! status carries no position, so the sequence has to be applied separately.
+
+use tidemark_types::ProviderStatus;
+
+/// One announced change.
+///
+/// The size difference between the variants is deliberate: a change carries a whole status
+/// because that is what the signal delivers, and the value is constructed once per signal
+/// and consumed immediately, so boxing it would buy an allocation and nothing else.
+// The tests below are the only callers until `watch` lands, so the expectation holds for
+// the binary and would be unfulfilled — an error under `-D warnings` — in a test build.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the watch command builds these from signals, in the next commit"
+    )
+)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "one status per signal, consumed at once; see the doc comment"
+)]
+#[derive(Debug)]
+pub enum Change {
+    Upsert(ProviderStatus),
+    Remove { provider: String, account: String },
+    Order(Vec<String>),
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the watch command is the caller, in the next commit"
+    )
+)]
+pub fn apply(statuses: &mut Vec<ProviderStatus>, change: Change) {
+    match change {
+        Change::Upsert(status) => {
+            match statuses
+                .iter_mut()
+                .find(|held| held.provider == status.provider && held.account == status.account)
+            {
+                Some(held) => *held = status,
+                None => statuses.push(status),
+            }
+        }
+        Change::Remove { provider, account } => {
+            statuses.retain(|held| !(held.provider == provider && held.account == account));
+        }
+        // A stable sort, so accounts keep the order the daemon gave them inside their
+        // provider. A provider the announcement does not name sorts last rather than
+        // disappearing.
+        Change::Order(providers) => statuses.sort_by_key(|status| {
+            providers
+                .iter()
+                .position(|slug| *slug == status.provider)
+                .unwrap_or(usize::MAX)
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, ProviderState};
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(
+            &ProviderId::new(provider.to_owned()),
+            &AccountId::new(account.to_owned()),
+        )
+    }
+
+    #[test]
+    fn a_change_replaces_the_account_where_it_stands() {
+        let mut statuses = vec![status("claude", "default"), status("codex", "default")];
+        let mut changed = status("claude", "default");
+        changed.state = ProviderState::Ok.as_wire().to_owned();
+
+        apply(&mut statuses, Change::Upsert(changed));
+
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].provider, "claude");
+        assert_eq!(statuses[0].state, "ok");
+    }
+
+    #[test]
+    fn an_account_nobody_has_seen_goes_on_the_end() {
+        let mut statuses = vec![status("claude", "default")];
+        apply(&mut statuses, Change::Upsert(status("claude", "work")));
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[1].account, "work");
+    }
+
+    #[test]
+    fn a_removal_drops_exactly_one_account() {
+        let mut statuses = vec![status("claude", "default"), status("claude", "work")];
+        apply(
+            &mut statuses,
+            Change::Remove {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+            },
+        );
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].account, "work");
+    }
+
+    #[test]
+    fn an_order_permutes_providers_and_keeps_accounts_together() {
+        let mut statuses = vec![
+            status("claude", "default"),
+            status("codex", "default"),
+            status("claude", "work"),
+        ];
+        apply(
+            &mut statuses,
+            Change::Order(vec!["codex".to_owned(), "claude".to_owned()]),
+        );
+        assert_eq!(statuses[0].provider, "codex");
+        assert_eq!(statuses[1].account, "default");
+        assert_eq!(statuses[2].account, "work");
+    }
+}

--- a/crates/tidemark-cli/src/watch/mirror.rs
+++ b/crates/tidemark-cli/src/watch/mirror.rs
@@ -13,15 +13,6 @@ use tidemark_types::ProviderStatus;
 /// The size difference between the variants is deliberate: a change carries a whole status
 /// because that is what the signal delivers, and the value is constructed once per signal
 /// and consumed immediately, so boxing it would buy an allocation and nothing else.
-// The tests below are the only callers until `watch` lands, so the expectation holds for
-// the binary and would be unfulfilled — an error under `-D warnings` — in a test build.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the watch command builds these from signals, in the next commit"
-    )
-)]
 #[expect(
     clippy::large_enum_variant,
     reason = "one status per signal, consumed at once; see the doc comment"
@@ -33,13 +24,6 @@ pub enum Change {
     Order(Vec<String>),
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the watch command is the caller, in the next commit"
-    )
-)]
 pub fn apply(statuses: &mut Vec<ProviderStatus>, change: Change) {
     match change {
         Change::Upsert(status) => {

--- a/crates/tidemark-cli/src/watch/mod.rs
+++ b/crates/tidemark-cli/src/watch/mod.rs
@@ -1,0 +1,86 @@
+//! The daemon's signals as a line-oriented stream.
+//!
+//! One JSON object per line, flushed as it is written, so a plugin can read a pipe instead
+//! of polling a snapshot every few seconds. The first line of a connection is always a
+//! snapshot, and so is the first line after a reconnect: whatever the daemon published
+//! while nothing was listening was announced to nobody, and re-reading is the only honest
+//! recovery.
+
+pub mod mirror;
+
+use serde::Serialize;
+use tidemark_types::{DataInfo, Preferences, ProviderStatus};
+
+/// One line of the stream.
+#[expect(
+    dead_code,
+    reason = "the watch command constructs every variant, in the next commit"
+)]
+#[derive(Debug, Serialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+pub enum Event<'a> {
+    Snapshot { accounts: &'a [ProviderStatus] },
+    Changed { account: &'a ProviderStatus },
+    Removed { provider: &'a str, account: &'a str },
+    Order { providers: &'a [String] },
+    Preferences { preferences: &'a Preferences },
+    Data { data: &'a DataInfo },
+    Update { version: &'a str },
+    Waiting,
+}
+
+/// One event, one line. The published wire types carry their D-Bus signatures under
+/// `serde_json`, so the line goes through [`crate::format::payload`] — the same peeling
+/// `usage --format json` does, because a plugin reading the stream and a plugin reading a
+/// snapshot must parse the same shapes.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the watch command is the caller, in the next commit"
+    )
+)]
+pub fn line(event: &Event<'_>) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&crate::format::payload(serde_json::to_value(event)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId};
+
+    #[test]
+    fn a_snapshot_names_itself_and_carries_every_account() {
+        let accounts = vec![ProviderStatus::pending(
+            &ProviderId::new("zai".to_owned()),
+            &AccountId::default(),
+        )];
+        let text = line(&Event::Snapshot {
+            accounts: &accounts,
+        })
+        .expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        assert_eq!(value["event"], "snapshot");
+        assert_eq!(value["accounts"][0]["provider"], "zai");
+        assert!(!text.contains('\n'), "one event is one line: {text}");
+    }
+
+    #[test]
+    fn a_removal_names_the_account_that_went_away() {
+        let text = line(&Event::Removed {
+            provider: "claude",
+            account: "work",
+        })
+        .expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        assert_eq!(value["event"], "removed");
+        assert_eq!(value["provider"], "claude");
+        assert_eq!(value["account"], "work");
+    }
+
+    #[test]
+    fn waiting_is_a_line_of_its_own() {
+        let text = line(&Event::Waiting).expect("serializes");
+        assert_eq!(text, r#"{"event":"waiting"}"#);
+    }
+}

--- a/crates/tidemark-cli/src/watch/mod.rs
+++ b/crates/tidemark-cli/src/watch/mod.rs
@@ -22,6 +22,7 @@ use tidemark_types::{DataInfo, Preferences, ProviderStatus, Timestamp};
 use zbus::export::futures_core::Stream;
 
 use crate::exit::{Exit, Failure};
+use crate::titles::Titles;
 use crate::{connect, format};
 
 /// How long to wait before trying the bus again. Only reached when the *bus* is
@@ -95,11 +96,18 @@ pub async fn pump(
     let mut preferences = pin!(proxy.receive_preferences_changed().await?);
     let mut data = pin!(proxy.receive_data_changed().await?);
 
+    // A tooltip names providers the way the catalog spells them; the event stream names
+    // them by slug and would be paying for this round trip with nothing to show.
+    let titles = match sink {
+        Sink::Waybar => Titles::index(&proxy.list_providers().await?),
+        Sink::Events => Titles::default(),
+    };
     let mut statuses = proxy.get_status().await?;
     publish(
         out,
         sink,
         provider,
+        &titles,
         &statuses,
         &Event::Snapshot {
             accounts: &statuses,
@@ -142,24 +150,28 @@ pub async fn pump(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Snapshot {
                         accounts: &statuses,
                     },
                 )?;
             }
-            Signal::Owner(Some(None)) => publish(out, sink, provider, &statuses, &Event::Waiting)?,
+            Signal::Owner(Some(None)) => {
+                publish(out, sink, provider, &titles, &statuses, &Event::Waiting)?
+            }
             Signal::Changed(Some(signal)) => {
                 let status = signal.args()?.status;
                 publish(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Changed { account: &status },
                 )?;
                 mirror::apply(&mut statuses, mirror::Change::Upsert(status));
-                republish(out, sink, provider, &statuses)?;
+                republish(out, sink, provider, &titles, &statuses)?;
             }
             Signal::Removed(Some(signal)) => {
                 let args = signal.args()?;
@@ -167,6 +179,7 @@ pub async fn pump(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Removed {
                         provider: args.provider,
@@ -180,7 +193,7 @@ pub async fn pump(
                         account: args.account.to_owned(),
                     },
                 );
-                republish(out, sink, provider, &statuses)?;
+                republish(out, sink, provider, &titles, &statuses)?;
             }
             Signal::Order(Some(signal)) => {
                 let providers = signal.args()?.providers;
@@ -188,18 +201,20 @@ pub async fn pump(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Order {
                         providers: &providers,
                     },
                 )?;
                 mirror::apply(&mut statuses, mirror::Change::Order(providers));
-                republish(out, sink, provider, &statuses)?;
+                republish(out, sink, provider, &titles, &statuses)?;
             }
             Signal::Update(Some(signal)) => publish(
                 out,
                 sink,
                 provider,
+                &titles,
                 &statuses,
                 &Event::Update {
                     version: signal.args()?.version,
@@ -211,6 +226,7 @@ pub async fn pump(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Preferences {
                         preferences: &args.preferences,
@@ -223,6 +239,7 @@ pub async fn pump(
                     out,
                     sink,
                     provider,
+                    &titles,
                     &statuses,
                     &Event::Data { data: &args.data },
                 )?;
@@ -256,13 +273,14 @@ fn publish(
     out: &mut impl Write,
     sink: Sink,
     provider: Option<&str>,
+    titles: &Titles,
     statuses: &[ProviderStatus],
     event: &Event<'_>,
 ) -> Result<(), std::io::Error> {
     match sink {
         Sink::Events => emit(out, event),
         Sink::Waybar => match event {
-            Event::Snapshot { .. } | Event::Waiting => card(out, provider, statuses),
+            Event::Snapshot { .. } | Event::Waiting => card(out, provider, titles, statuses),
             _ => Ok(()),
         },
     }
@@ -274,22 +292,24 @@ fn republish(
     out: &mut impl Write,
     sink: Sink,
     provider: Option<&str>,
+    titles: &Titles,
     statuses: &[ProviderStatus],
 ) -> Result<(), std::io::Error> {
     match sink {
         Sink::Events => Ok(()),
-        Sink::Waybar => card(out, provider, statuses),
+        Sink::Waybar => card(out, provider, titles, statuses),
     }
 }
 
 fn card(
     out: &mut impl Write,
     provider: Option<&str>,
+    titles: &Titles,
     statuses: &[ProviderStatus],
 ) -> Result<(), std::io::Error> {
     let selected = format::select(statuses, provider, None);
-    let rendered =
-        format::waybar::render(&selected, Timestamp::now()).map_err(std::io::Error::other)?;
+    let rendered = format::waybar::render(&selected, titles, Timestamp::now())
+        .map_err(std::io::Error::other)?;
     writeln!(out, "{rendered}")?;
     out.flush()
 }

--- a/crates/tidemark-cli/src/watch/mod.rs
+++ b/crates/tidemark-cli/src/watch/mod.rs
@@ -8,14 +8,27 @@
 
 pub mod mirror;
 
+use std::io::Write;
+use std::pin::pin;
+use std::task::Poll;
+use std::time::Duration;
+
 use serde::Serialize;
-use tidemark_types::{DataInfo, Preferences, ProviderStatus};
+use tidemark_ipc::{
+    DaemonProxy, DataChanged, OrderChanged, PreferencesChanged, ProviderChanged, ProviderRemoved,
+    UpdateChanged,
+};
+use tidemark_types::{DataInfo, Preferences, ProviderStatus, Timestamp};
+use zbus::export::futures_core::Stream;
+
+use crate::exit::{Exit, Failure};
+use crate::{connect, format};
+
+/// How long to wait before trying the bus again. Only reached when the *bus* is
+/// unreachable; a daemon that is merely not running is waited for by name.
+const RETRY: Duration = Duration::from_secs(5);
 
 /// One line of the stream.
-#[expect(
-    dead_code,
-    reason = "the watch command constructs every variant, in the next commit"
-)]
 #[derive(Debug, Serialize)]
 #[serde(tag = "event", rename_all = "kebab-case")]
 pub enum Event<'a> {
@@ -33,15 +46,259 @@ pub enum Event<'a> {
 /// `serde_json`, so the line goes through [`crate::format::payload`] — the same peeling
 /// `usage --format json` does, because a plugin reading the stream and a plugin reading a
 /// snapshot must parse the same shapes.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the watch command is the caller, in the next commit"
-    )
-)]
 pub fn line(event: &Event<'_>) -> Result<String, serde_json::Error> {
     serde_json::to_string(&crate::format::payload(serde_json::to_value(event)?))
+}
+
+/// What the stream prints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sink {
+    /// One JSON event per line.
+    Events,
+    /// One Waybar card per change, re-rendered from the mirror.
+    Waybar,
+}
+
+/// Streams until the process is killed. Each connection's events are printed, and the loop
+/// re-reads everything after a gap.
+pub async fn run(sink: Sink, provider: Option<String>) -> Result<Exit, Failure> {
+    let mut out = std::io::stdout();
+    loop {
+        match connect::daemon().await {
+            Ok(proxy) => {
+                if let Err(error) = pump(&proxy, sink, provider.as_deref(), &mut out).await {
+                    eprintln!("{error}");
+                }
+            }
+            Err(error) => eprintln!("{error}"),
+        }
+        emit(&mut out, &Event::Waiting)?;
+        async_io::Timer::after(RETRY).await;
+    }
+}
+
+/// One connection's worth of streaming. Returns when a stream ends, which on the session
+/// bus means the connection is finished with.
+pub async fn pump(
+    proxy: &DaemonProxy<'_>,
+    sink: Sink,
+    provider: Option<&str>,
+    out: &mut impl Write,
+) -> zbus::Result<()> {
+    // Subscribed before the first GetStatus, so a poll finishing between the two arrives as
+    // a signal rather than being missed by both.
+    let mut owner = pin!(proxy.inner().receive_owner_changed().await?);
+    let mut changes = pin!(proxy.receive_provider_changed().await?);
+    let mut removals = pin!(proxy.receive_provider_removed().await?);
+    let mut orders = pin!(proxy.receive_order_changed().await?);
+    let mut updates = pin!(proxy.receive_update_changed().await?);
+    let mut preferences = pin!(proxy.receive_preferences_changed().await?);
+    let mut data = pin!(proxy.receive_data_changed().await?);
+
+    let mut statuses = proxy.get_status().await?;
+    publish(
+        out,
+        sink,
+        provider,
+        &statuses,
+        &Event::Snapshot {
+            accounts: &statuses,
+        },
+    )?;
+
+    loop {
+        let event = std::future::poll_fn(|context| {
+            if let Poll::Ready(owner) = owner.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Owner(owner));
+            }
+            if let Poll::Ready(change) = changes.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Changed(change));
+            }
+            if let Poll::Ready(removal) = removals.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Removed(removal));
+            }
+            if let Poll::Ready(order) = orders.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Order(order));
+            }
+            if let Poll::Ready(update) = updates.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Update(update));
+            }
+            if let Poll::Ready(changed) = preferences.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Preferences(changed));
+            }
+            if let Poll::Ready(changed) = data.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Data(changed));
+            }
+            Poll::Pending
+        })
+        .await;
+
+        match event {
+            // The daemon appeared, or a newer one replaced it. Re-read: what it published
+            // while nothing was listening was announced to nobody.
+            Signal::Owner(Some(Some(_))) => {
+                statuses = proxy.get_status().await?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Snapshot {
+                        accounts: &statuses,
+                    },
+                )?;
+            }
+            Signal::Owner(Some(None)) => publish(out, sink, provider, &statuses, &Event::Waiting)?,
+            Signal::Changed(Some(signal)) => {
+                let status = signal.args()?.status;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Changed { account: &status },
+                )?;
+                mirror::apply(&mut statuses, mirror::Change::Upsert(status));
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Removed(Some(signal)) => {
+                let args = signal.args()?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Removed {
+                        provider: args.provider,
+                        account: args.account,
+                    },
+                )?;
+                mirror::apply(
+                    &mut statuses,
+                    mirror::Change::Remove {
+                        provider: args.provider.to_owned(),
+                        account: args.account.to_owned(),
+                    },
+                );
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Order(Some(signal)) => {
+                let providers = signal.args()?.providers;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Order {
+                        providers: &providers,
+                    },
+                )?;
+                mirror::apply(&mut statuses, mirror::Change::Order(providers));
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Update(Some(signal)) => publish(
+                out,
+                sink,
+                provider,
+                &statuses,
+                &Event::Update {
+                    version: signal.args()?.version,
+                },
+            )?,
+            Signal::Preferences(Some(signal)) => {
+                let args = signal.args()?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Preferences {
+                        preferences: &args.preferences,
+                    },
+                )?;
+            }
+            Signal::Data(Some(signal)) => {
+                let args = signal.args()?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Data { data: &args.data },
+                )?;
+            }
+            // Any stream ending means this connection is done.
+            Signal::Owner(None)
+            | Signal::Changed(None)
+            | Signal::Removed(None)
+            | Signal::Order(None)
+            | Signal::Update(None)
+            | Signal::Preferences(None)
+            | Signal::Data(None) => return Ok(()),
+        }
+    }
+}
+
+/// Which stream produced something.
+enum Signal {
+    Owner(Option<Option<zbus::names::UniqueName<'static>>>),
+    Changed(Option<ProviderChanged>),
+    Removed(Option<ProviderRemoved>),
+    Order(Option<OrderChanged>),
+    Update(Option<UpdateChanged>),
+    Preferences(Option<PreferencesChanged>),
+    Data(Option<DataChanged>),
+}
+
+/// In event mode, one line per event; in Waybar mode, events are silent and only the card
+/// is printed, from `republish`.
+fn publish(
+    out: &mut impl Write,
+    sink: Sink,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+    event: &Event<'_>,
+) -> Result<(), std::io::Error> {
+    match sink {
+        Sink::Events => emit(out, event),
+        Sink::Waybar => match event {
+            Event::Snapshot { .. } | Event::Waiting => card(out, provider, statuses),
+            _ => Ok(()),
+        },
+    }
+}
+
+/// After a change has been applied to the mirror, a Waybar module wants the whole card
+/// again: its text is the worst window across every account, not the one that changed.
+fn republish(
+    out: &mut impl Write,
+    sink: Sink,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+) -> Result<(), std::io::Error> {
+    match sink {
+        Sink::Events => Ok(()),
+        Sink::Waybar => card(out, provider, statuses),
+    }
+}
+
+fn card(
+    out: &mut impl Write,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+) -> Result<(), std::io::Error> {
+    let selected = format::select(statuses, provider, None);
+    let rendered =
+        format::waybar::render(&selected, Timestamp::now()).map_err(std::io::Error::other)?;
+    writeln!(out, "{rendered}")?;
+    out.flush()
+}
+
+/// Written and flushed per line: stdout is block-buffered when it is a pipe, and a plugin
+/// reading a pipe must not wait for a buffer to fill.
+fn emit(out: &mut impl Write, event: &Event<'_>) -> Result<(), std::io::Error> {
+    writeln!(out, "{}", line(event).map_err(std::io::Error::other)?)?;
+    out.flush()
 }
 
 #[cfg(test)]

--- a/crates/tidemark-cli/tests/completions.rs
+++ b/crates/tidemark-cli/tests/completions.rs
@@ -1,0 +1,49 @@
+//! Shell completions are a stdout-only command: no daemon, no files and no side effects.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+#[test]
+fn every_supported_shell_receives_its_own_script() {
+    let cases = [
+        ("bash", "_tidemarkctl()"),
+        ("zsh", "#compdef tidemarkctl"),
+        ("fish", "complete -c tidemarkctl"),
+    ];
+
+    for (shell, marker) in cases {
+        let output = Command::new(env!("CARGO_BIN_EXE_tidemarkctl"))
+            .args(["completions", shell])
+            .output()
+            .expect("tidemarkctl runs");
+
+        assert!(output.status.success(), "{shell}: {output:?}");
+        let stdout = String::from_utf8(output.stdout).expect("completion script is UTF-8");
+        assert!(
+            stdout.contains(marker),
+            "{shell} completion did not contain {marker:?}: {stdout}"
+        );
+        assert!(stdout.contains("provider"), "{shell}: {stdout}");
+    }
+}
+
+#[test]
+fn a_reader_that_stops_early_does_not_make_the_cli_panic() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tidemarkctl"))
+        .args(["completions", "bash"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tidemarkctl starts");
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut first = [0_u8; 1];
+    stdout.read_exact(&mut first).expect("script starts");
+    drop(stdout);
+
+    let output = child.wait_with_output().expect("tidemarkctl exits");
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+        "{output:?}"
+    );
+}

--- a/crates/tidemark-cli/tests/fake/mod.rs
+++ b/crates/tidemark-cli/tests/fake/mod.rs
@@ -1,0 +1,171 @@
+//! A daemon that answers, and records what it was asked.
+//!
+//! The commands take a proxy, so a test drives the real command bodies against this
+//! instead of the machine's own daemon. There is deliberately no environment variable that
+//! redirects the bus name: testability comes from the parameter, not from a back door a
+//! user could trip over.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::{
+    AccountId, ProviderDefinition, ProviderId, ProviderState, ProviderStatus, ids,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct Calls(Arc<Mutex<Vec<String>>>);
+
+impl Calls {
+    pub fn record(&self, call: impl Into<String>) {
+        self.0.lock().expect("not poisoned").push(call.into());
+    }
+
+    pub fn recorded(&self) -> Vec<String> {
+        self.0.lock().expect("not poisoned").clone()
+    }
+}
+
+pub struct FakeDaemon {
+    pub calls: Calls,
+    pub statuses: Vec<ProviderStatus>,
+}
+
+impl FakeDaemon {
+    pub fn with_one_account() -> Self {
+        let mut status =
+            ProviderStatus::pending(&ProviderId::new("claude".to_owned()), &AccountId::default());
+        status.state = ProviderState::Ok.as_wire().to_owned();
+        Self {
+            calls: Calls::default(),
+            statuses: vec![status],
+        }
+    }
+}
+
+#[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+impl FakeDaemon {
+    async fn get_status(&self) -> Vec<ProviderStatus> {
+        self.calls.record("GetStatus");
+        self.statuses.clone()
+    }
+
+    async fn list_providers(&self) -> Vec<ProviderDefinition> {
+        self.calls.record("ListProviders");
+        Vec::new()
+    }
+
+    async fn add_provider(&self, provider: &str) {
+        self.calls.record(format!("AddProvider({provider})"));
+    }
+
+    async fn remove_provider(&self, provider: &str, account: &str) {
+        self.calls
+            .record(format!("RemoveProvider({provider},{account})"));
+    }
+
+    async fn add_account(&self, provider: &str, account: &str) {
+        self.calls
+            .record(format!("AddAccount({provider},{account})"));
+    }
+
+    async fn rename_account(&self, provider: &str, account: &str, new: &str) {
+        self.calls
+            .record(format!("RenameAccount({provider},{account},{new})"));
+    }
+
+    async fn set_order(&self, providers: Vec<String>) {
+        self.calls
+            .record(format!("SetOrder({})", providers.join(",")));
+    }
+
+    async fn set_account_order(&self, provider: &str, accounts: Vec<String>) {
+        self.calls.record(format!(
+            "SetAccountOrder({provider},{})",
+            accounts.join(",")
+        ));
+    }
+
+    async fn refresh(&self, provider: &str) {
+        self.calls.record(format!("Refresh({provider})"));
+    }
+
+    async fn set_key(&self, provider: &str, account: &str, key: &str) {
+        // The key's *length* is recorded, never the key: a test that printed a secret
+        // would teach the next person that printing secrets is fine.
+        self.calls.record(format!(
+            "SetKey({provider},{account},{} chars)",
+            key.chars().count()
+        ));
+    }
+
+    async fn sign_out(&self, provider: &str, account: &str) {
+        self.calls.record(format!("SignOut({provider},{account})"));
+    }
+
+    async fn set_option(&self, provider: &str, account: &str, name: &str, value: &str) {
+        self.calls
+            .record(format!("SetOption({provider},{account},{name},{value})"));
+    }
+
+    async fn set_window_notify(&self, provider: &str, account: &str, window: &str, enabled: bool) {
+        self.calls.record(format!(
+            "SetWindowNotify({provider},{account},{window},{enabled})"
+        ));
+    }
+
+    async fn set_proxy(&self, mode: &str, host: &str, port: u16) {
+        self.calls.record(format!("SetProxy({mode},{host},{port})"));
+    }
+
+    #[zbus(signal)]
+    async fn provider_changed(
+        emitter: &zbus::object_server::SignalEmitter<'_>,
+        status: ProviderStatus,
+    ) -> zbus::Result<()>;
+
+    #[zbus(property(emits_changed_signal = "false"))]
+    async fn version(&self) -> String {
+        "0.0.0-test".to_owned()
+    }
+}
+
+/// One name per served daemon. `cargo test` runs tests in parallel threads on one session
+/// bus, and a second service under a name already taken would fail to start.
+static SERVED: AtomicU32 = AtomicU32::new(0);
+
+/// Serves one fake daemon under a unique name and returns a proxy pointed at it.
+pub async fn serve(daemon: FakeDaemon) -> Option<(zbus::Connection, DaemonProxy<'static>, Calls)> {
+    let calls = daemon.calls.clone();
+    let client = zbus::Connection::session().await.ok()?;
+    let name = format!(
+        "io.github.zbndev.TidemarkCliTest{}x{}",
+        std::process::id(),
+        SERVED.fetch_add(1, Ordering::Relaxed)
+    );
+    let server = zbus::connection::Builder::session()
+        .expect("session builder")
+        .name(name.as_str())
+        .expect("unique test name")
+        .serve_at(ids::OBJECT_PATH, daemon)
+        .expect("serves the object")
+        .build()
+        .await
+        .expect("test service starts");
+    let proxy = DaemonProxy::builder(&client)
+        .destination(name)
+        .expect("valid destination")
+        .build()
+        .await
+        .expect("proxy builds");
+    Some((server, proxy, calls))
+}
+
+/// Emits `ProviderChanged` from the served object, the way the real daemon does.
+pub async fn emit_change(server: &zbus::Connection, status: ProviderStatus) {
+    let emitter =
+        zbus::object_server::SignalEmitter::new(server, ids::OBJECT_PATH).expect("valid emitter");
+    FakeDaemon::provider_changed(&emitter, status)
+        .await
+        .expect("signal goes out");
+}

--- a/crates/tidemark-cli/tests/fake/mod.rs
+++ b/crates/tidemark-cli/tests/fake/mod.rs
@@ -162,6 +162,11 @@ pub async fn serve(daemon: FakeDaemon) -> Option<(zbus::Connection, DaemonProxy<
 }
 
 /// Emits `ProviderChanged` from the served object, the way the real daemon does.
+///
+/// This module is compiled into every integration test binary and each one uses the part
+/// it needs, so an unused helper here is expected rather than dead — `expect` would itself
+/// go unfulfilled in the binary that does use it.
+#[allow(dead_code)]
 pub async fn emit_change(server: &zbus::Connection, status: ProviderStatus) {
     let emitter =
         zbus::object_server::SignalEmitter::new(server, ids::OBJECT_PATH).expect("valid emitter");

--- a/crates/tidemark-cli/tests/fake/mod.rs
+++ b/crates/tidemark-cli/tests/fake/mod.rs
@@ -118,6 +118,14 @@ impl FakeDaemon {
         self.calls.record(format!("SetProxy({mode},{host},{port})"));
     }
 
+    async fn set_refresh_mode(&self, mode: &str) {
+        self.calls.record(format!("SetRefreshMode({mode})"));
+    }
+
+    async fn set_refresh_minutes(&self, minutes: u32) {
+        self.calls.record(format!("SetRefreshMinutes({minutes})"));
+    }
+
     #[zbus(signal)]
     async fn provider_changed(
         emitter: &zbus::object_server::SignalEmitter<'_>,

--- a/crates/tidemark-cli/tests/managing_a_fake_daemon.rs
+++ b/crates/tidemark-cli/tests/managing_a_fake_daemon.rs
@@ -1,0 +1,163 @@
+//! The mutating commands, driven against a daemon that records what it was asked.
+//!
+//! What is asserted is the *call*, not a printed line: these commands exist to reach the
+//! daemon with the arguments the user typed, and the daemon owns everything after that.
+
+mod fake;
+
+use tidemark_cli::cli::{AccountCommand, ProviderCommand};
+use tidemark_cli::commands;
+
+#[test]
+fn adding_and_ordering_reach_the_daemon_with_the_arguments_given() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        commands::provider::run(
+            &proxy,
+            ProviderCommand::Add {
+                provider: "codex".to_owned(),
+            },
+        )
+        .await
+        .expect("add succeeds");
+
+        commands::provider::run(
+            &proxy,
+            ProviderCommand::Order {
+                providers: vec!["codex".to_owned(), "claude".to_owned()],
+            },
+        )
+        .await
+        .expect("order succeeds");
+
+        commands::account::run(
+            &proxy,
+            AccountCommand::Rename {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+                new: "work".to_owned(),
+            },
+        )
+        .await
+        .expect("rename succeeds");
+
+        commands::account::run(
+            &proxy,
+            AccountCommand::Order {
+                provider: "claude".to_owned(),
+                accounts: vec!["work".to_owned(), "personal".to_owned()],
+            },
+        )
+        .await
+        .expect("account order succeeds");
+
+        assert_eq!(
+            calls.recorded(),
+            vec![
+                "AddProvider(codex)".to_owned(),
+                "SetOrder(codex,claude)".to_owned(),
+                "RenameAccount(claude,default,work)".to_owned(),
+                "SetAccountOrder(claude,work,personal)".to_owned(),
+            ]
+        );
+        drop(server);
+    });
+}
+
+/// `provider rm` and `account rm` are the same daemon call, and the daemon removes the
+/// credential and the card with the account. A test that let them drift apart would be a
+/// test of nothing.
+#[test]
+fn removing_an_account_is_one_call_whichever_noun_the_user_reached_for() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        commands::provider::run(
+            &proxy,
+            ProviderCommand::Rm {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+            },
+        )
+        .await
+        .expect("provider rm succeeds");
+
+        commands::account::run(
+            &proxy,
+            AccountCommand::Rm {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+            },
+        )
+        .await
+        .expect("account rm succeeds");
+
+        let recorded = calls.recorded();
+        assert_eq!(
+            recorded,
+            vec![
+                "RemoveProvider(claude,default)".to_owned(),
+                "RemoveProvider(claude,default)".to_owned(),
+            ]
+        );
+        drop(server);
+    });
+}
+
+#[test]
+fn an_order_with_no_providers_is_refused_before_the_daemon_hears_it() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let failure = commands::provider::run(
+            &proxy,
+            ProviderCommand::Order {
+                providers: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("an empty order is not a permutation");
+
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+        drop(server);
+    });
+}
+
+#[test]
+fn an_account_order_with_no_accounts_is_refused_too() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let failure = commands::account::run(
+            &proxy,
+            AccountCommand::Order {
+                provider: "claude".to_owned(),
+                accounts: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("an empty order is not a permutation");
+
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+        drop(server);
+    });
+}

--- a/crates/tidemark-cli/tests/managing_a_fake_daemon.rs
+++ b/crates/tidemark-cli/tests/managing_a_fake_daemon.rs
@@ -5,7 +5,7 @@
 
 mod fake;
 
-use tidemark_cli::cli::{AccountCommand, ProviderCommand};
+use tidemark_cli::cli::{AccountCommand, ConfigCommand, ProviderCommand};
 use tidemark_cli::commands;
 
 #[test]
@@ -158,6 +158,95 @@ fn an_account_order_with_no_accounts_is_refused_too() {
 
         assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
         assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+        drop(server);
+    });
+}
+
+#[test]
+fn a_proxy_is_sent_as_one_setting_and_a_half_of_one_is_refused() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let failure = commands::config::run(
+            &proxy,
+            ConfigCommand::Proxy {
+                mode: "socks5".to_owned(),
+                host: Some("127.0.0.1".to_owned()),
+                port: None,
+            },
+        )
+        .await
+        .expect_err("half a proxy is not a proxy");
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+
+        commands::config::run(
+            &proxy,
+            ConfigCommand::Proxy {
+                mode: "socks5".to_owned(),
+                host: Some("127.0.0.1".to_owned()),
+                port: Some(1080),
+            },
+        )
+        .await
+        .expect("a whole proxy is accepted");
+        assert_eq!(
+            calls.recorded(),
+            vec!["SetProxy(socks5,127.0.0.1,1080)".to_owned()]
+        );
+
+        commands::config::run(
+            &proxy,
+            ConfigCommand::Proxy {
+                mode: "off".to_owned(),
+                host: None,
+                port: None,
+            },
+        )
+        .await
+        .expect("off needs neither");
+        assert_eq!(
+            calls.recorded().last().map(String::as_str),
+            Some("SetProxy(off,,0)")
+        );
+
+        drop(server);
+    });
+}
+
+/// The interval must be sent *before* the mode, because `SetRefreshMode` polls every
+/// account immediately: the other order would poll once at the interval the user was
+/// leaving behind.
+#[test]
+fn a_manual_interval_is_sent_before_the_mode_that_starts_using_it() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        commands::config::run(
+            &proxy,
+            ConfigCommand::Refresh {
+                mode: "manual".to_owned(),
+                minutes: Some(15),
+            },
+        )
+        .await
+        .expect("sets both");
+
+        assert_eq!(
+            calls.recorded(),
+            vec![
+                "SetRefreshMinutes(15)".to_owned(),
+                "SetRefreshMode(manual)".to_owned(),
+            ]
+        );
         drop(server);
     });
 }

--- a/crates/tidemark-cli/tests/storing_a_secret.rs
+++ b/crates/tidemark-cli/tests/storing_a_secret.rs
@@ -1,0 +1,99 @@
+//! What a credential command sends, and what it must never say out loud.
+
+mod fake;
+
+use tidemark_cli::cli::AuthCommand;
+use tidemark_cli::commands;
+
+#[test]
+fn a_key_from_a_file_reaches_the_daemon_and_is_never_printed() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let path = std::env::temp_dir().join(format!("tidemarkctl-key-{}", std::process::id()));
+        std::fs::write(&path, "sk-secret-value\n").expect("writes the key file");
+
+        commands::auth::run(
+            &proxy,
+            AuthCommand::SetKey {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+                key_file: Some(path.clone()),
+            },
+        )
+        .await
+        .expect("stores the key");
+
+        let recorded = calls.recorded();
+        assert_eq!(recorded, vec!["SetKey(claude,default,15 chars)".to_owned()]);
+        assert!(
+            !recorded.iter().any(|call| call.contains("sk-secret")),
+            "a secret must never reach a log or a test name: {recorded:?}"
+        );
+
+        std::fs::remove_file(path).ok();
+        drop(server);
+    });
+}
+
+/// An unreadable key file stops before the bus: a `SetKey` that stored the empty string,
+/// or a D-Bus error about a value the user never managed to supply, are both worse than
+/// the sentence naming the file.
+#[test]
+fn a_key_file_that_is_not_there_never_becomes_a_daemon_call() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let path = std::env::temp_dir().join("tidemarkctl-key-does-not-exist");
+        std::fs::remove_file(&path).ok();
+
+        let failure = commands::auth::run(
+            &proxy,
+            AuthCommand::SetKey {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+                key_file: Some(path),
+            },
+        )
+        .await
+        .expect_err("there is no key to store");
+
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+        drop(server);
+    });
+}
+
+/// `sign_out` is the one credential command with nothing to read, and the account it names
+/// must be the account the daemon is told to clear.
+#[test]
+fn signing_out_names_the_account_it_was_given() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        commands::auth::run(
+            &proxy,
+            AuthCommand::SignOut {
+                provider: "zai".to_owned(),
+                account: "tanya".to_owned(),
+            },
+        )
+        .await
+        .expect("signs out");
+
+        assert_eq!(calls.recorded(), vec!["SignOut(zai,tanya)".to_owned()]);
+        drop(server);
+    });
+}

--- a/crates/tidemark-cli/tests/watching_a_fake_daemon.rs
+++ b/crates/tidemark-cli/tests/watching_a_fake_daemon.rs
@@ -1,0 +1,84 @@
+//! The stream against a daemon this test serves itself.
+
+mod fake;
+
+use std::time::Duration;
+
+use tidemark_types::{AccountId, ProviderId, ProviderState, ProviderStatus};
+
+/// How long the pump is allowed to keep streaming before the test reads what it printed.
+///
+/// `pump` deliberately never returns while its connection lives: its streams belong to the
+/// *client* connection, and dropping the served name only makes the daemon leave the bus —
+/// which is a `waiting` line, not the end of the stream. So the test bounds it instead of
+/// waiting for a return that would mean the session bus itself had gone away.
+const STREAMING: Duration = Duration::from_millis(900);
+
+/// Long enough for a subscription to be registered, or a signal to be delivered, on a
+/// loopback session bus.
+const SETTLE: Duration = Duration::from_millis(200);
+
+#[test]
+fn the_stream_opens_with_a_snapshot_and_follows_every_change() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let mut out = Vec::new();
+        let pumping = async {
+            let _ = tidemark_cli::watch::pump(
+                &proxy,
+                tidemark_cli::watch::Sink::Events,
+                None,
+                &mut out,
+            )
+            .await;
+        };
+
+        let emitting = async {
+            let mut changed = ProviderStatus::pending(
+                &ProviderId::new("claude".to_owned()),
+                &AccountId::default(),
+            );
+            changed.state = ProviderState::RateLimited.as_wire().to_owned();
+            // Give the pump a moment to subscribe before the signal goes out.
+            async_io::Timer::after(SETTLE).await;
+            fake::emit_change(&server, changed).await;
+            async_io::Timer::after(SETTLE).await;
+            // The daemon leaving the bus is an owner change, not a closed stream.
+            drop(server);
+            async_io::Timer::after(SETTLE).await;
+        };
+
+        let bounded = futures_lite::future::or(pumping, async {
+            async_io::Timer::after(STREAMING).await;
+        });
+        futures_lite::future::zip(bounded, emitting).await;
+
+        let text = String::from_utf8(out).expect("utf-8");
+        let mut lines = text.lines();
+
+        let snapshot: serde_json::Value =
+            serde_json::from_str(lines.next().expect("a snapshot line")).expect("json");
+        assert_eq!(snapshot["event"], "snapshot");
+        assert_eq!(snapshot["accounts"][0]["provider"], "claude");
+        assert_eq!(snapshot["accounts"][0]["state"], "ok");
+
+        let change: serde_json::Value =
+            serde_json::from_str(lines.next().expect("a change line")).expect("json");
+        assert_eq!(change["event"], "changed");
+        assert_eq!(change["account"]["state"], "rate-limited");
+
+        // A daemon that went away says so, so a plugin can grey out rather than keep
+        // showing numbers nothing is refreshing.
+        let waiting: serde_json::Value =
+            serde_json::from_str(lines.next().expect("a waiting line")).expect("json");
+        assert_eq!(waiting["event"], "waiting");
+
+        // The snapshot came off the wire once; every later line came from a signal.
+        assert_eq!(calls.recorded(), vec!["GetStatus".to_owned()], "{text}");
+    });
+}

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -552,11 +552,31 @@ impl Config {
 
     /// Adds a provider to the configured set and normalizes any existing duplicates.
     pub fn add_provider(&mut self, provider: &str) -> Result<bool, ConfigError> {
+        self.add_provider_with_initial_option(provider, None)
+    }
+
+    /// Adds a provider and one initial setting in the same durable write.
+    pub fn add_provider_with_option(
+        &mut self,
+        provider: &str,
+        name: &str,
+        setting: &str,
+    ) -> Result<bool, ConfigError> {
+        self.add_provider_with_initial_option(provider, Some((name, setting)))
+    }
+
+    fn add_provider_with_initial_option(
+        &mut self,
+        provider: &str,
+        option: Option<(&str, &str)>,
+    ) -> Result<bool, ConfigError> {
         let normalized = self.normalize_providers(None)?;
         let already_configured = self
             .providers()?
             .iter()
             .any(|configured| configured == provider);
+        let option_changed =
+            option.is_some_and(|(name, setting)| self.option(provider, name) != Some(setting));
         let item = self
             .document
             .entry(PROVIDERS_KEY)
@@ -570,7 +590,10 @@ impl Config {
         if !already_configured {
             push_provider(array, provider);
         }
-        if normalized || !already_configured {
+        if let Some((name, setting)) = option.filter(|_| option_changed) {
+            self.set_option_value(provider, name, setting)?;
+        }
+        if normalized || !already_configured || option_changed {
             self.write()?;
         }
         Ok(!already_configured)
@@ -685,6 +708,16 @@ impl Config {
         setting: &str,
     ) -> Result<(), ConfigError> {
         self.normalize_providers(None)?;
+        self.set_option_value(provider, name, setting)?;
+        self.write()
+    }
+
+    fn set_option_value(
+        &mut self,
+        provider: &str,
+        name: &str,
+        setting: &str,
+    ) -> Result<(), ConfigError> {
         let providers = self
             .document
             .entry(PROVIDER_TABLE)
@@ -705,7 +738,7 @@ impl Config {
                 table: format!("{PROVIDER_TABLE}.{provider}"),
             })?;
         table.insert(name, value(setting));
-        self.write()
+        Ok(())
     }
 
     /// Sets one provider's ordered account list and writes the file.

--- a/crates/tidemark-ipc/AGENTS.md
+++ b/crates/tidemark-ipc/AGENTS.md
@@ -1,0 +1,26 @@
+# IPC CONTRACT KNOWLEDGE BASE
+
+## OVERVIEW
+The generated D-Bus proxy for `io.github.zbndev.Tidemark.Daemon1`, shared by every client: the GTK window and `tidemarkctl` build their proxy from the same trait, so a method that changed shape breaks the build instead of a user's machine.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Method, property or signal set | `src/lib.rs` | The one `#[zbus::proxy]` trait; `tidemarkd/src/service.rs` is the server half |
+| Wire payload shapes | `../tidemark-types/src/wire.rs` | This crate names those types, never defines them |
+| Interface name, path, bus name | `../tidemark-types/src/lib.rs` (`ids`) | The proxy attribute repeats them as literals; the test pins the pair |
+
+## CONVENTIONS
+- `#[zbus::proxy]` consumes the trait: the public names are `DaemonProxy` and one message struct per signal (`ProviderChanged`, `DataChanged`, …). There is no `Daemon` trait at runtime.
+- Signatures mirror the daemon's interface exactly; a change here requires the same change in `tidemarkd`'s `#[zbus::interface]`.
+- `zbus`'s `p2p` feature stays enabled: the Windows GUI builds a peer-to-peer connection and generates its proxy from this crate.
+- Nothing here opens a connection, retries, or names a transport — reconnection is `tidemark/src/bus.rs`, and the CLI's single connection is `tidemark-cli/src/connect.rs`.
+
+## ANTI-PATTERNS
+- Do not add provider I/O, storage, a display dependency, or a second async runtime; `scripts/check-layering.sh` forbids `tidemark-core`, `reqwest`, `hyper`, `rusqlite`, `libsqlite3-sys`, `gtk4`, `gtk4-sys`, `libadwaita` and `tokio`.
+- Do not define wire structures here; they belong to `tidemark-types` so the daemon and clients decode one vocabulary.
+- Do not add a client-side policy (defaults on error, retry, fallback) to the contract: a caller that wants one writes it.
+
+## CHECKS
+- `cargo test -p tidemark-ipc` serves a fake daemon on the session bus and reads it back; with no session bus it prints `skipped: no session bus reachable` and passes.
+- `cargo test -p tidemark` exercises the same proxy through the window's reconnect paths.

--- a/crates/tidemark-ipc/AGENTS.md
+++ b/crates/tidemark-ipc/AGENTS.md
@@ -19,6 +19,8 @@ The generated D-Bus proxy for `io.github.zbndev.Tidemark.Daemon1`, shared by eve
 ## ANTI-PATTERNS
 - Do not add provider I/O, storage, a display dependency, or a second async runtime; `scripts/check-layering.sh` forbids `tidemark-core`, `reqwest`, `hyper`, `rusqlite`, `libsqlite3-sys`, `gtk4`, `gtk4-sys`, `libadwaita` and `tokio`.
 - Do not define wire structures here; they belong to `tidemark-types` so the daemon and clients decode one vocabulary.
+- Never let a second `#[zbus::proxy]` definition exist anywhere in the workspace: every
+  client generates from `src/lib.rs`, so interface drift is a compile failure.
 - Do not add a client-side policy (defaults on error, retry, fallback) to the contract: a caller that wants one writes it.
 
 ## CHECKS

--- a/crates/tidemark-ipc/Cargo.toml
+++ b/crates/tidemark-ipc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tidemark-ipc"
+description = "The D-Bus contract between tidemarkd and its clients"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+# NOTE: this crate is the contract's client half. It may open a connection and nothing
+# else: no provider I/O, no database, no display, and no second async runtime — zbus's
+# async-io backend is what both the window and tidemarkctl already build on.
+# scripts/check-layering.sh enforces this.
+[dependencies]
+tidemark-types = { path = "../tidemark-types" }
+# `p2p` because the Windows GUI builds its connection that way, and this crate is what it
+# generates the proxy from.
+zbus = { version = "5.13.2", features = ["p2p"] }
+
+[dev-dependencies]
+async-io = "2.6.0"

--- a/crates/tidemark-ipc/src/lib.rs
+++ b/crates/tidemark-ipc/src/lib.rs
@@ -89,7 +89,7 @@ pub trait Daemon {
     /// Inspects secret-free local authentication candidates for one account.
     fn get_auth_sources(&self, provider: &str, account: &str) -> zbus::Result<Vec<AuthCandidate>>;
 
-    /// Revalidates and stores one local authentication selection.
+    /// Validates and stores one explicit authentication selection.
     fn select_auth_source(
         &self,
         provider: &str,

--- a/crates/tidemark-ipc/src/lib.rs
+++ b/crates/tidemark-ipc/src/lib.rs
@@ -1,0 +1,222 @@
+//! The D-Bus contract between `tidemarkd` and everything that reads it.
+//!
+//! One definition, shared: the GTK window and `tidemarkctl` generate their proxy from this
+//! trait, so a method that changed shape is a compile error here rather than a runtime
+//! error on somebody's machine. That is the same argument that keeps the wire vocabulary in
+//! `tidemark-types` — a rule the build enforces beats a rule a hurry can skip.
+//!
+//! Nothing here opens a connection or decides a policy. Reconnection, retry and the
+//! Windows peer-to-peer transport belong to the client that needs them.
+
+use tidemark_types::{
+    AuthCandidate, AuthSelection, DataInfo, HistoryPoint, Preferences, ProviderDefinition,
+    ProviderStatus,
+};
+
+#[zbus::proxy(
+    interface = "io.github.zbndev.Tidemark.Daemon1",
+    default_service = "io.github.zbndev.Tidemark.Daemon",
+    default_path = "/io/github/zbndev/Tidemark"
+)]
+pub trait Daemon {
+    /// Every provider this build knows how to configure.
+    fn list_providers(&self) -> zbus::Result<Vec<ProviderDefinition>>;
+
+    /// Adds a compiled-in provider's default account.
+    fn add_provider(&self, provider: &str) -> zbus::Result<()>;
+
+    /// Removes one configured account.
+    fn remove_provider(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Adds one more account to a provider the config already has.
+    fn add_account(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Renames one configured account, carrying its credential and history to the new id.
+    fn rename_account(&self, provider: &str, account: &str, new: &str) -> zbus::Result<()>;
+
+    /// Every account the daemon watches.
+    fn get_status(&self) -> zbus::Result<Vec<ProviderStatus>>;
+
+    /// A newer published application release, or an empty string when none is known.
+    fn get_update(&self) -> zbus::Result<String>;
+    /// Application-wide preferences stored by the daemon.
+    fn get_preferences(&self) -> zbus::Result<Preferences>;
+
+    /// Paths and storage facts for the Preferences data page.
+    fn get_data_info(&self) -> zbus::Result<DataInfo>;
+
+    /// Stored points in the current segment of one window, oldest first.
+    fn current_segment(
+        &self,
+        provider: &str,
+        account: &str,
+        window: &str,
+    ) -> zbus::Result<Vec<HistoryPoint>>;
+
+    /// Polls now: one provider by slug, or everything when given an empty string.
+    fn refresh(&self, provider: &str) -> zbus::Result<()>;
+
+    /// Asks the running window to come forward; the caller exits after this.
+    fn request_activate(&self) -> zbus::Result<()>;
+
+    /// Stores an API key for an account.
+    fn set_key(&self, provider: &str, account: &str, key: &str) -> zbus::Result<()>;
+
+    /// Stores a browser session the user pasted in, and puts the account on it.
+    fn set_session(&self, provider: &str, account: &str, session: &str) -> zbus::Result<()>;
+
+    /// Removes whatever credential Tidemark holds for an account.
+    fn sign_out(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Starts a login and returns the URL to open. Nothing is waited for yet.
+    fn begin_login(&self, provider: &str, account: &str) -> zbus::Result<String>;
+
+    /// Waits for a started login to finish. Long-running: up to the browser timeout.
+    fn await_login(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Abandons a login in progress. Not an error when there is none.
+    fn cancel_login(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// Changes one of a provider's own settings.
+    fn set_option(
+        &self,
+        provider: &str,
+        account: &str,
+        name: &str,
+        value: &str,
+    ) -> zbus::Result<()>;
+
+    /// Inspects secret-free local authentication candidates for one account.
+    fn get_auth_sources(&self, provider: &str, account: &str) -> zbus::Result<Vec<AuthCandidate>>;
+
+    /// Revalidates and stores one local authentication selection.
+    fn select_auth_source(
+        &self,
+        provider: &str,
+        account: &str,
+        selection: AuthSelection,
+    ) -> zbus::Result<()>;
+
+    /// Switches notifications for one of an account's windows on or off.
+    fn set_window_notify(
+        &self,
+        provider: &str,
+        account: &str,
+        window: &str,
+        enabled: bool,
+    ) -> zbus::Result<()>;
+
+    fn set_release_check(&self, enabled: bool) -> zbus::Result<()>;
+    fn set_minimize_on_close(&self, enabled: bool) -> zbus::Result<()>;
+    fn set_theme(&self, theme: &str) -> zbus::Result<()>;
+    fn set_startup_mode(&self, mode: &str) -> zbus::Result<()>;
+    fn set_history_retention(&self, retention: &str) -> zbus::Result<()>;
+
+    /// Chooses zone-based or fixed-interval polling for healthy accounts.
+    fn set_refresh_mode(&self, mode: &str) -> zbus::Result<()>;
+
+    /// Sets the fixed interval Manual mode polls at, in minutes.
+    fn set_refresh_minutes(&self, minutes: u32) -> zbus::Result<()>;
+
+    /// All three proxy settings at once: they are one setting, and half of it applied is a
+    /// proxy nothing can be reached through.
+    fn set_proxy(&self, mode: &str, host: &str, port: u16) -> zbus::Result<()>;
+
+    fn clear_history(&self) -> zbus::Result<()>;
+
+    /// Puts the configured providers in the order the user arranged the cards in.
+    fn set_order(&self, providers: &[String]) -> zbus::Result<()>;
+
+    /// Puts one provider's accounts in the order the user arranged them in.
+    fn set_account_order(&self, provider: &str, accounts: Vec<String>) -> zbus::Result<()>;
+
+    /// What the daemon on the other end is.
+    #[zbus(property(emits_changed_signal = "false"))]
+    fn version(&self) -> zbus::Result<String>;
+
+    /// One account changed.
+    #[zbus(signal)]
+    fn provider_changed(&self, status: ProviderStatus) -> zbus::Result<()>;
+
+    /// One configured account was removed.
+    #[zbus(signal)]
+    fn provider_removed(&self, provider: &str, account: &str) -> zbus::Result<()>;
+
+    /// The configured providers are now in this order.
+    #[zbus(signal)]
+    fn order_changed(&self, providers: Vec<String>) -> zbus::Result<()>;
+
+    /// Application preferences changed.
+    #[zbus(signal)]
+    fn preferences_changed(&self, preferences: Preferences) -> zbus::Result<()>;
+
+    /// Paths or storage facts changed.
+    #[zbus(signal)]
+    fn data_changed(&self, data: DataInfo) -> zbus::Result<()>;
+
+    /// Availability of a newer published application release changed.
+    #[zbus(signal)]
+    fn update_changed(&self, version: &str) -> zbus::Result<()>;
+
+    /// Another client asked this one to come forward.
+    #[zbus(signal)]
+    fn activate_requested(&self) -> zbus::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use tidemark_types::{AccountId, ProviderId, ProviderStatus, ids};
+
+    /// A daemon that answers two of the real methods.
+    struct FakeDaemon;
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl FakeDaemon {
+        async fn get_status(&self) -> Vec<ProviderStatus> {
+            vec![ProviderStatus::pending(
+                &ProviderId::new("zai".to_owned()),
+                &AccountId::default(),
+            )]
+        }
+
+        #[zbus(property(emits_changed_signal = "false"))]
+        async fn version(&self) -> String {
+            "0.0.0-test".to_owned()
+        }
+    }
+
+    #[test]
+    fn the_proxy_reads_a_daemon_serving_the_interface() {
+        async_io::block_on(async {
+            let Ok(connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus reachable");
+                return;
+            };
+            let name = format!("io.github.zbndev.TidemarkIpcTest{}", std::process::id());
+            let server = zbus::connection::Builder::session()
+                .expect("session builder")
+                .name(name.as_str())
+                .expect("unique test name")
+                .serve_at(ids::OBJECT_PATH, FakeDaemon)
+                .expect("serves the object")
+                .build()
+                .await
+                .expect("test service starts");
+
+            let proxy = super::DaemonProxy::builder(&connection)
+                .destination(name.as_str())
+                .expect("valid destination")
+                .build()
+                .await
+                .expect("proxy builds");
+
+            assert_eq!(proxy.version().await.expect("version"), "0.0.0-test");
+            let statuses = proxy.get_status().await.expect("status");
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].provider, "zai");
+            assert_eq!(statuses[0].state, "pending");
+
+            drop(server);
+        });
+    }
+}

--- a/crates/tidemark/Cargo.toml
+++ b/crates/tidemark/Cargo.toml
@@ -90,6 +90,7 @@ maintainer-scripts = "../../data/packaging/deb"
 assets = [
     ["target/release/tidemark", "usr/bin/", "755"],
     ["target/release/tidemarkd", "usr/bin/", "755"],
+    ["target/release/tidemarkctl", "usr/bin/", "755"],
     ["../../data/tidemarkd.service", "usr/lib/systemd/user/", "644"],
     ["../../data/icons/hicolor/16x16/apps/io.github.zbndev.Tidemark.png", "usr/share/icons/hicolor/16x16/apps/", "644"],
     ["../../data/icons/hicolor/22x22/apps/io.github.zbndev.Tidemark.png", "usr/share/icons/hicolor/22x22/apps/", "644"],
@@ -137,6 +138,7 @@ post_install_script_prog = ["/bin/sh", "-e"]
 assets = [
     { source = "target/release/tidemark", dest = "/usr/bin/tidemark", mode = "755" },
     { source = "target/release/tidemarkd", dest = "/usr/bin/tidemarkd", mode = "755" },
+    { source = "target/release/tidemarkctl", dest = "/usr/bin/tidemarkctl", mode = "755" },
     { source = "../../data/tidemarkd.service", dest = "/usr/lib/systemd/user/tidemarkd.service", mode = "644" },
     { source = "../../data/icons/hicolor/16x16/apps/io.github.zbndev.Tidemark.png", dest = "/usr/share/icons/hicolor/16x16/apps/io.github.zbndev.Tidemark.png", mode = "644" },
     { source = "../../data/icons/hicolor/22x22/apps/io.github.zbndev.Tidemark.png", dest = "/usr/share/icons/hicolor/22x22/apps/io.github.zbndev.Tidemark.png", mode = "644" },

--- a/crates/tidemark/Cargo.toml
+++ b/crates/tidemark/Cargo.toml
@@ -24,6 +24,7 @@ gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }
 # bundled Rubik available to GTK without installing it for the user.
 pango = { version = "0.22.3", features = ["v1_56"] }
 semver = "1.0.28"
+tidemark-ipc = { path = "../tidemark-ipc" }
 tidemark-types = { path = "../tidemark-types" }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/crates/tidemark/src/bus.rs
+++ b/crates/tidemark/src/bus.rs
@@ -25,9 +25,7 @@ use std::future::poll_fn;
 use std::pin::pin;
 use std::task::Poll;
 
-use tidemark_types::{
-    AuthCandidate, AuthSelection, DataInfo, Preferences, ProviderDefinition, ProviderStatus, ids,
-};
+use tidemark_types::{DataInfo, Preferences, ProviderDefinition, ProviderStatus, ids};
 use zbus::export::futures_core::Stream;
 
 /// How long to wait before trying the session bus again after a failure. Only reached when
@@ -35,155 +33,16 @@ use zbus::export::futures_core::Stream;
 /// with no polling at all.
 const RETRY_SECONDS: u32 = 5;
 
-#[zbus::proxy(
-    interface = "io.github.zbndev.Tidemark.Daemon1",
-    default_service = "io.github.zbndev.Tidemark.Daemon",
-    default_path = "/io/github/zbndev/Tidemark"
-)]
-pub trait Daemon {
-    /// Every provider this build knows how to configure.
-    fn list_providers(&self) -> zbus::Result<Vec<ProviderDefinition>>;
-
-    /// Adds a compiled-in provider's default account.
-    fn add_provider(&self, provider: &str) -> zbus::Result<()>;
-
-    /// Removes one configured account.
-    fn remove_provider(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// Adds one more account to a provider the config already has.
-    fn add_account(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// Renames one configured account, carrying its credential and history to the new id.
-    fn rename_account(&self, provider: &str, account: &str, new: &str) -> zbus::Result<()>;
-
-    /// Every account the daemon watches.
-    fn get_status(&self) -> zbus::Result<Vec<ProviderStatus>>;
-
-    /// A newer published application release, or an empty string when none is known.
-    fn get_update(&self) -> zbus::Result<String>;
-    /// Application-wide preferences stored by the daemon.
-    fn get_preferences(&self) -> zbus::Result<Preferences>;
-
-    /// Paths and storage facts for the Preferences data page.
-    fn get_data_info(&self) -> zbus::Result<DataInfo>;
-
-    /// Stored points in the current segment of one window, oldest first.
-    fn current_segment(
-        &self,
-        provider: &str,
-        account: &str,
-        window: &str,
-    ) -> zbus::Result<Vec<tidemark_types::HistoryPoint>>;
-
-    /// Polls now: one provider by slug, or everything when given an empty string.
-    fn refresh(&self, provider: &str) -> zbus::Result<()>;
-
-    /// Asks the running window to come forward; the caller exits after this.
-    fn request_activate(&self) -> zbus::Result<()>;
-
-    /// Stores an API key for an account.
-    fn set_key(&self, provider: &str, account: &str, key: &str) -> zbus::Result<()>;
-
-    /// Stores a browser session the user pasted in, and puts the account on it.
-    fn set_session(&self, provider: &str, account: &str, session: &str) -> zbus::Result<()>;
-
-    /// Removes whatever credential Tidemark holds for an account.
-    fn sign_out(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// Starts a login and returns the URL to open. Nothing is waited for yet.
-    fn begin_login(&self, provider: &str, account: &str) -> zbus::Result<String>;
-
-    /// Waits for a started login to finish. Long-running: up to the browser timeout.
-    fn await_login(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// Abandons a login in progress. Not an error when there is none.
-    fn cancel_login(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// Changes one of a provider's own settings.
-    fn set_option(
-        &self,
-        provider: &str,
-        account: &str,
-        name: &str,
-        value: &str,
-    ) -> zbus::Result<()>;
-
-    /// Inspects secret-free local authentication candidates for one account.
-    fn get_auth_sources(&self, provider: &str, account: &str) -> zbus::Result<Vec<AuthCandidate>>;
-
-    /// Revalidates and stores one local authentication selection.
-    fn select_auth_source(
-        &self,
-        provider: &str,
-        account: &str,
-        selection: AuthSelection,
-    ) -> zbus::Result<()>;
-
-    /// Switches notifications for one of an account's windows on or off.
-    fn set_window_notify(
-        &self,
-        provider: &str,
-        account: &str,
-        window: &str,
-        enabled: bool,
-    ) -> zbus::Result<()>;
-
-    fn set_release_check(&self, enabled: bool) -> zbus::Result<()>;
-    fn set_minimize_on_close(&self, enabled: bool) -> zbus::Result<()>;
-    fn set_theme(&self, theme: &str) -> zbus::Result<()>;
-    fn set_startup_mode(&self, mode: &str) -> zbus::Result<()>;
-    fn set_history_retention(&self, retention: &str) -> zbus::Result<()>;
-
-    /// Chooses zone-based or fixed-interval polling for healthy accounts.
-    fn set_refresh_mode(&self, mode: &str) -> zbus::Result<()>;
-
-    /// Sets the fixed interval Manual mode polls at, in minutes.
-    fn set_refresh_minutes(&self, minutes: u32) -> zbus::Result<()>;
-
-    /// All three proxy settings at once: they are one setting, and half of it applied is a
-    /// proxy nothing can be reached through.
-    fn set_proxy(&self, mode: &str, host: &str, port: u16) -> zbus::Result<()>;
-
-    fn clear_history(&self) -> zbus::Result<()>;
-
-    /// Puts the configured providers in the order the user arranged the cards in.
-    fn set_order(&self, providers: &[String]) -> zbus::Result<()>;
-
-    /// Puts one provider's accounts in the order the user arranged them in.
-    fn set_account_order(&self, provider: &str, accounts: Vec<String>) -> zbus::Result<()>;
-
-    /// What the daemon on the other end is.
-    #[zbus(property(emits_changed_signal = "false"))]
-    fn version(&self) -> zbus::Result<String>;
-
-    /// One account changed.
-    #[zbus(signal)]
-    fn provider_changed(&self, status: ProviderStatus) -> zbus::Result<()>;
-
-    /// One configured account was removed.
-    #[zbus(signal)]
-    fn provider_removed(&self, provider: &str, account: &str) -> zbus::Result<()>;
-
-    /// The configured providers are now in this order.
-    #[zbus(signal)]
-    fn order_changed(&self, providers: Vec<String>) -> zbus::Result<()>;
-
-    /// Application preferences changed.
-    #[zbus(signal)]
-    fn preferences_changed(&self, preferences: Preferences) -> zbus::Result<()>;
-
-    /// Paths or storage facts changed.
-    #[zbus(signal)]
-    fn data_changed(&self, data: DataInfo) -> zbus::Result<()>;
-
-    /// Availability of a newer published application release changed.
-    #[zbus(signal)]
-    fn update_changed(&self, version: &str) -> zbus::Result<()>;
-
-    /// Another client asked this one to come forward.
-    #[zbus(signal)]
-    fn activate_requested(&self) -> zbus::Result<()>;
-}
+/// The contract lives in `tidemark-ipc`, shared with `tidemarkctl`. Re-exported here so
+/// this module stays the one place the rest of the interface asks for the daemon.
+///
+/// `#[zbus::proxy]` consumes the trait it is written on and emits the proxy plus one
+/// message type per signal, so those names come from there too: [`Event`] below matches on
+/// them.
+pub use tidemark_ipc::{
+    ActivateRequested, DaemonProxy, DataChanged, OrderChanged, PreferencesChanged, ProviderChanged,
+    ProviderRemoved, UpdateChanged,
+};
 
 /// What the window is told.
 ///

--- a/crates/tidemarkd/AGENTS.md
+++ b/crates/tidemarkd/AGENTS.md
@@ -26,6 +26,9 @@ Polling, credential orchestration, and IPC publication; score 9, a distinct runt
 - Rename/removal copies credentials and rekeys history before the config durability point.
 - Roll back pre-commit migration failures; post-commit cleanup failures do not undo reported success.
 - Service identity locks and login cancellation prevent stale writes under retired account IDs.
+- A newly added OAuth-or-CLI provider persists `source = "oauth"` before its first probe.
+  Existing configured accounts without `source` retain legacy `Auto`; never migrate them
+  implicitly or adopt a vendor credential during a fresh add.
 - Notification delivery is recorded only after transport acceptance; a failed send remains retryable.
 - `PeerHub` uses `try_send`: evict an entire full/closed peer rather than blocking publication.
 

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -542,17 +542,29 @@ impl Engine {
             return Ok(());
         }
 
-        let Some(mut account) =
-            crate::registry::account(provider, &AccountId::default(), &self.secrets, &config)
-                .map_err(|error| error.to_string())?
+        let source = crate::registry::source_for_new_account(provider);
+        let Some(mut account) = crate::registry::account_with_source(
+            provider,
+            &AccountId::default(),
+            &self.secrets,
+            &config,
+            source,
+        )
+        .map_err(|error| error.to_string())?
         else {
             return Err(format!(
                 "provider {provider} is not supported by this build"
             ));
         };
-        config
-            .add_provider(provider)
-            .map_err(|error| error.to_string())?;
+        match source {
+            Some(source) => config.add_provider_with_option(
+                provider,
+                crate::registry::AUTH_SOURCE,
+                source.as_value(),
+            ),
+            None => config.add_provider(provider),
+        }
+        .map_err(|error| error.to_string())?;
 
         account.due = Instant::now();
         self.accounts.push(account);
@@ -1193,7 +1205,7 @@ impl Engine {
         Ok(sources)
     }
 
-    /// Revalidates, then atomically persists one selected dynamic local source.
+    /// Validates and atomically persists one selected authentication source.
     pub async fn select_auth_source(
         &mut self,
         provider: &str,
@@ -1205,6 +1217,25 @@ impl Engine {
         }) else {
             return Err(format!("account {provider}/{account} is not configured"));
         };
+        if crate::registry::source_for_new_account(provider).is_some() {
+            if account != AccountId::default().as_str() {
+                return Err(
+                    "the local credential source can only be selected for the default account"
+                        .to_owned(),
+                );
+            }
+            if selection.candidate.is_some() {
+                return Err("an OAuth or CLI source does not take a candidate".to_owned());
+            }
+            return self
+                .set_option(
+                    provider,
+                    account,
+                    crate::registry::AUTH_SOURCE,
+                    &selection.mode,
+                )
+                .await;
+        }
         // A pasted session is stored, not discovered: there are no candidates to resolve
         // it against, and nothing can prove it until the client is rebuilt around it. The
         // poll this schedules is what asks — the same contract `SetKey` has.
@@ -2701,6 +2732,88 @@ mod tests {
         assert!(matches!(publication, Publication::Changed(status) if status.provider == "kimi"));
         let config = Config::at(harness.config_path.clone()).expect("parses");
         assert_eq!(config.providers().expect("readable"), ["kimi"]);
+    }
+
+    #[tokio::test]
+    async fn adding_an_oauth_provider_pins_tidemark_login_before_the_first_probe() {
+        let mut harness = Harness::empty("runtime-add-oauth").await;
+        harness.engine.add_provider("codex").await.expect("added");
+
+        let account = &harness.engine.accounts()[0];
+        assert_eq!(account.source, tidemark_core::providers::Source::OAuth);
+        assert_eq!(account.status().auth_source.as_deref(), Some("oauth"));
+        let source = account
+            .status()
+            .options
+            .iter()
+            .find(|option| option.name == crate::registry::AUTH_SOURCE)
+            .expect("the credential source is published");
+        assert_eq!(source.value, "oauth");
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(
+            config.option("codex", crate::registry::AUTH_SOURCE),
+            Some("oauth")
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_select_switches_the_default_oauth_account_to_the_cli_source() {
+        let mut harness = Harness::empty("runtime-select-oauth-source").await;
+        harness.engine.add_provider("codex").await.expect("added");
+
+        harness
+            .engine
+            .select_auth_source(
+                "codex",
+                "default",
+                AuthSelection {
+                    mode: "cli".to_owned(),
+                    candidate: None,
+                },
+            )
+            .await
+            .expect("source selected");
+
+        assert_eq!(
+            harness.engine.accounts()[0].source,
+            tidemark_core::providers::Source::Cli
+        );
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(
+            config.option("codex", crate::registry::AUTH_SOURCE),
+            Some("cli")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_extra_oauth_account_cannot_change_the_default_accounts_source() {
+        let mut harness = Harness::empty("runtime-select-extra-oauth-source").await;
+        harness.engine.add_provider("codex").await.expect("added");
+        harness
+            .engine
+            .add_account("codex", "work")
+            .await
+            .expect("extra account added");
+
+        let error = harness
+            .engine
+            .select_auth_source(
+                "codex",
+                "work",
+                AuthSelection {
+                    mode: "cli".to_owned(),
+                    candidate: None,
+                },
+            )
+            .await
+            .expect_err("an extra account is OAuth-only");
+
+        assert!(error.contains("default account"), "{error}");
+        let config = Config::at(harness.config_path.clone()).expect("parses");
+        assert_eq!(
+            config.option("codex", crate::registry::AUTH_SOURCE),
+            Some("oauth")
+        );
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/registry.rs
+++ b/crates/tidemarkd/src/registry.rs
@@ -299,10 +299,41 @@ pub fn account(
     secrets: &Arc<dyn Secrets>,
     config: &Config,
 ) -> Result<Option<Account>, ProviderError> {
+    account_with_source(provider, account, secrets, config, None)
+}
+
+/// Builds an account with a source chosen before its configuration is durable.
+pub(crate) fn account_with_source(
+    provider: &str,
+    account: &AccountId,
+    secrets: &Arc<dyn Secrets>,
+    config: &Config,
+    source: Option<Source>,
+) -> Result<Option<Account>, ProviderError> {
+    let mut published_options = options(provider, config);
+    if let Some(source) = source
+        && let Some(option) = published_options
+            .iter_mut()
+            .find(|option| option.name == AUTH_SOURCE)
+    {
+        option.value = source.as_value().to_owned();
+    }
     let account = match provider {
-        antigravity::PROVIDER_ID => Some(antigravity_account(account, secrets, config)?),
-        claude::PROVIDER_ID => Some(claude_account(account, secrets, config)?),
-        codex::PROVIDER_ID => Some(codex_account(account, secrets, config)?),
+        antigravity::PROVIDER_ID => Some(antigravity_account(
+            account,
+            secrets,
+            source.unwrap_or_else(|| source_for_account(provider, account, config)),
+        )?),
+        claude::PROVIDER_ID => Some(claude_account(
+            account,
+            secrets,
+            source.unwrap_or_else(|| source_for_account(provider, account, config)),
+        )?),
+        codex::PROVIDER_ID => Some(codex_account(
+            account,
+            secrets,
+            source.unwrap_or_else(|| source_for_account(provider, account, config)),
+        )?),
         other => keyed::CATALOG
             .iter()
             .find(|spec| spec.id == other)
@@ -316,7 +347,7 @@ pub fn account(
     };
     Ok(account.map(|account| {
         account
-            .with_options(options(provider, config))
+            .with_options(published_options)
             .with_auth_selection(browser_auth_selection(provider, config))
             .with_notify(notify(provider, config))
     }))
@@ -582,6 +613,14 @@ fn source_value(provider: &str, config: &Config) -> Source {
     Source::from_value(config.option(provider, AUTH_SOURCE))
 }
 
+/// A newly configured OAuth provider starts pinned to Tidemark's own login.
+///
+/// Existing providers without a stored choice keep [`Source::Auto`] through
+/// [`source_for_account`]; this value is only used while adding a provider.
+pub(crate) fn source_for_new_account(provider: &str) -> Option<Source> {
+    oauth_entry(provider).map(|_| Source::OAuth)
+}
+
 /// Extra configured accounts have no vendor CLI file, so they always use Tidemark's login.
 pub(crate) fn source_for_account(provider: &str, account: &AccountId, config: &Config) -> Source {
     if account.as_str() == "default" {
@@ -708,9 +747,8 @@ fn build_antigravity(
 fn antigravity_account(
     account: &AccountId,
     secrets: &Arc<dyn Secrets>,
-    config: &Config,
+    source: Source,
 ) -> Result<Account, ProviderError> {
-    let source = source_for_account(antigravity::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(build_antigravity(
         account_id.clone(),
@@ -745,9 +783,8 @@ fn antigravity_account(
 fn claude_account(
     account: &AccountId,
     secrets: &Arc<dyn Secrets>,
-    config: &Config,
+    source: Source,
 ) -> Result<Account, ProviderError> {
-    let source = source_for_account(claude::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(claude::Claude::new(
         account_id.clone(),
@@ -777,9 +814,8 @@ fn claude_account(
 fn codex_account(
     account: &AccountId,
     secrets: &Arc<dyn Secrets>,
-    config: &Config,
+    source: Source,
 ) -> Result<Account, ProviderError> {
-    let source = source_for_account(codex::PROVIDER_ID, account, config);
     let account_id = account.clone();
     Ok(Account::with_client(Arc::new(codex::Codex::new(
         account_id.clone(),
@@ -992,6 +1028,18 @@ mod tests {
         assert_eq!(
             source_for_account(claude::PROVIDER_ID, &AccountId::new("work"), &config),
             Source::OAuth
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn an_existing_default_account_without_a_source_keeps_legacy_auto_selection() {
+        let path = scratch_config("codex-legacy-source", "providers = [\"codex\"]\n");
+        let config = Config::at(path.clone()).expect("config reads");
+
+        assert_eq!(
+            source_for_account(codex::PROVIDER_ID, &AccountId::default(), &config),
+            Source::Auto
         );
         let _ = std::fs::remove_file(path);
     }

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -1246,7 +1246,7 @@ impl Daemon {
         self.auth_sources_request(provider, account).await
     }
 
-    /// Revalidates and persists one explicit local authentication source.
+    /// Validates and persists one explicit authentication source.
     async fn select_auth_source(
         &self,
         provider: &str,

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -553,6 +553,10 @@ git commit -m "feat(cli): tidemarkctl skeleton and version"
 
 ### Task 3: `usage --format text`
 
+> Superseded in Task 9: `render` takes a `&Titles` and names providers the way the daemon's
+> catalog spells them, because `provider_label` alone says "Deepseek" where every other
+> surface says "DeepSeek". The signature below is one argument short.
+
 **Files:**
 - Create: `crates/tidemark-cli/src/format/mod.rs`
 - Create: `crates/tidemark-cli/src/format/text.rs`
@@ -1019,6 +1023,8 @@ git commit -m "feat(cli): usage as json"
 ```
 
 ### Task 5: `usage --format waybar`
+
+> Superseded in Task 9: the tooltip takes a `&Titles` too. See Task 9 Step 4.
 
 **Files:**
 - Create: `crates/tidemark-cli/src/format/waybar.rs`
@@ -2450,7 +2456,7 @@ git commit -m "feat(cli): watch the daemon as a stream"
 **Interfaces:**
 - Produces: `commands::provider::run(&DaemonProxy<'_>, cli::ProviderCommand) -> Result<Exit, Failure>` and `commands::account::run(&DaemonProxy<'_>, cli::AccountCommand) -> Result<Exit, Failure>`.
 
-- [ ] **Step 1: Extend the grammar**
+- [x] **Step 1: Extend the grammar**
 
 In `cli.rs`, add to `Command`:
 
@@ -2509,7 +2515,12 @@ pub enum AccountCommand {
 }
 ```
 
-- [ ] **Step 2: Write the failing integration test**
+- [x] **Step 2: Write the failing integration test**
+
+Two more tests than the plan asked for, both of a rule the code states and nothing else
+checked: `provider rm` and `account rm` are one daemon call (a drift between them would
+silently change what happens to the credential and the history), and an empty *account*
+order is refused for the same reason an empty provider order is.
 
 `crates/tidemark-cli/tests/managing_a_fake_daemon.rs`:
 
@@ -2594,12 +2605,33 @@ fn an_order_with_no_providers_is_refused_before_the_daemon_hears_it() {
 }
 ```
 
-- [ ] **Step 3: Run and watch it fail**
+- [x] **Step 3: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli --test managing_a_fake_daemon`
 Expected: FAIL — `commands` does not exist.
 
-- [ ] **Step 4: Write the commands**
+- [x] **Step 4: Write the commands**
+
+**Deviation: the plan's `provider_label` is the wrong half of a convention this repo
+already has.** The daemon's catalog spells each name — "DeepSeek", "OpenRouter",
+"ClinePass" — while `tidemark_types::provider_label` only capitalises the slug, so the
+plan's `provider list` would print "Deepseek" where the card
+(`crates/tidemark/src/model.rs:28`, catalog title first, label as fallback), the tray menu
+and the notification (`crates/tidemarkd/src/notify.rs:240`, the same rule again) all print
+"DeepSeek". Verified live: the catalog says `DeepSeek`, `OpenRouter`, `NanoGPT`, and
+`provider_label` answers `Deepseek`, `Openrouter`, `NanoGPT`.
+
+So `crates/tidemark-cli/src/titles.rs` holds that one rule for this client — catalog title,
+label fallback for a provider newer than this build — and `format::text::render`,
+`format::waybar::render` (the tooltip) and `provider list` take a `&Titles`. That is a
+change to Tasks 3 and 5 as well; the cost is one `ListProviders` call per command that
+prints a name. `--format json` names providers by slug and pays nothing, and `watch`
+fetches the catalog only for its Waybar sink, which is why its integration test still
+asserts `calls.recorded() == ["GetStatus"]`.
+
+`tests/fake/mod.rs` needed `#[allow(dead_code)]` on `emit_change`: a shared test module is
+compiled into *every* integration test binary and each uses the part it needs, so `expect`
+would go unfulfilled in the binary that does use it.
 
 `crates/tidemark-cli/src/commands/mod.rs`:
 
@@ -2716,31 +2748,28 @@ pub async fn run(proxy: &DaemonProxy<'_>, command: AccountCommand) -> Result<Exi
         }
 ```
 
-- [ ] **Step 5: Run the tests**
+- [x] **Step 5: Run the tests**
 
-Run: `cargo test -p tidemark-cli`
-Expected: PASS.
+- [x] **Step 6: Smoke it**
 
-- [ ] **Step 6: Smoke it**
+58 catalog rows, 9 configured accounts, `refresh` accepted. The full mutation round trip on
+`wayfinder`, then put back exactly as found: `provider add wayfinder` → the row appears
+`unreachable` (no credential, as expected); `provider order wayfinder codex claude …` → the
+list comes back with wayfinder first; `provider rm wayfinder default` → gone, and the
+original order restored.
 
-```bash
-cargo run -p tidemark-cli -- provider catalog | head -5
-cargo run -p tidemark-cli -- provider list
-cargo run -p tidemark-cli -- refresh
-```
-Expected: the catalog, the configured set, and a poll that shows up in `watch`.
+The refusals are worth recording, because they are the exit-code split working on live
+data rather than on a fake:
 
-Then verify a real mutation round trip on a provider you do not mind touching:
+- `account add wayfinder second` → **70**, `provider wayfinder does not support multiple
+  accounts`. The daemon's rule, surfaced verbatim.
+- `account order zai tanya default` → **70**, `the default account must be first`. Also the
+  daemon's, and the config was left untouched.
+- `refresh nonesuch` → **70**, `no account is configured for provider nonesuch`.
+- `provider order` and `account order zai` with no names → **64**, refused by this client
+  before the bus heard anything.
 
-```bash
-cargo run -p tidemark-cli -- provider add wayfinder
-cargo run -p tidemark-cli -- provider list | grep wayfinder
-cargo run -p tidemark-cli -- provider rm wayfinder default
-```
-Expected: the card appears in the running window and then goes away. Wayfinder needs no
-credential, which is why it is the safe one to test with.
-
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add crates/tidemark-cli Cargo.lock

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -1816,7 +1816,11 @@ git commit -m "feat(cli): the watch stream's events and mirror"
 - Produces: `watch::run(Sink) -> Result<Exit, Failure>` — the connect/retry loop, never returning under normal operation.
 - Produces: `tests::fake::FakeDaemon` and `tests::fake::serve(name) -> (zbus::Connection, DaemonProxy<'static>)`, reused by Tasks 9-11.
 
-- [ ] **Step 1: Write the pump and the retry loop**
+- [x] **Step 1: Write the pump and the retry loop**
+
+`Signal::Owner` holds `Option<Option<zbus::names::UniqueName<'static>>>`, not
+`OwnedUniqueName`: `receive_owner_changed` yields the borrowed name, which is what
+`crates/tidemark/src/bus.rs` matches on too. The compiler names the right type.
 
 Append to `crates/tidemark-cli/src/watch/mod.rs`. The structure mirrors
 `crates/tidemark/src/bus.rs:249-357` (`serve`) — read it first — minus the GLib half and
@@ -2091,7 +2095,7 @@ impl From<std::io::Error> for Failure {
 }
 ```
 
-- [ ] **Step 2: Extend the grammar and wire the command**
+- [x] **Step 2: Extend the grammar and wire the command**
 
 `cli.rs` gains:
 
@@ -2130,7 +2134,11 @@ pub enum StreamFormat {
         }
 ```
 
-- [ ] **Step 3: Write the fake daemon the integration tests share**
+- [x] **Step 3: Write the fake daemon the integration tests share**
+
+The unique name counts served daemons in an `AtomicU32` rather than
+`calls.recorded().len()`, which is zero for every fresh daemon and so would not be unique
+at all.
 
 `crates/tidemark-cli/tests/fake/mod.rs`:
 
@@ -2298,7 +2306,17 @@ A unique bus name per test matters: `cargo test` runs tests in parallel threads 
 session bus, and two services under the same name would make the second one fail.
 Include the test's own name in the string if collisions still happen.
 
-- [ ] **Step 4: Write the failing integration test**
+- [x] **Step 4: Write the failing integration test**
+
+**The plan's test design was wrong and hung.** `drop(server)` does not end the pump: the
+signal streams belong to the *client* connection, and a served name going away is an owner
+change — a `waiting` line — not a closed stream. `pump` correctly kept streaming, so
+`zip(pumping, emitting)` never completed and `cargo test` sat there until it was killed.
+The test now bounds the pump with
+`futures_lite::future::or(pumping, Timer::after(900ms))` and reads what it printed
+afterwards, which also lets it assert the third line: `waiting`, emitted when the daemon
+left the bus. It additionally asserts `calls.recorded() == ["GetStatus"]` — the snapshot
+came off the wire once and every later line came from a signal, not from re-polling.
 
 `crates/tidemark-cli/tests/watching_a_fake_daemon.rs`:
 
@@ -2385,24 +2403,30 @@ This needs three things the crate does not have yet:
    ```
 3. `cargo add -p tidemark-cli --dev futures-lite` for `zip`.
 
-- [ ] **Step 5: Run it**
+- [x] **Step 5: Run it**
 
 Run: `cargo test -p tidemark-cli --test watching_a_fake_daemon`
 Expected: PASS, or the skip line with no session bus.
 
-- [ ] **Step 6: Smoke it against the live daemon**
+- [x] **Step 6: Smoke it against the live daemon**
 
-In one terminal: `cargo run -p tidemark-cli -- watch`
-In another: `cargo run -p tidemark-cli -- refresh claude`
-Expected: a `snapshot` line at once, then a `changed` line per poll. Then
-`systemctl --user restart tidemarkd` and expect a `waiting` line followed by a fresh
-`snapshot`.
+`refresh` is Task 9's command, so the poll was asked for with the documented probe:
+`busctl --user call io.github.zbndev.Tidemark.Daemon /io/github/zbndev/Tidemark io.github.zbndev.Tidemark.Daemon1 Refresh s "zai"`.
 
-Also: `cargo run -p tidemark-cli -- watch --format waybar | head -3`
-Expected: one card per change, each a complete JSON object on its own line. `head` closing
-the pipe must not hang the process.
+Observed: `snapshot` (9 accounts) at once, then one `changed` line per Z.ai account. Across
+`systemctl --user restart tidemarkd`: `snapshot`, `waiting`, `snapshot`, then 18 `changed`
+lines as the fresh daemon polled everything.
 
-- [ ] **Step 7: Full gate and commit**
+**What the pipe test actually shows:** `watch --format waybar | head -1` does *not* end the
+process when `head` closes the pipe — nothing is written until the next signal, so nothing
+notices. At the next event the write fails and the process exits **69** with
+`cannot write the stream: Broken pipe`, verified end to end (5 s: 3 s idle, then a
+`Refresh`). It is not a hang — it is a process that ends when it next has something to say.
+Noticing sooner would mean polling stdout for `POLLERR`, which is real machinery for a
+cosmetic case: Waybar kills its module with a signal, and a shell pipeline has already
+returned to the prompt. Left alone deliberately.
+
+- [x] **Step 7: Full gate and commit**
 
 ```bash
 cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -3173,7 +3173,16 @@ git commit -m "feat(cli): store credentials without putting them on a command li
 **Interfaces:**
 - Produces: `commands::config::run(&DaemonProxy<'_>, cli::ConfigCommand) -> Result<Exit, Failure>`.
 
-- [ ] **Step 1: Extend the grammar**
+- [x] **Step 1: Extend the grammar**
+
+**Deviation: `#[arg(value_parser = switch)] enabled: bool` does not compile as a grammar.**
+clap derives a *flag* from a `bool` positional, and `Cli::command().debug_assert()` — the
+grammar test from Task 2 — caught it: `Argument 'enabled' is positional and it must take a
+value but action is SetTrue`. Replaced with `pub enum Switch { On, Off }` deriving
+`clap::ValueEnum`, plus `impl From<Switch> for bool`. Better than forcing
+`action = ArgAction::Set` onto the `bool`: `--help` now lists
+`[possible values: on, off]`, and a wrong word is refused by clap with those values shown
+rather than by a hand-written message.
 
 `cli.rs` gains four commands:
 
@@ -3271,7 +3280,13 @@ pub enum HistoryCommand {
 }
 ```
 
-- [ ] **Step 2: Write the failing test**
+- [x] **Step 2: Write the failing test**
+
+Plus an assertion the plan left off — `off` sends `SetProxy(off,,0)`, i.e. the empty host
+and the zero port, not the previous ones — and a second test for the ordering rule that
+`config.rs` states in a comment and nothing else checked: the interval is sent *before* the
+mode, because `SetRefreshMode` polls every account immediately, so the other order would
+poll once at the pace the user is leaving behind.
 
 Append to `crates/tidemark-cli/tests/managing_a_fake_daemon.rs`:
 
@@ -3329,12 +3344,22 @@ fn a_proxy_is_sent_as_one_setting_and_a_half_of_one_is_refused() {
 }
 ```
 
-- [ ] **Step 3: Run and watch it fail**
+- [x] **Step 3: Run and watch it fail**
+
+Failed as `cannot find `config` in `commands``, then a second time — after the command
+existed — as `Unknown method 'SetRefreshMinutes'`, which is the fake missing the two
+refresh methods. Added exactly those two: a test drives them.
 
 Run: `cargo test -p tidemark-cli --test managing_a_fake_daemon`
 Expected: FAIL — `commands::config` does not exist.
 
-- [ ] **Step 4: Write the command**
+- [x] **Step 4: Write the command**
+
+**Deviation: `show` prints switches as `on`/`off`, not `true`/`false`.** The plan printed
+the raw bools, which would have made `config show` output that no subcommand accepts —
+`config release-check true` is a clap error. Two unit tests hold that: a switch prints the
+word the subcommand takes, and an absent `theme` reads as `system` rather than as an empty
+column. `show` returns a `String` for the same reason `auth sources` does.
 
 `crates/tidemark-cli/src/commands/config.rs`:
 
@@ -3405,7 +3430,13 @@ Note the ordering in `Refresh`: the interval is sent before the mode, so switchi
 `manual` with a new interval polls at the interval the user asked for rather than at the
 old one. `set_refresh_mode` polls every account immediately — see `CONTEXT.md` § Polling.
 
-- [ ] **Step 5: Wire the remaining arms in `main.rs`**
+- [x] **Step 5: Wire the remaining arms in `main.rs`**
+
+**Deviation: `data`'s last row is `release-check-built`, not `release-check`.** The plan
+gave it the same name as the preference in `config show`, where it is a different thing:
+`config show`'s row is the user's switch, `data`'s is whether the build has the release
+checker at all. Two sibling commands printing one name for two facts is how somebody ends
+up scripting the wrong one.
 
 ```rust
         cli::Command::Option {
@@ -3479,27 +3510,56 @@ old one. `set_refresh_mode` polls every account immediately — see `CONTEXT.md`
 
 `commands/mod.rs` gains `pub mod config;`.
 
-- [ ] **Step 6: Run the tests**
+- [x] **Step 6: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 7: Smoke it**
+- [x] **Step 7: Smoke it**
 
-```bash
-cargo run -p tidemark-cli -- config show
-cargo run -p tidemark-cli -- data
-cargo run -p tidemark-cli -- update
-cargo run -p tidemark-cli -- config refresh manual --minutes 15
-cargo run -p tidemark-cli -- config show | grep refresh
-cargo run -p tidemark-cli -- config refresh auto
-cargo run -p tidemark-cli -- history segment claude default w18000 | tail -3
 ```
-Expected: `config show` reflects each change, the running Preferences dialog updates live
-(it listens to `PreferencesChanged`), and the segment prints timestamps with percentages.
-Put `refresh` back to whatever it was before.
+config show   →  release-check on / minimize-on-close on / theme dark / startup app /
+                 retention forever / refresh auto / refresh-minutes 1 /
+                 proxy http 127.0.0.1 10808
+data          →  config and history paths, history-bytes 1203760, both keyring schemas,
+                 release-check-built true
+update        →  0.4.1
+config refresh manual --minutes 15   →  config show says manual / 15
+config refresh auto --minutes 1      →  back to auto / 1
+history segment claude default w18000 | tail -3  →  1788810721 87% / 1788810752 88% /
+                                                    1788810985 92%
+history segment claude default w99999            →  no lines, exit 0: a window with no
+                                                    stored points is not an error
+```
 
-- [ ] **Step 8: Full gate and commit**
+All three refusal layers, on live data:
+
+- `config release-check maybe` → **2**, clap, `[possible values: on, off]`.
+- `config proxy socks5 127.0.0.1` → **64**, `the `socks5` proxy mode needs a host and a
+  port`. Never reached the bus.
+- `config theme neon` → **70**, `unknown theme "neon"`. The daemon's list, not ours.
+- `option antigravity default source nonsense` → **70**, `nonsense is not one of the values
+  source can take`.
+
+`notify claude default w604800 on` then `off`: the account's `notify` array went `[]` →
+`["w604800"]` → `[]`. `option antigravity default source cli` took effect and was visible
+in the published option value.
+
+**Two things the smoke wrote into the user's config, and how they were undone.** `option`
+pinned `[provider.antigravity] source = "cli"` where nothing had been pinned before (the
+published value was the `auto` sentinel, and `auto` is *not* one of the option's choices —
+there is no CLI way to unset it), and the `notify` round trip left an empty
+`[notify.claude] windows = []` section. Restored by stopping `tidemarkd`, deleting both
+stanzas from `config.toml`, and starting it again; verified afterwards that the option
+publishes `auto` with `auth_source` still `cli`, that claude's `notify` is `[]`, and that
+every other preference reads exactly as it did before. Worth knowing for later: `option`
+can pin a provider setting that no command can unpin.
+
+`history clear` was deliberately not run: it deletes every stored point, and this machine's
+history is 1.2 MB of the user's real readings. Its argument path is one proxy call with no
+arguments to get wrong.
+
+- [x] **Step 8: Full gate and commit**
 
 ```bash
 cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -1286,7 +1286,7 @@ git commit -m "feat(cli): usage as a waybar card"
 **Interfaces:**
 - Produces: `guard::Selection { Dominant, Named(String), Any }`, `guard::Verdict { Safe { remaining }, Below { remaining }, Unavailable(String) }` with `fn exit(&self) -> Exit`, and `guard::decide(&[&ProviderStatus], &Selection, u8) -> Verdict`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 `crates/tidemark-cli/src/guard.rs`:
 
@@ -1382,12 +1382,16 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli guard`
 Expected: FAIL — `decide`, `Selection` and `Verdict` are not defined.
 
-- [ ] **Step 3: Write the decision**
+- [x] **Step 3: Write the decision**
+
+`Exit::Below` now has a constructor, so its Task 2 `#[expect(dead_code, …)]` is deleted
+here. `Exit::Usage`, `Failure::usage` and `Failure::unavailable` keep theirs: `guard`
+rejects nothing itself, and clap's own usage errors exit 2.
 
 Above the test module:
 
@@ -1473,7 +1477,7 @@ pub fn decide(statuses: &[&ProviderStatus], selection: &Selection, min_remaining
 }
 ```
 
-- [ ] **Step 4: Extend the grammar**
+- [x] **Step 4: Extend the grammar**
 
 In `cli.rs`, add to `Command`:
 
@@ -1505,7 +1509,7 @@ pub struct Guard {
 }
 ```
 
-- [ ] **Step 5: Wire the command**
+- [x] **Step 5: Wire the command**
 
 `main.rs` gains `mod guard;` and:
 
@@ -1531,12 +1535,12 @@ pub struct Guard {
         }
 ```
 
-- [ ] **Step 6: Run the tests**
+- [x] **Step 6: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 7: Smoke it**
+- [x] **Step 7: Smoke it**
 
 ```bash
 cargo run -p tidemark-cli -- guard --min-remaining 1 --provider claude; echo $?
@@ -1546,7 +1550,7 @@ cargo run -p tidemark-cli -- guard --min-remaining 900; echo $?
 ```
 Expected: `0`, `1`, `69`, and clap's own `2` for the out-of-range threshold.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -2788,7 +2788,12 @@ git commit -m "feat(cli): manage providers and accounts"
 - Produces: `secret::Source { Stdin, File(PathBuf) }` and `secret::read(Source) -> Result<String, Failure>`.
 - Produces: `commands::auth::run(&DaemonProxy<'_>, cli::AuthCommand) -> Result<Exit, Failure>`.
 
-- [ ] **Step 1: Write the failing secret-input tests**
+- [x] **Step 1: Write the failing secret-input tests**
+
+Two tests beyond the plan's three, both of a rule the code makes and nothing else checked:
+a CRLF file is a Windows file whose carriage return is the line ending rather than part of
+the key, and an unreadable file names itself in the message, because the usual cause is a
+typo in the path.
 
 `crates/tidemark-cli/src/secret.rs`:
 
@@ -2881,13 +2886,17 @@ An empty value is refused locally because `SetKey("")` is a request to store not
 the daemon already refuses it — failing here gives the user the sentence that says what to
 do instead of a D-Bus error.
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Run and watch it fail**
+
+Ran before declaring the module: `running 0 tests … 33 filtered out` — the harness cannot
+see a file that is in no module tree, which is the failure this step is for. With
+`pub mod secret;` added: 5 passed.
 
 Run: `cargo test -p tidemark-cli secret`
 Expected: FAIL — the module is not declared yet. Add `pub mod secret;` to `lib.rs`, then
 the tests compile and pass.
 
-- [ ] **Step 3: Extend the grammar**
+- [x] **Step 3: Extend the grammar**
 
 `cli.rs` gains:
 
@@ -2939,7 +2948,18 @@ pub enum AuthCommand {
 }
 ```
 
-- [ ] **Step 4: Write the commands**
+- [x] **Step 4: Write the commands**
+
+Two deviations, both in the `auth sources` listing:
+
+1. The plan's `print_candidate` printed `id`, `state` and `subtitle`, dropping `title` —
+   the only field a person recognises the source by ("Google Chrome", "Zen"). The row is
+   now `id`, `title`, `state`, `subtitle`: the id first because that is the word
+   `auth select --candidate` takes.
+2. It printed line by line, so its shape could not be tested without a daemon. It is now
+   `sources(&[AuthCandidate]) -> String` with `rows` recursing, and two unit tests: a
+   profile is indented under its browser, and an absent subtitle prints as nothing rather
+   than as a word standing in for one.
 
 `crates/tidemark-cli/src/commands/auth.rs`:
 
@@ -3039,7 +3059,12 @@ fn print_candidate(candidate: &AuthCandidate, depth: usize) {
 
 `commands/mod.rs` gains `pub mod auth;`.
 
-- [ ] **Step 5: Write the failing integration test**
+- [x] **Step 5: Write the failing integration test**
+
+Two more than the plan asked for: a `--key-file` that is not there must fail *before* the
+bus (otherwise the choice is between storing the empty string and a D-Bus error about a
+value the user never managed to supply), and `sign-out` — the one credential command with
+nothing to read — must name the account it was given.
 
 `crates/tidemark-cli/tests/storing_a_secret.rs`:
 
@@ -3089,26 +3114,49 @@ fn a_key_from_a_file_reaches_the_daemon_and_is_never_printed() {
 with `set_session`, `begin_login`, `await_login`, `cancel_login`, `get_auth_sources` and
 `select_auth_source` only if a test drives them; do not add unused methods.
 
-- [ ] **Step 6: Run the tests**
+- [x] **Step 6: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 7: Smoke it**
+- [x] **Step 7: Smoke it**
 
-```bash
-printf '%s' 'sk-not-a-real-key' | cargo run -p tidemark-cli -- auth set-key zai default
-cargo run -p tidemark-cli -- usage --provider zai
-cargo run -p tidemark-cli -- auth sign-out zai default
+**Not on `zai`:** that account holds a real working key, and the plan's own command would
+have destroyed it. Used `groq` instead — a `key` provider that was not configured — added
+for the test and removed afterwards. `provider list` is back to exactly the eight providers
+it started with, and `claude` is still `ok`.
+
 ```
-Expected: the card moves to `credential-rejected` (a wrong key is a real answer), then back
-to `no-credential`. Do this on a provider you are not signed into, or restore your key
-afterwards.
+provider add groq
+printf '%s' 'gsk-not-a-real-key' | auth set-key groq default   # 0
+provider list | grep groq   →  groq  default  Groq  credential-rejected
+usage --provider groq       →  "the credential was rejected (HTTP 401)"
+auth sign-out groq default  →  0, then the row reads no-credential
+provider rm groq default    →  0
+```
 
-Confirm the prohibition holds: `cargo run -p tidemark-cli -- auth set-key zai default sk-x`
-Expected: clap rejects the extra argument — there is no positional slot for a key.
+The prohibition holds: `auth set-key zai default sk-x` → clap, exit **2**,
+`unexpected argument 'sk-x' found`. There is no positional slot for a secret, and
+`--help` shows only `<PROVIDER> <ACCOUNT>`.
 
-- [ ] **Step 8: Commit**
+Refusals: empty stdin → **64** `no value on stdin: pipe the key in, or pass --key-file`;
+`--key-file /tmp/nope` → **64** naming the path. Neither reached the daemon.
+
+`auth sources` needed a provider with a browser selector, so `t3chat` was added, read and
+removed. It printed 11 rows — `browser` with `chrome`, `chromium`, `firefox` and `zen`
+under it, each with its profiles indented one further, plus `paste` with its hint — and no
+cookie value, token or database path anywhere. `auth select t3chat default --mode browser
+--candidate firefox` returned 0, and `usage --format json` then showed
+`{"candidate":"firefox/j7aiac5u.default-release","mode":"browser"}`: the daemon resolved
+the browser-level id to the profile leaf, which is the behaviour the GUI's dialog relies on.
+`--mode nonsense` → **70**, `the selected authentication source is not ready`.
+
+`auth login claude default` printed the authorize URL immediately — the flush before the
+blocking `AwaitLogin` works — and stayed waiting. `auth cancel-login claude default` from a
+second process ended it with **70** and the daemon's own sentence, `the login was
+cancelled`. Claude's stored credential was untouched: still `ok`.
+
+- [x] **Step 8: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -891,7 +891,7 @@ git commit -m "feat(cli): usage in text form"
 **Interfaces:**
 - Produces: `format::json::render(&[&ProviderStatus]) -> Result<String, serde_json::Error>` emitting `{"accounts": [...]}`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 `crates/tidemark-cli/src/format/json.rs`:
 
@@ -955,19 +955,28 @@ mod tests {
 }
 ```
 
-These two tests **pin a published contract**, which is their whole point. If a key comes
-out under another spelling than the field name — the shape is `zvariant`'s
-`SerializeDict` derive, not ours — then that spelling *is* the contract: record it in the
-test and in the README. Do not add a `rename` to `tidemark-types` to make this test pretty;
-the D-Bus dictionary keys and the JSON keys are the same names, and renaming one changes
-both.
+These two tests **pin a published contract**, which is their whole point.
 
-- [ ] **Step 2: Run and watch it fail**
+**What running them found, and the one deviation in this task:** the key *spellings* are
+the field names, as expected — but `SerializeDict` exists to encode `a{sv}`, so under
+`serde_json` every value arrives inside its D-Bus envelope:
+`"provider": {"signature": "s", "value": "claude"}`, and `details` nests three levels of
+them. Publishing that would make a plugin unwrap every scalar. The plan's instruction —
+record the shape, never `rename` `tidemark-types` — still holds for spellings, and adding a
+second `Serialize` to the wire types is impossible anyway (one `impl` per type) while
+mirroring `ProviderStatus` in the CLI would be the duplicated wire model
+`crates/tidemark-types/AGENTS.md` forbids. So `format::json::payload` peels the envelope
+recursively after `serde_json::to_value`: one wire model, one set of key names, and no
+`{"signature","value"}` in what a plugin reads. Absent still stays absent — the derive
+omits `None` before the peeling ever sees it. A third test,
+`details_arrive_as_plain_objects_all_the_way_down`, pins the deepest published structure.
+
+- [x] **Step 2: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli format::json`
 Expected: FAIL — `render` is not defined.
 
-- [ ] **Step 3: Write the renderer**
+- [x] **Step 3: Write the renderer**
 
 Above the test module:
 
@@ -979,11 +988,12 @@ struct Document<'a> {
 }
 
 pub fn render(statuses: &[&ProviderStatus]) -> Result<String, serde_json::Error> {
-    serde_json::to_string_pretty(&Document { accounts: statuses })
+    let document = serde_json::to_value(Document { accounts: statuses })?;
+    serde_json::to_string_pretty(&payload(document))
 }
 ```
 
-- [ ] **Step 4: Wire it up**
+- [x] **Step 4: Wire it up**
 
 `format/mod.rs` gains `pub mod json;`. `cli::Format` gains `Json`. `main.rs`'s match gains:
 
@@ -991,17 +1001,17 @@ pub fn render(statuses: &[&ProviderStatus]) -> Result<String, serde_json::Error>
                 cli::Format::Json => println!("{}", format::json::render(&selected)?),
 ```
 
-- [ ] **Step 5: Run the tests**
+- [x] **Step 5: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 6: Smoke it**
+- [x] **Step 6: Smoke it**
 
 Run: `cargo run -p tidemark-cli -- usage --format json | jq '.accounts[0] | {provider, state, windows}'`
 Expected: real values; no `null` where the provider said nothing.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -3752,7 +3752,7 @@ git commit -m "feat(cli): completions, and ship tidemarkctl in every Linux packa
 - Modify: `AGENTS.md`
 - Modify: `crates/tidemark-ipc/AGENTS.md` (created in Task 1)
 
-- [ ] **Step 1: Write the README section**
+- [x] **Step 1: Write the README section**
 
 In `README.md`, after the "Getting started" section, add:
 
@@ -3802,7 +3802,7 @@ and in your stylesheet, the classes it sets — `ok`, `warning`, `danger` at the
 `history`.
 ````
 
-- [ ] **Step 2: Update the architecture record**
+- [x] **Step 2: Update the architecture record**
 
 In `CONTEXT.md` § Architecture, the crate-layout paragraph currently opens with "Four
 crates, not three." Replace that sentence and add the two rows to its table. The new
@@ -3854,7 +3854,7 @@ endpoint discovery lives in the window's own reconnect module. The binary still 
 there; it is packaged only on Linux.
 ```
 
-- [ ] **Step 3: Write the crate AGENTS files**
+- [x] **Step 3: Write the crate AGENTS files**
 
 `crates/tidemark-ipc/AGENTS.md` and `crates/tidemark-cli/AGENTS.md`, following the shape of
 `crates/tidemark-types/AGENTS.md`: an OVERVIEW line, a WHERE TO LOOK table, CONVENTIONS and
@@ -3867,27 +3867,43 @@ ANTI-PATTERNS. The anti-patterns that matter, stated plainly:
   `json` and `waybar` shapes and the exit codes are a published contract — add keys, never
   rename or remove them.
 
-- [ ] **Step 4: Update the root knowledge base**
+- [x] **Step 4: Update the root knowledge base**
 
 In the root `AGENTS.md`: add `tidemark-ipc` and `tidemark-cli` to the STRUCTURE block, one
 row each to WHERE TO LOOK (`Change the CLI` → `crates/tidemark-cli/`; `Change the D-Bus
 proxy` → `crates/tidemark-ipc/src/lib.rs`), and `tidemarkctl usage --format json` to
 COMMANDS.
 
-- [ ] **Step 5: Verify the documentation against the binary**
+- [x] **Step 5: Verify the documentation against the binary**
 
 Run every command block in the new README section verbatim against the live daemon, and the
 Waybar snippet in a real Waybar if one is running.
 Expected: each works as written. A documented command that does not run is worse than an
 undocumented one.
 
-- [ ] **Step 6: Full gate and commit**
+Verified with `target/release/tidemarkctl` on the active user daemon. `usage` printed the
+live account view; JSON parsed with an `accounts` array; the documented weekly guard took
+the unjudgeable path and exited `69`; `watch` opened with `snapshot`; and
+`watch --format waybar` emitted an object whose `class` was an array. No Waybar process was
+running, so there was no live panel in which to install the snippet.
+
+`ZAI_API_KEY` was not set. The live `zai/default` credential was deliberately not
+overwritten: empty stdin exited `64` before a daemon call, and
+`cargo test -p tidemark-cli --test storing_a_secret -- --nocapture` passed all three tests,
+including that a file-provided key reaches the fake daemon and is never printed. Completion
+generation was verified without creating `~/.zfunc/_tidemarkctl`.
+
+- [x] **Step 6: Full gate and commit**
 
 ```bash
 cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh
 git add README.md CONTEXT.md AGENTS.md crates/tidemark-cli/AGENTS.md crates/tidemark-ipc/AGENTS.md
 git commit -m "docs: tidemarkctl, and the contract it publishes"
 ```
+
+Committed as `e507b52`. Before the commit: `cargo fmt --check`, workspace clippy with
+`-D warnings`, 1527 tests across 23 suites, and the layering check all passed. The commit
+also updates the stale future-CLI comment in `scripts/check-layering.sh`.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -1,0 +1,3632 @@
+# tidemarkctl Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `tidemarkctl`, a command-line client that can do everything the GTK window can, so panel plugins and scripts consume the daemon without generating a D-Bus proxy of their own.
+
+**Architecture:** The `#[zbus::proxy] trait Daemon` already covers the entire interface and
+lives in the GUI crate; it moves into a new `tidemark-ipc` crate so the window and the CLI
+share one definition of the contract. A second new crate, `tidemark-cli`, builds the
+`tidemarkctl` binary on top of it: clap grammar grouped by entity, three output formats
+(`text`, `json`, `waybar`), a `guard` verdict with stable exit codes, and a `watch` stream
+that prints NDJSON as the daemon's signals arrive. No provider I/O, no GTK, no Tokio.
+
+**Tech Stack:** Rust 2024 (MSRV 1.92), zbus 5.13.2 on its async-io backend, clap 4 derive,
+clap_complete, serde_json, async-io for `block_on` and the retry timer.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-tidemarkctl-design.md` — read it first; this plan argues from it.
+
+## Global Constraints
+
+- Work only on branch `feat/cli`. Never commit to `main`.
+- Gate before every commit: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`. Run the targeted test during a task.
+- `tidemark-ipc` and `tidemark-cli` must not depend on `tidemark-core`, `reqwest`, `hyper`, `rusqlite`, `libsqlite3-sys`, `gtk4`, `gtk4-sys`, `libadwaita` **or `tokio`**. `scripts/check-layering.sh` enforces it.
+- Pin `zbus = "5.13.2"`, the version `tidemark` and `tidemarkd` already use. Add every dependency with `cargo add` — the committed `Cargo.lock` changes through Cargo, never by hand.
+- No `anyhow`. The CLI's error type is one struct, `exit::Failure { exit: Exit, message: String }`.
+- Exit codes: `0` success, `1` guard below threshold, `64` invalid arguments, `69` daemon unreachable or reading unavailable, `70` the daemon returned an error.
+- Percentages and spans go through `tidemark_types::present::{percent, duration}`. Never format a percentage or a duration by hand: the card, the notification and the CLI must not disagree.
+- Absent stays absent. A window without `resets_at` prints nothing about a reset and serializes without the key. Never substitute `0` or `null`.
+- Secrets arrive on stdin or via `--key-file PATH`. **Never** as an argv value, under any flag.
+- Windows: `tidemarkctl` must keep compiling there (CI builds `--workspace`) but is not packaged and not supported. Do not add it to any NSIS or Windows staging list, and do not touch `crates/tidemark/src/bus.rs`'s `cfg(windows)` `reconnect` module.
+- Tests: built-in `#[test]`/`#[tokio::test]`-free — this crate has no Tokio, so async tests use `async_io::block_on` inside a plain `#[test]`. Colocated `#[cfg(test)] mod tests`, descriptive `a_…`/`the_…` snake_case names. Tests needing a session bus print `skipped: no session bus reachable` and return, the way `crates/tidemarkd/src/service.rs` tests do.
+- Commit style: Conventional Commits with scopes (`feat(cli):`, `refactor(ipc):`, `docs:`).
+
+---
+
+## Phase A — one definition of the contract
+
+### Task 1: `tidemark-ipc`, the shared proxy
+
+**Files:**
+- Create: `crates/tidemark-ipc/Cargo.toml`
+- Create: `crates/tidemark-ipc/src/lib.rs`
+- Create: `crates/tidemark-ipc/AGENTS.md`
+- Modify: `Cargo.toml` (workspace members)
+- Modify: `crates/tidemark/Cargo.toml` (add the dependency)
+- Modify: `crates/tidemark/src/bus.rs:38-186` (cut the trait, re-export instead)
+- Modify: `scripts/check-layering.sh`
+
+**Interfaces:**
+- Produces: `tidemark_ipc::Daemon` (the proxy trait) and `tidemark_ipc::DaemonProxy` (generated), with the same method, property and signal set the GUI has today. Every later task consumes `DaemonProxy`.
+- Produces: `crate::bus::DaemonProxy` in the GUI keeps resolving, via `pub use`, so `detail.rs`, `preferences.rs`, `window.rs`, `provider_settings/mod.rs` and `provider_settings/detail.rs` are not edited at all.
+
+- [ ] **Step 1: Create the crate manifest**
+
+`crates/tidemark-ipc/Cargo.toml`. Copy the `[package]`/`[lints]` shape from
+`crates/tidemark-types/Cargo.toml` so the workspace inheritance matches:
+
+```toml
+[package]
+name = "tidemark-ipc"
+description = "The D-Bus contract between tidemarkd and its clients"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tidemark-types = { path = "../tidemark-types" }
+zbus = { version = "5.13.2", features = ["p2p"] }
+```
+
+`p2p` is kept because the Windows GUI builds its connection that way and this crate is
+what it builds the proxy from.
+
+- [ ] **Step 2: Add the crate to the workspace**
+
+In the root `Cargo.toml`, `members` becomes:
+
+```toml
+members = [
+    "crates/tidemark-types",
+    "crates/tidemark-ipc",
+    "crates/tidemark-core",
+    "crates/tidemarkd",
+    "crates/tidemark",
+    "crates/tidemark-cli",
+]
+```
+
+`crates/tidemark-cli` is listed now and created in Task 2; until then
+`cargo` commands must be run with `-p` on an existing crate. If that is inconvenient,
+add the `tidemark-cli` line in Task 2 instead — but do not forget it.
+
+- [ ] **Step 3: Move the proxy**
+
+`crates/tidemark-ipc/src/lib.rs` starts with this module documentation, then contains
+lines 38-186 of `crates/tidemark/src/bus.rs` **verbatim** — the whole `#[zbus::proxy]`
+attribute and `pub trait Daemon`, unchanged, including every doc comment:
+
+```rust
+//! The D-Bus contract between `tidemarkd` and everything that reads it.
+//!
+//! One definition, shared: the GTK window and `tidemarkctl` generate their proxy from this
+//! trait, so a method that changed shape is a compile error here rather than a runtime
+//! error on somebody's machine. That is the same argument that keeps the wire vocabulary in
+//! `tidemark-types` — a rule the build enforces beats a rule a hurry can skip.
+//!
+//! Nothing here opens a connection or decides a policy. Reconnection, retry and the
+//! Windows peer-to-peer transport belong to the client that needs them.
+
+use tidemark_types::{
+    AuthCandidate, AuthSelection, DataInfo, HistoryPoint, Preferences, ProviderDefinition,
+    ProviderStatus,
+};
+```
+
+The trait body references `tidemark_types::HistoryPoint` by full path today
+(`current_segment`'s return type); with the import above, shorten it to `Vec<HistoryPoint>`.
+Nothing else changes.
+
+- [ ] **Step 4: Point the GUI at it**
+
+In `crates/tidemark/Cargo.toml`, beside the other path dependency:
+
+```toml
+tidemark-ipc = { path = "../tidemark-ipc" }
+```
+
+In `crates/tidemark/src/bus.rs`, replace lines 38-186 (the attribute and the trait) with:
+
+```rust
+/// The contract lives in `tidemark-ipc`, shared with `tidemarkctl`. Re-exported here so
+/// this module stays the one place the rest of the interface asks for the daemon.
+pub use tidemark_ipc::{Daemon, DaemonProxy};
+```
+
+Keep the `use tidemark_types::{…}` list at the top of `bus.rs`: `Update` and `load` still
+name those types. Remove from it only what the compiler then reports as unused.
+
+- [ ] **Step 5: Build the GUI and run its tests**
+
+Run: `cargo test -p tidemark`
+Expected: PASS, including the five `bus.rs` reconnect tests that build a `DaemonProxy`
+through `DaemonProxy::builder(…)`. If a `cfg(windows)` block fails to resolve
+`DaemonProxy`, check that the `pub use` is outside every `cfg`.
+
+- [ ] **Step 6: Write the contract's own test**
+
+At the end of `crates/tidemark-ipc/src/lib.rs`. This proves the moved proxy still names the
+right interface and path, and still decodes the published dictionaries:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use tidemark_types::{AccountId, ProviderId, ProviderStatus, ids};
+
+    /// A daemon that answers two of the real methods.
+    struct FakeDaemon;
+
+    #[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+    impl FakeDaemon {
+        async fn get_status(&self) -> Vec<ProviderStatus> {
+            vec![ProviderStatus::pending(
+                &ProviderId::new("zai".to_owned()),
+                &AccountId::default(),
+            )]
+        }
+
+        #[zbus(property(emits_changed_signal = "false"))]
+        async fn version(&self) -> String {
+            "0.0.0-test".to_owned()
+        }
+    }
+
+    #[test]
+    fn the_proxy_reads_a_daemon_serving_the_interface() {
+        async_io::block_on(async {
+            let Ok(connection) = zbus::Connection::session().await else {
+                eprintln!("skipped: no session bus reachable");
+                return;
+            };
+            let name = format!("io.github.zbndev.TidemarkIpcTest{}", std::process::id());
+            let server = zbus::connection::Builder::session()
+                .expect("session builder")
+                .name(name.as_str())
+                .expect("unique test name")
+                .serve_at(ids::OBJECT_PATH, FakeDaemon)
+                .expect("serves the object")
+                .build()
+                .await
+                .expect("test service starts");
+
+            let proxy = super::DaemonProxy::builder(&connection)
+                .destination(name.as_str())
+                .expect("valid destination")
+                .build()
+                .await
+                .expect("proxy builds");
+
+            assert_eq!(proxy.version().await.expect("version"), "0.0.0-test");
+            let statuses = proxy.get_status().await.expect("status");
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].provider, "zai");
+            assert_eq!(statuses[0].state, "pending");
+
+            drop(server);
+        });
+    }
+}
+```
+
+Add the dev-dependency this needs: `cargo add -p tidemark-ipc --dev async-io`.
+
+- [ ] **Step 7: Run it**
+
+Run: `cargo test -p tidemark-ipc`
+Expected: PASS (or the skip line on a machine with no session bus).
+
+- [ ] **Step 8: Teach the layering check about the new crate**
+
+In `scripts/check-layering.sh`, after the `tidemark-types` block, insert:
+
+```bash
+# The contract's client half: it may open a connection, and nothing else. tokio is on the
+# list because zbus can be built on either reactor, and a CLI whose value is starting fast
+# must not acquire a second runtime by accident.
+forbid tidemark-ipc 'the contract carries no implementation' \
+    tidemark-core reqwest hyper rusqlite libsqlite3-sys gtk4 gtk4-sys libadwaita tokio
+```
+
+Also extend the header comment block at the top of the file, which currently describes
+four crates, with:
+
+```bash
+#   tidemark-ipc    the generated D-Bus proxy, shared by every client.
+#   tidemark-cli    tidemarkctl. Speaks D-Bus and prints; no runtime, no display.
+```
+
+- [ ] **Step 9: Run the full gate**
+
+Run: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`
+Expected: PASS, `layering ok`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/tidemark-ipc crates/tidemark/Cargo.toml crates/tidemark/src/bus.rs scripts/check-layering.sh
+git commit -m "refactor(ipc): share the daemon proxy between the window and a CLI"
+```
+
+---
+
+## Phase B — reading
+
+### Task 2: the binary, and `version`
+
+**Files:**
+- Create: `crates/tidemark-cli/Cargo.toml`
+- Create: `crates/tidemark-cli/src/main.rs`
+- Create: `crates/tidemark-cli/src/cli.rs`
+- Create: `crates/tidemark-cli/src/connect.rs`
+- Create: `crates/tidemark-cli/src/exit.rs`
+- Modify: `scripts/check-layering.sh`
+
+**Interfaces:**
+- Produces: `exit::Exit` (`Ok`, `Below`, `Usage`, `Unavailable`, `Daemon`) with `fn code(self) -> u8`, and `exit::Failure { exit, message }` with `From<zbus::Error>`.
+- Produces: `connect::daemon() -> zbus::Result<DaemonProxy<'static>>`.
+- Produces: `cli::Cli` with `cli::Command`, extended by every later task.
+
+- [ ] **Step 1: Create the crate**
+
+`crates/tidemark-cli/Cargo.toml`:
+
+```toml
+[package]
+name = "tidemark-cli"
+description = "Tidemark command-line client"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "tidemarkctl"
+path = "src/main.rs"
+
+[dependencies]
+tidemark-ipc = { path = "../tidemark-ipc" }
+tidemark-types = { path = "../tidemark-types" }
+zbus = "5.13.2"
+```
+
+Then add the rest with Cargo, so the lockfile is Cargo's work:
+
+```bash
+cargo add -p tidemark-cli clap --features derive
+cargo add -p tidemark-cli serde_json async-io
+cargo add -p tidemark-cli serde --features derive
+```
+
+Note the absent `p2p`: the CLI only ever talks to a session bus.
+
+- [ ] **Step 2: Write the exit codes**
+
+`crates/tidemark-cli/src/exit.rs`:
+
+```rust
+//! How the process ends. `guard`'s codes *are* its output, so every code is named once
+//! here and shared, and the two failures a script reacts to differently — nobody answered,
+//! versus the daemon refused — never collapse into the same number.
+
+/// Process exit codes, following sysexits where one applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Exit {
+    /// The command did what it was asked.
+    Ok = 0,
+    /// `guard` only: less quota is left than was asked for.
+    Below = 1,
+    /// The arguments do not name a command this build can run (`EX_USAGE`).
+    Usage = 64,
+    /// The daemon could not be reached, or there is no reading to judge (`EX_UNAVAILABLE`).
+    Unavailable = 69,
+    /// The daemon answered with an error (`EX_SOFTWARE`).
+    Daemon = 70,
+}
+
+impl Exit {
+    pub const fn code(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Why a command stopped, in the form the process exits with.
+#[derive(Debug)]
+pub struct Failure {
+    pub exit: Exit,
+    pub message: String,
+}
+
+impl Failure {
+    pub fn usage(message: impl Into<String>) -> Self {
+        Self {
+            exit: Exit::Usage,
+            message: message.into(),
+        }
+    }
+
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self {
+            exit: Exit::Unavailable,
+            message: message.into(),
+        }
+    }
+}
+
+/// An error *reply* is the daemon refusing something; anything else is the daemon not being
+/// there. A script retries one and gives up on the other.
+impl From<zbus::Error> for Failure {
+    fn from(error: zbus::Error) -> Self {
+        let exit = match &error {
+            zbus::Error::MethodError(..) | zbus::Error::FDO(_) => Exit::Daemon,
+            _ => Exit::Unavailable,
+        };
+        Self {
+            exit,
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Failure {
+    fn from(error: serde_json::Error) -> Self {
+        Self {
+            exit: Exit::Daemon,
+            message: format!("cannot serialize the daemon's answer: {error}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Write the connection**
+
+`crates/tidemark-cli/src/connect.rs`:
+
+```rust
+//! The one connection this program makes.
+//!
+//! Nothing here inspects `systemctl`: the daemon is D-Bus-activated, so asking for it is
+//! how it starts. A machine with no session bus fails as unreachable, which is the truth.
+
+use tidemark_ipc::DaemonProxy;
+
+pub async fn daemon() -> zbus::Result<DaemonProxy<'static>> {
+    let connection = zbus::Connection::session().await?;
+    DaemonProxy::new(&connection).await
+}
+```
+
+- [ ] **Step 4: Write the failing grammar test**
+
+`crates/tidemark-cli/src/cli.rs`:
+
+```rust
+//! The argument grammar, grouped by the entity a subcommand acts on rather than flattened
+//! into thirty verbs: a person reading `--help` should find `provider add` under
+//! `provider`, and a plugin author should be able to guess the next one.
+
+use clap::{Parser, Subcommand};
+
+/// The command-line client for the Tidemark daemon.
+#[derive(Debug, Parser)]
+#[command(name = "tidemarkctl", version, about, arg_required_else_help = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// This client's version, and the daemon's.
+    Version,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_grammar_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn version_takes_no_arguments() {
+        let cli = Cli::parse_from(["tidemarkctl", "version"]);
+        assert!(matches!(cli.command, Command::Version));
+    }
+}
+```
+
+`Cli::command()` needs `use clap::CommandFactory;` inside the test module.
+`debug_assert()` is clap's own grammar validator — it catches a `requires` naming a
+non-existent argument, which is the mistake this grammar will make most often as it grows.
+
+- [ ] **Step 5: Run it and watch it fail**
+
+Run: `cargo test -p tidemark-cli`
+Expected: FAIL — `main.rs` does not exist yet, so the crate does not build.
+
+- [ ] **Step 6: Write main**
+
+`crates/tidemark-cli/src/main.rs`:
+
+```rust
+//! `tidemarkctl`: the third consumer of the daemon's interface, after the window and
+//! `busctl`.
+//!
+//! It performs no provider I/O — every number it prints came off the bus — and it holds no
+//! runtime: zbus's async-io backend drives its own connection thread, so one `block_on` at
+//! the top is the whole of this program's concurrency.
+
+mod cli;
+mod connect;
+mod exit;
+
+use std::process::ExitCode;
+
+use clap::Parser;
+
+use crate::exit::{Exit, Failure};
+
+fn main() -> ExitCode {
+    let parsed = cli::Cli::parse();
+    match async_io::block_on(run(parsed)) {
+        Ok(exit) => ExitCode::from(exit.code()),
+        Err(failure) => {
+            eprintln!("{}", failure.message);
+            ExitCode::from(failure.exit.code())
+        }
+    }
+}
+
+async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
+    match cli.command {
+        cli::Command::Version => {
+            let proxy = connect::daemon().await?;
+            println!("tidemarkctl {}", env!("CARGO_PKG_VERSION"));
+            println!("tidemarkd {}", proxy.version().await?);
+            Ok(Exit::Ok)
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 8: Smoke it against the live daemon**
+
+Run: `cargo run -p tidemark-cli -- version`
+Expected: two lines, the second being the running daemon's version.
+
+Run: `env DBUS_SESSION_BUS_ADDRESS=unix:path=/nonexistent cargo run -p tidemark-cli -- version; echo $?`
+Expected: a message on stderr and `69`.
+
+- [ ] **Step 9: Add the CLI to the layering check**
+
+In `scripts/check-layering.sh`, after the `tidemark-ipc` block:
+
+```bash
+forbid tidemark-cli 'the CLI prints what the daemon publishes and nothing else' \
+    tidemark-core reqwest hyper rusqlite libsqlite3-sys gtk4 gtk4-sys libadwaita tokio
+```
+
+Run: `./scripts/check-layering.sh`
+Expected: `layering ok`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/tidemark-cli scripts/check-layering.sh
+git commit -m "feat(cli): tidemarkctl skeleton and version"
+```
+
+### Task 3: `usage --format text`
+
+**Files:**
+- Create: `crates/tidemark-cli/src/format/mod.rs`
+- Create: `crates/tidemark-cli/src/format/text.rs`
+- Modify: `crates/tidemark-cli/src/cli.rs`
+- Modify: `crates/tidemark-cli/src/main.rs`
+
+**Interfaces:**
+- Produces: `format::select<'a>(&'a [ProviderStatus], Option<&str>, Option<&str>) -> Vec<&'a ProviderStatus>` — the daemon's published order, filtered.
+- Produces: `format::dominant(&ProviderStatus) -> Option<Window>` — the window a card leads with, owned.
+- Produces: `format::text::render(&[&ProviderStatus], Timestamp) -> String`.
+- Produces: `cli::Usage { provider, account, format }` and `cli::Format` (variants added per format task).
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/tidemark-cli/src/format/text.rs`:
+
+```rust
+//! Usage as a person reads it.
+//!
+//! Percentages and spans come from `tidemark_types::present`, which is why a number here
+//! and the same number on a card cannot drift apart. Everything else on the line is the
+//! provider's own text, printed as it arrived.
+
+use tidemark_types::present::{duration, percent};
+use tidemark_types::{ProviderStatus, Timestamp, WindowStatus, provider_label};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, ProviderState};
+
+    fn status(state: ProviderState, windows: Vec<WindowStatus>) -> ProviderStatus {
+        let mut status = ProviderStatus::pending(
+            &ProviderId::new("claude".to_owned()),
+            &AccountId::default(),
+        );
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = windows;
+        status
+    }
+
+    fn window(resets_at: Option<i64>, used_percent: f64) -> WindowStatus {
+        WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: Some("72 / 100 prompts".to_owned()),
+            used_percent,
+            resets_at,
+            length_secs: Some(18_000),
+        }
+    }
+
+    /// 1785704400 + 3600.
+    const NOW: i64 = 1_785_708_000;
+
+    fn now() -> Timestamp {
+        Timestamp::from_unix(NOW).expect("plausible")
+    }
+
+    #[test]
+    fn a_window_without_a_reset_time_says_nothing_about_one() {
+        let status = status(ProviderState::Ok, vec![window(None, 72.0)]);
+        let out = render(&[&status], now());
+        assert!(out.contains("72%"), "{out}");
+        assert!(!out.contains("resets in"), "{out}");
+        assert!(!out.contains("pace"), "{out}");
+    }
+
+    #[test]
+    fn a_reset_time_brings_the_span_and_the_pace() {
+        let status = status(ProviderState::Ok, vec![window(Some(NOW + 3_600), 72.0)]);
+        let out = render(&[&status], now());
+        assert!(out.contains("resets in 1 h"), "{out}");
+        assert!(out.contains("outpacing"), "{out}");
+    }
+
+    #[test]
+    fn a_failed_poll_keeps_the_last_reading_under_its_state() {
+        let mut status = status(ProviderState::Unreachable, vec![window(None, 72.0)]);
+        status.message = Some("connection timed out".to_owned());
+        let out = render(&[&status], now());
+        assert!(out.contains("unreachable"), "{out}");
+        assert!(out.contains("connection timed out"), "{out}");
+        assert!(out.contains("72%"), "{out}");
+    }
+
+    #[test]
+    fn a_barely_touched_window_never_reads_as_untouched() {
+        let status = status(ProviderState::Ok, vec![window(None, 0.2)]);
+        assert!(render(&[&status], now()).contains("<1%"));
+    }
+}
+```
+
+The pace assertion is real arithmetic, not a guess: the window is five hours long and
+resets in one, so four fifths of it have elapsed, and 72% consumed is behind that — the
+window is *not* outpacing. **Verify this when the test runs**: if `outpacing` is the wrong
+word for `is_outpacing() == Some(false)`, the test says `on pace` instead. Fix the test to
+match `Window::is_outpacing`'s meaning, never the other way round.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli format::text`
+Expected: FAIL — `render` is not defined.
+
+- [ ] **Step 3: Write the renderer**
+
+Append to `crates/tidemark-cli/src/format/text.rs`, above the test module:
+
+```rust
+/// Every selected account, one block each, in the order the daemon published them.
+pub fn render(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+    let mut out = String::new();
+    for status in statuses {
+        let label = status
+            .account_label
+            .as_deref()
+            .unwrap_or(status.account.as_str());
+        out.push_str(&format!(
+            "{} · {}  [{}]\n",
+            provider_label(&status.provider),
+            label,
+            status.state
+        ));
+        if let Some(plan) = status.plan() {
+            out.push_str(&format!("  plan {plan}\n"));
+        }
+        if let Some(balance) = status.balance() {
+            out.push_str(&format!("  balance {balance}\n"));
+        }
+        if let Some(message) = &status.message {
+            out.push_str(&format!("  {message}\n"));
+        }
+        for window in &status.windows {
+            out.push_str(&line(window, now));
+        }
+        if let Some(captured) = status.captured_at {
+            out.push_str(&format!(
+                "  read {} ago\n",
+                duration(now.as_unix() - captured)
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// One window. The reset span and the pace note appear only when the provider gave enough
+/// to compute them; a withheld value is drawn as withheld, never as zero.
+fn line(status: &WindowStatus, now: Timestamp) -> String {
+    let window = status.to_window();
+    let mut line = format!("  {:<20} {:>5}", status.title, percent(window.used_percent));
+    if let Some(seconds) = window.seconds_until_reset(now) {
+        line.push_str(&format!("  resets in {}", duration(seconds)));
+    }
+    match window.is_outpacing(now) {
+        Some(true) => line.push_str("  outpacing"),
+        Some(false) => line.push_str("  on pace"),
+        None => {}
+    }
+    if let Some(subtitle) = &status.subtitle {
+        line.push_str(&format!("  ({subtitle})"));
+    }
+    line.push('\n');
+    line
+}
+```
+
+- [ ] **Step 4: Write the selection helpers**
+
+`crates/tidemark-cli/src/format/mod.rs`:
+
+```rust
+//! Turning what the daemon published into what a caller asked for.
+
+pub mod text;
+
+use tidemark_types::{ProviderStatus, Window};
+
+/// The accounts a `--provider` / `--account` pair names, in the daemon's published order.
+///
+/// The order is the user's, kept by the daemon and never re-sorted here: a CLI that
+/// ordered by urgency would disagree with the grid about which card comes first.
+pub fn select<'a>(
+    statuses: &'a [ProviderStatus],
+    provider: Option<&str>,
+    account: Option<&str>,
+) -> Vec<&'a ProviderStatus> {
+    statuses
+        .iter()
+        .filter(|status| provider.is_none_or(|slug| status.provider == slug))
+        .filter(|status| account.is_none_or(|id| status.account == id))
+        .collect()
+}
+
+/// The window a card would lead with, cloned out of the rebuilt snapshot so it outlives it.
+///
+/// `Snapshot::dominant_window` is the shared rule — shortest window unless the provider
+/// names a lead one — and reusing it is what keeps the CLI, the card and the tray naming
+/// the same window.
+pub fn dominant(status: &ProviderStatus) -> Option<Window> {
+    let snapshot = status.to_snapshot()?;
+    snapshot.dominant_window().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId};
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(
+            &ProviderId::new(provider.to_owned()),
+            &AccountId::new(account.to_owned()),
+        )
+    }
+
+    #[test]
+    fn no_filter_keeps_every_account_in_published_order() {
+        let statuses = vec![status("codex", "default"), status("claude", "work")];
+        let selected = select(&statuses, None, None);
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].provider, "codex");
+    }
+
+    #[test]
+    fn a_provider_filter_keeps_all_of_its_accounts() {
+        let statuses = vec![
+            status("claude", "default"),
+            status("claude", "work"),
+            status("codex", "default"),
+        ];
+        assert_eq!(select(&statuses, Some("claude"), None).len(), 2);
+        assert_eq!(select(&statuses, Some("claude"), Some("work")).len(), 1);
+    }
+
+    #[test]
+    fn an_account_that_is_not_there_selects_nothing() {
+        let statuses = vec![status("claude", "default")];
+        assert!(select(&statuses, Some("claude"), Some("nope")).is_empty());
+    }
+}
+```
+
+`AccountId::new` and `ProviderId::new` both take anything that converts into a `String`, so
+`AccountId::new("work")` is fine and the `to_owned()` above is optional — `tidemarkd`'s own
+tests call them both ways. `is_none_or` is stable in Rust 1.92 and reads better here than
+`map_or(true, …)`, which clippy rejects.
+
+- [ ] **Step 5: Extend the grammar and wire the command**
+
+In `cli.rs`, add to `Command`:
+
+```rust
+    /// What every configured account currently reports.
+    Usage(Usage),
+```
+
+and, after it:
+
+```rust
+#[derive(Debug, clap::Args)]
+pub struct Usage {
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Only this account of that provider.
+    #[arg(long, requires = "provider")]
+    pub account: Option<String>,
+    /// How to print it.
+    #[arg(long, value_enum, default_value_t = Format::Text)]
+    pub format: Format,
+}
+
+/// The output shapes. `json` and `waybar` are contracts other programs parse; `text` is
+/// for a person and may be reworded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Format {
+    Text,
+}
+```
+
+In `main.rs`, add `mod format;` and the arm:
+
+```rust
+        cli::Command::Usage(args) => {
+            let proxy = connect::daemon().await?;
+            let statuses = proxy.get_status().await?;
+            let selected = format::select(&statuses, args.provider.as_deref(), args.account.as_deref());
+            match args.format {
+                cli::Format::Text => print!(
+                    "{}",
+                    format::text::render(&selected, tidemark_types::Timestamp::now())
+                ),
+            }
+            Ok(Exit::Ok)
+        }
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 7: Smoke it**
+
+Run: `cargo run -p tidemark-cli -- usage`
+Expected: one block per configured account, matching what the window shows.
+
+Run: `cargo run -p tidemark-cli -- usage --provider claude`
+Expected: only Claude's accounts.
+
+Run: `cargo run -p tidemark-cli -- usage --account work`
+Expected: exit 2 from clap, complaining that `--account` requires `--provider`. clap's own
+usage error is code 2, not 64; that is clap's contract and is left alone — `Exit::Usage` is
+for arguments this program rejects itself.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): usage in text form"
+```
+
+### Task 4: `usage --format json`
+
+**Files:**
+- Create: `crates/tidemark-cli/src/format/json.rs`
+- Modify: `crates/tidemark-cli/src/format/mod.rs`, `src/cli.rs`, `src/main.rs`
+
+**Interfaces:**
+- Produces: `format::json::render(&[&ProviderStatus]) -> Result<String, serde_json::Error>` emitting `{"accounts": [...]}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/tidemark-cli/src/format/json.rs`:
+
+```rust
+//! Usage as another program parses it.
+//!
+//! An object with one key rather than a bare array, so a later build can add a second key
+//! without breaking a plugin that already reads this one — the same reason every published
+//! D-Bus structure is a dictionary. The account objects are `ProviderStatus` as serde
+//! renders it, which means **absent stays absent**: a provider that withheld a reset time
+//! produces no key at all, and no `null` invites a plugin to render it as zero.
+
+use serde::Serialize;
+use tidemark_types::ProviderStatus;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, ProviderState, WindowStatus};
+
+    #[test]
+    fn an_account_with_no_reading_publishes_no_reading_keys() {
+        let status = ProviderStatus::pending(
+            &ProviderId::new("zai".to_owned()),
+            &AccountId::default(),
+        );
+        let text = render(&[&status]).expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        let account = &value["accounts"][0];
+        assert_eq!(account["provider"], "zai");
+        assert_eq!(account["state"], "pending");
+        assert!(account.get("captured_at").is_none(), "{text}");
+        assert!(account.get("message").is_none(), "{text}");
+    }
+
+    #[test]
+    fn a_window_publishes_the_keys_a_plugin_parses() {
+        let mut status = ProviderStatus::pending(
+            &ProviderId::new("claude".to_owned()),
+            &AccountId::default(),
+        );
+        status.state = ProviderState::Ok.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = vec![WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: None,
+            used_percent: 72.0,
+            resets_at: Some(1_785_708_000),
+            length_secs: Some(18_000),
+        }];
+        let text = render(&[&status]).expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        let window = &value["accounts"][0]["windows"][0];
+        assert_eq!(window["key"], "w18000");
+        assert_eq!(window["used_percent"], 72.0);
+        assert_eq!(window["resets_at"], 1_785_708_000_i64);
+        assert_eq!(window["length_secs"], 18_000);
+        assert!(window.get("subtitle").is_none(), "{text}");
+    }
+}
+```
+
+These two tests **pin a published contract**, which is their whole point. If a key comes
+out under another spelling than the field name — the shape is `zvariant`'s
+`SerializeDict` derive, not ours — then that spelling *is* the contract: record it in the
+test and in the README. Do not add a `rename` to `tidemark-types` to make this test pretty;
+the D-Bus dictionary keys and the JSON keys are the same names, and renaming one changes
+both.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli format::json`
+Expected: FAIL — `render` is not defined.
+
+- [ ] **Step 3: Write the renderer**
+
+Above the test module:
+
+```rust
+/// The published document.
+#[derive(Debug, Serialize)]
+struct Document<'a> {
+    accounts: &'a [&'a ProviderStatus],
+}
+
+pub fn render(statuses: &[&ProviderStatus]) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&Document { accounts: statuses })
+}
+```
+
+- [ ] **Step 4: Wire it up**
+
+`format/mod.rs` gains `pub mod json;`. `cli::Format` gains `Json`. `main.rs`'s match gains:
+
+```rust
+                cli::Format::Json => println!("{}", format::json::render(&selected)?),
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 6: Smoke it**
+
+Run: `cargo run -p tidemark-cli -- usage --format json | jq '.accounts[0] | {provider, state, windows}'`
+Expected: real values; no `null` where the provider said nothing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): usage as json"
+```
+
+### Task 5: `usage --format waybar`
+
+**Files:**
+- Create: `crates/tidemark-cli/src/format/waybar.rs`
+- Modify: `crates/tidemark-cli/src/format/mod.rs`, `src/cli.rs`, `src/main.rs`
+
+**Interfaces:**
+- Produces: `format::waybar::render(&[&ProviderStatus], Timestamp) -> Result<String, serde_json::Error>` emitting `{"text","tooltip","class","percentage"}` with `class` always an array.
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/tidemark-cli/src/format/waybar.rs`:
+
+```rust
+//! Usage as a Waybar custom module consumes it.
+//!
+//! The number is the worst dominant window across the selected accounts — the same window
+//! a card leads with, so the panel and the grid never disagree about which limit matters.
+//! `class` is always an array: a rate-limited account at 95% is `["danger", "stale"]`, and
+//! a shape that changed with the situation would make somebody's CSS conditional.
+
+use serde::Serialize;
+use tidemark_types::present::{duration, percent};
+use tidemark_types::{
+    DANGER_AT, ProviderState, ProviderStatus, Timestamp, WARNING_AT, provider_label,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, WindowStatus};
+
+    const NOW: i64 = 1_785_708_000;
+
+    fn now() -> Timestamp {
+        Timestamp::from_unix(NOW).expect("plausible")
+    }
+
+    fn status(provider: &str, state: ProviderState, used_percent: f64) -> ProviderStatus {
+        let mut status = ProviderStatus::pending(
+            &ProviderId::new(provider.to_owned()),
+            &AccountId::default(),
+        );
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(NOW - 60);
+        status.windows = vec![WindowStatus {
+            key: "w18000".to_owned(),
+            title: "Session".to_owned(),
+            subtitle: None,
+            used_percent,
+            resets_at: Some(NOW + 3_600),
+            length_secs: Some(18_000),
+        }];
+        status
+    }
+
+    fn card(text: &str) -> serde_json::Value {
+        serde_json::from_str(text).expect("valid json")
+    }
+
+    #[test]
+    fn the_worst_account_sets_the_number() {
+        let low = status("claude", ProviderState::Ok, 12.0);
+        let high = status("codex", ProviderState::Ok, 91.0);
+        let card = card(&render(&[&low, &high], now()).expect("serializes"));
+        assert_eq!(card["text"], "91%");
+        assert_eq!(card["percentage"], 91);
+        assert_eq!(card["class"][0], "danger");
+    }
+
+    #[test]
+    fn a_stale_account_keeps_its_zone() {
+        let status = status("claude", ProviderState::RateLimited, 95.0);
+        let card = card(&render(&[&status], now()).expect("serializes"));
+        assert_eq!(card["class"][0], "danger");
+        assert_eq!(card["class"][1], "stale");
+    }
+
+    #[test]
+    fn nothing_to_report_hides_the_module() {
+        let pending = ProviderStatus::pending(
+            &ProviderId::new("zai".to_owned()),
+            &AccountId::default(),
+        );
+        let card = card(&render(&[&pending], now()).expect("serializes"));
+        assert_eq!(card["text"], "");
+        assert_eq!(card["percentage"], 0);
+        assert_eq!(card["class"][0], "stale");
+    }
+
+    #[test]
+    fn a_tooltip_escapes_the_provider_own_text() {
+        let mut status = status("claude", ProviderState::Ok, 50.0);
+        status.windows[0].title = "Session & overage".to_owned();
+        let card = card(&render(&[&status], now()).expect("serializes"));
+        let tooltip = card["tooltip"].as_str().expect("a string");
+        assert!(tooltip.contains("&amp;"), "{tooltip}");
+        assert!(!tooltip.contains("Session & overage"), "{tooltip}");
+    }
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli format::waybar`
+Expected: FAIL — `render` is not defined.
+
+- [ ] **Step 3: Write the renderer**
+
+Above the test module:
+
+```rust
+/// What a Waybar custom module reads.
+#[derive(Debug, Serialize)]
+struct Card {
+    text: String,
+    tooltip: String,
+    class: Vec<String>,
+    percentage: u8,
+}
+
+pub fn render(
+    statuses: &[&ProviderStatus],
+    now: Timestamp,
+) -> Result<String, serde_json::Error> {
+    let worst = statuses
+        .iter()
+        .filter_map(|status| super::dominant(status))
+        .map(|window| window.used_percent)
+        .fold(None, |worst: Option<f64>, used| {
+            Some(worst.map_or(used, |worst| worst.max(used)))
+        });
+    let stale = statuses
+        .iter()
+        .any(|status| ProviderState::from_wire(&status.state) != Some(ProviderState::Ok));
+
+    let card = match worst {
+        Some(used) => Card {
+            text: percent(used),
+            tooltip: tooltip(statuses, now),
+            class: classes(Some(used), stale),
+            percentage: used.clamp(0.0, 100.0).round() as u8,
+        },
+        // An empty text hides the module, which is the honest rendering of "no reading
+        // yet": a zero would be a claim about quota nobody has measured.
+        None => Card {
+            text: String::new(),
+            tooltip: "Tidemark has no reading yet".to_owned(),
+            class: classes(None, true),
+            percentage: 0,
+        },
+    };
+    serde_json::to_string(&card)
+}
+
+/// The zone first, so a stylesheet keyed on `.danger` keeps working when a second class
+/// applies. The boundaries are the shared constants the bar recolours at.
+fn classes(used: Option<f64>, stale: bool) -> Vec<String> {
+    let mut classes = Vec::new();
+    if let Some(used) = used {
+        classes.push(
+            if used >= DANGER_AT {
+                "danger"
+            } else if used >= WARNING_AT {
+                "warning"
+            } else {
+                "ok"
+            }
+            .to_owned(),
+        );
+    }
+    if stale {
+        classes.push("stale".to_owned());
+    }
+    classes
+}
+
+fn tooltip(statuses: &[&ProviderStatus], now: Timestamp) -> String {
+    statuses
+        .iter()
+        .map(|status| {
+            let mut line = format!(
+                "{} · {}",
+                provider_label(&status.provider),
+                status
+                    .account_label
+                    .as_deref()
+                    .unwrap_or(status.account.as_str())
+            );
+            if let Some(window) = super::dominant(status) {
+                line.push_str(&format!(
+                    " — {} {}",
+                    window.title,
+                    percent(window.used_percent)
+                ));
+                if let Some(seconds) = window.seconds_until_reset(now) {
+                    line.push_str(&format!(", resets in {}", duration(seconds)));
+                }
+            }
+            if ProviderState::from_wire(&status.state) != Some(ProviderState::Ok) {
+                line.push_str(&format!(" [{}]", status.state));
+            }
+            escape(&line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Waybar renders a tooltip as Pango markup, and a provider's own window title is text we
+/// did not write. Escaping the five predefined entities is the whole of it.
+fn escape(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '\'' => escaped.push_str("&apos;"),
+            '"' => escaped.push_str("&quot;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+```
+
+- [ ] **Step 4: Wire it up**
+
+`format/mod.rs` gains `pub mod waybar;`. `cli::Format` gains `Waybar`. `main.rs`'s match
+gains:
+
+```rust
+                cli::Format::Waybar => println!(
+                    "{}",
+                    format::waybar::render(&selected, tidemark_types::Timestamp::now())?
+                ),
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 6: Smoke it**
+
+Run: `cargo run -p tidemark-cli -- usage --format waybar | jq .`
+Expected: four keys, `class` an array, `percentage` an integer matching `text`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): usage as a waybar card"
+```
+
+### Task 6: `guard`
+
+**Files:**
+- Create: `crates/tidemark-cli/src/guard.rs`
+- Modify: `crates/tidemark-cli/src/cli.rs`, `src/main.rs`
+
+**Interfaces:**
+- Produces: `guard::Selection { Dominant, Named(String), Any }`, `guard::Verdict { Safe { remaining }, Below { remaining }, Unavailable(String) }` with `fn exit(&self) -> Exit`, and `guard::decide(&[&ProviderStatus], &Selection, u8) -> Verdict`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/tidemark-cli/src/guard.rs`:
+
+```rust
+//! "May I start a long run right now?", answered with an exit code.
+//!
+//! Only an `ok` account's reading is judged. A last-good number sitting behind a rejected
+//! credential or a rate limit would answer "safe" about quota that cannot be spent, so
+//! those exit 69 — unavailable — and a script can tell "no answer" from "no quota".
+
+use tidemark_types::{ProviderState, ProviderStatus};
+
+use crate::exit::Exit;
+use crate::format;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, WindowStatus};
+
+    fn window(key: &str, used_percent: f64) -> WindowStatus {
+        WindowStatus {
+            key: key.to_owned(),
+            title: key.to_owned(),
+            subtitle: None,
+            used_percent,
+            resets_at: None,
+            length_secs: Some(18_000),
+        }
+    }
+
+    fn status(state: ProviderState, windows: Vec<WindowStatus>) -> ProviderStatus {
+        let mut status = ProviderStatus::pending(
+            &ProviderId::new("claude".to_owned()),
+            &AccountId::default(),
+        );
+        status.state = state.as_wire().to_owned();
+        status.captured_at = Some(1_785_704_400);
+        status.windows = windows;
+        status
+    }
+
+    #[test]
+    fn enough_left_is_safe() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 40.0)]);
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict, Verdict::Safe { remaining: 60.0 });
+        assert_eq!(verdict.exit(), Exit::Ok);
+    }
+
+    #[test]
+    fn too_little_left_is_below() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 85.0)]);
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict, Verdict::Below { remaining: 15.0 });
+        assert_eq!(verdict.exit(), Exit::Below);
+    }
+
+    #[test]
+    fn a_named_window_that_is_not_there_is_unavailable_not_safe() {
+        let status = status(ProviderState::Ok, vec![window("w18000", 5.0)]);
+        let verdict = decide(&[&status], &Selection::Named("w604800".to_owned()), 20);
+        assert_eq!(verdict.exit(), Exit::Unavailable);
+    }
+
+    #[test]
+    fn a_stale_reading_is_never_judged() {
+        let status = status(ProviderState::CredentialRejected, vec![window("w18000", 1.0)]);
+        let verdict = decide(&[&status], &Selection::Dominant, 20);
+        assert_eq!(verdict.exit(), Exit::Unavailable);
+    }
+
+    #[test]
+    fn any_window_judges_the_fullest_one() {
+        let status = status(
+            ProviderState::Ok,
+            vec![window("w18000", 10.0), window("w604800", 95.0)],
+        );
+        assert_eq!(
+            decide(&[&status], &Selection::Any, 20).exit(),
+            Exit::Below
+        );
+        assert_eq!(
+            decide(&[&status], &Selection::Dominant, 20).exit(),
+            Exit::Ok
+        );
+    }
+
+    #[test]
+    fn selecting_no_account_is_unavailable() {
+        assert_eq!(decide(&[], &Selection::Dominant, 20).exit(), Exit::Unavailable);
+    }
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli guard`
+Expected: FAIL — `decide`, `Selection` and `Verdict` are not defined.
+
+- [ ] **Step 3: Write the decision**
+
+Above the test module:
+
+```rust
+/// Which window the verdict is about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selection {
+    /// The window a card leads with.
+    Dominant,
+    /// One window by its stable key.
+    Named(String),
+    /// Every window of every selected account; the fullest one decides.
+    Any,
+}
+
+/// What the guard concluded.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Verdict {
+    Safe { remaining: f64 },
+    Below { remaining: f64 },
+    /// Nothing trustworthy to judge, with the reason for stderr.
+    Unavailable(String),
+}
+
+impl Verdict {
+    pub const fn exit(&self) -> Exit {
+        match self {
+            Self::Safe { .. } => Exit::Ok,
+            Self::Below { .. } => Exit::Below,
+            Self::Unavailable(_) => Exit::Unavailable,
+        }
+    }
+}
+
+/// The fullest selected window against the threshold. Every selected account must be `ok`
+/// and must have the window asked for; anything else is unavailable rather than a guess.
+pub fn decide(statuses: &[&ProviderStatus], selection: &Selection, min_remaining: u8) -> Verdict {
+    if statuses.is_empty() {
+        return Verdict::Unavailable("no configured account matches".to_owned());
+    }
+
+    let mut fullest: Option<f64> = None;
+    for status in statuses {
+        if ProviderState::from_wire(&status.state) != Some(ProviderState::Ok) {
+            return Verdict::Unavailable(format!(
+                "{} · {} is {}",
+                status.provider, status.account, status.state
+            ));
+        }
+        let used = match selection {
+            Selection::Dominant => format::dominant(status).map(|window| window.used_percent),
+            Selection::Named(key) => status
+                .windows
+                .iter()
+                .find(|window| &window.key == key)
+                .map(|window| window.used_percent),
+            Selection::Any => status
+                .windows
+                .iter()
+                .map(|window| window.used_percent)
+                .fold(None, |worst: Option<f64>, used| {
+                    Some(worst.map_or(used, |worst| worst.max(used)))
+                }),
+        };
+        let Some(used) = used else {
+            return Verdict::Unavailable(match selection {
+                Selection::Named(key) => format!(
+                    "{} · {} reports no window {key}",
+                    status.provider, status.account
+                ),
+                _ => format!("{} · {} has no reading", status.provider, status.account),
+            });
+        };
+        fullest = Some(fullest.map_or(used, |worst: f64| worst.max(used)));
+    }
+
+    let remaining = 100.0 - fullest.unwrap_or(100.0);
+    if remaining >= f64::from(min_remaining) {
+        Verdict::Safe { remaining }
+    } else {
+        Verdict::Below { remaining }
+    }
+}
+```
+
+- [ ] **Step 4: Extend the grammar**
+
+In `cli.rs`, add to `Command`:
+
+```rust
+    /// Exit 0 when enough quota is left to start something, 1 when there is not.
+    Guard(Guard),
+```
+
+and:
+
+```rust
+#[derive(Debug, clap::Args)]
+pub struct Guard {
+    /// Fail when less than this percentage of the window is left.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub min_remaining: u8,
+    /// Judge this window key instead of the one a card leads with.
+    #[arg(long, conflicts_with = "any")]
+    pub window: Option<String>,
+    /// Judge every window, not just the leading one.
+    #[arg(long)]
+    pub any: bool,
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// Only this account of that provider.
+    #[arg(long, requires = "provider")]
+    pub account: Option<String>,
+}
+```
+
+- [ ] **Step 5: Wire the command**
+
+`main.rs` gains `mod guard;` and:
+
+```rust
+        cli::Command::Guard(args) => {
+            let proxy = connect::daemon().await?;
+            let statuses = proxy.get_status().await?;
+            let selected =
+                format::select(&statuses, args.provider.as_deref(), args.account.as_deref());
+            let selection = match (args.any, args.window) {
+                (true, _) => guard::Selection::Any,
+                (false, Some(key)) => guard::Selection::Named(key),
+                (false, None) => guard::Selection::Dominant,
+            };
+            let verdict = guard::decide(&selected, &selection, args.min_remaining);
+            match &verdict {
+                guard::Verdict::Safe { remaining } | guard::Verdict::Below { remaining } => {
+                    println!("{} left", tidemark_types::present::percent(*remaining));
+                }
+                guard::Verdict::Unavailable(reason) => eprintln!("{reason}"),
+            }
+            Ok(verdict.exit())
+        }
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 7: Smoke it**
+
+```bash
+cargo run -p tidemark-cli -- guard --min-remaining 1 --provider claude; echo $?
+cargo run -p tidemark-cli -- guard --min-remaining 100 --provider claude; echo $?
+cargo run -p tidemark-cli -- guard --min-remaining 20 --window nope --provider claude; echo $?
+cargo run -p tidemark-cli -- guard --min-remaining 900; echo $?
+```
+Expected: `0`, `1`, `69`, and clap's own `2` for the out-of-range threshold.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): guard a long run behind an exit code"
+```
+
+---
+
+## Phase C — streaming
+
+### Task 7: the event lines and the client-side mirror
+
+**Files:**
+- Create: `crates/tidemark-cli/src/watch/mod.rs`
+- Create: `crates/tidemark-cli/src/watch/mirror.rs`
+
+**Interfaces:**
+- Produces: `watch::Event<'a>` serializing as `{"event":"<kind>", …}`, and `watch::line(&Event) -> Result<String, serde_json::Error>`.
+- Produces: `watch::mirror::Change { Upsert(ProviderStatus), Remove { provider, account }, Order(Vec<String>) }` and `watch::mirror::apply(&mut Vec<ProviderStatus>, Change)`.
+
+- [ ] **Step 1: Write the failing mirror tests**
+
+`crates/tidemark-cli/src/watch/mirror.rs`:
+
+```rust
+//! The client-side copy of what the daemon published.
+//!
+//! `watch --format waybar` has to re-render one card from *every* account after each
+//! signal, so the stream keeps a mirror. The rules are the daemon's own: a change to a
+//! known `(provider, account)` replaces it where it stands, an unknown one goes on the end,
+//! and an order announcement is a permutation of provider slugs rather than a new set — a
+//! status carries no position, so the sequence has to be applied separately.
+
+use tidemark_types::ProviderStatus;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId, ProviderState};
+
+    fn status(provider: &str, account: &str) -> ProviderStatus {
+        ProviderStatus::pending(
+            &ProviderId::new(provider.to_owned()),
+            &AccountId::new(account.to_owned()),
+        )
+    }
+
+    #[test]
+    fn a_change_replaces_the_account_where_it_stands() {
+        let mut statuses = vec![status("claude", "default"), status("codex", "default")];
+        let mut changed = status("claude", "default");
+        changed.state = ProviderState::Ok.as_wire().to_owned();
+
+        apply(&mut statuses, Change::Upsert(changed));
+
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].provider, "claude");
+        assert_eq!(statuses[0].state, "ok");
+    }
+
+    #[test]
+    fn an_account_nobody_has_seen_goes_on_the_end() {
+        let mut statuses = vec![status("claude", "default")];
+        apply(&mut statuses, Change::Upsert(status("claude", "work")));
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[1].account, "work");
+    }
+
+    #[test]
+    fn a_removal_drops_exactly_one_account() {
+        let mut statuses = vec![status("claude", "default"), status("claude", "work")];
+        apply(
+            &mut statuses,
+            Change::Remove {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+            },
+        );
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].account, "work");
+    }
+
+    #[test]
+    fn an_order_permutes_providers_and_keeps_accounts_together() {
+        let mut statuses = vec![
+            status("claude", "default"),
+            status("codex", "default"),
+            status("claude", "work"),
+        ];
+        apply(
+            &mut statuses,
+            Change::Order(vec!["codex".to_owned(), "claude".to_owned()]),
+        );
+        assert_eq!(statuses[0].provider, "codex");
+        assert_eq!(statuses[1].account, "default");
+        assert_eq!(statuses[2].account, "work");
+    }
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli watch::mirror`
+Expected: FAIL — `apply` and `Change` are not defined.
+
+- [ ] **Step 3: Write the mirror**
+
+Above the test module:
+
+```rust
+/// One announced change.
+#[derive(Debug)]
+pub enum Change {
+    Upsert(ProviderStatus),
+    Remove { provider: String, account: String },
+    Order(Vec<String>),
+}
+
+pub fn apply(statuses: &mut Vec<ProviderStatus>, change: Change) {
+    match change {
+        Change::Upsert(status) => {
+            match statuses
+                .iter_mut()
+                .find(|held| held.provider == status.provider && held.account == status.account)
+            {
+                Some(held) => *held = status,
+                None => statuses.push(status),
+            }
+        }
+        Change::Remove { provider, account } => {
+            statuses.retain(|held| !(held.provider == provider && held.account == account));
+        }
+        // A stable sort, so accounts keep the order the daemon gave them inside their
+        // provider. A provider the announcement does not name sorts last rather than
+        // disappearing.
+        Change::Order(providers) => statuses.sort_by_key(|status| {
+            providers
+                .iter()
+                .position(|slug| *slug == status.provider)
+                .unwrap_or(usize::MAX)
+        }),
+    }
+}
+```
+
+- [ ] **Step 4: Write the failing event-line tests**
+
+`crates/tidemark-cli/src/watch/mod.rs`:
+
+```rust
+//! The daemon's signals as a line-oriented stream.
+//!
+//! One JSON object per line, flushed as it is written, so a plugin can read a pipe instead
+//! of polling a snapshot every few seconds. The first line of a connection is always a
+//! snapshot, and so is the first line after a reconnect: whatever the daemon published
+//! while nothing was listening was announced to nobody, and re-reading is the only honest
+//! recovery.
+
+pub mod mirror;
+
+use serde::Serialize;
+use tidemark_types::{DataInfo, Preferences, ProviderStatus};
+
+/// One line of the stream.
+#[derive(Debug, Serialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+pub enum Event<'a> {
+    Snapshot { accounts: &'a [ProviderStatus] },
+    Changed { account: &'a ProviderStatus },
+    Removed { provider: &'a str, account: &'a str },
+    Order { providers: &'a [String] },
+    Preferences { preferences: &'a Preferences },
+    Data { data: &'a DataInfo },
+    Update { version: &'a str },
+    Waiting,
+}
+
+pub fn line(event: &Event<'_>) -> Result<String, serde_json::Error> {
+    serde_json::to_string(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidemark_types::{AccountId, ProviderId};
+
+    #[test]
+    fn a_snapshot_names_itself_and_carries_every_account() {
+        let accounts = vec![ProviderStatus::pending(
+            &ProviderId::new("zai".to_owned()),
+            &AccountId::default(),
+        )];
+        let text = line(&Event::Snapshot {
+            accounts: &accounts,
+        })
+        .expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        assert_eq!(value["event"], "snapshot");
+        assert_eq!(value["accounts"][0]["provider"], "zai");
+        assert!(!text.contains('\n'), "one event is one line: {text}");
+    }
+
+    #[test]
+    fn a_removal_names_the_account_that_went_away() {
+        let text = line(&Event::Removed {
+            provider: "claude",
+            account: "work",
+        })
+        .expect("serializes");
+        let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+        assert_eq!(value["event"], "removed");
+        assert_eq!(value["provider"], "claude");
+        assert_eq!(value["account"], "work");
+    }
+
+    #[test]
+    fn waiting_is_a_line_of_its_own() {
+        let text = line(&Event::Waiting).expect("serializes");
+        assert_eq!(text, r#"{"event":"waiting"}"#);
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p tidemark-cli watch`
+Expected: PASS. `main.rs` needs `mod watch;` for the module to be compiled at all.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): the watch stream's events and mirror"
+```
+
+### Task 8: `watch`, the stream and the reconnect
+
+**Files:**
+- Modify: `crates/tidemark-cli/src/watch/mod.rs`
+- Modify: `crates/tidemark-cli/src/cli.rs`, `src/main.rs`
+- Create: `crates/tidemark-cli/tests/fake/mod.rs`
+- Create: `crates/tidemark-cli/tests/watching_a_fake_daemon.rs`
+
+**Interfaces:**
+- Consumes: `watch::Event`, `watch::line`, `watch::mirror::{apply, Change}`, `format::waybar::render`, `connect::daemon`.
+- Produces: `watch::pump(&DaemonProxy<'_>, Sink, &mut impl Write) -> zbus::Result<()>` — one connection's worth of streaming.
+- Produces: `watch::run(Sink) -> Result<Exit, Failure>` — the connect/retry loop, never returning under normal operation.
+- Produces: `tests::fake::FakeDaemon` and `tests::fake::serve(name) -> (zbus::Connection, DaemonProxy<'static>)`, reused by Tasks 9-11.
+
+- [ ] **Step 1: Write the pump and the retry loop**
+
+Append to `crates/tidemark-cli/src/watch/mod.rs`. The structure mirrors
+`crates/tidemark/src/bus.rs:249-357` (`serve`) — read it first — minus the GLib half and
+minus the `cfg(windows)` transport, which stays the window's business:
+
+```rust
+use std::io::Write;
+use std::pin::pin;
+use std::task::Poll;
+use std::time::Duration;
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::Timestamp;
+use zbus::export::futures_core::Stream;
+
+use crate::exit::{Exit, Failure};
+use crate::{connect, format};
+
+/// How long to wait before trying the bus again. Only reached when the *bus* is
+/// unreachable; a daemon that is merely not running is waited for by name.
+const RETRY: Duration = Duration::from_secs(5);
+
+/// What the stream prints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sink {
+    /// One JSON event per line.
+    Events,
+    /// One Waybar card per change, re-rendered from the mirror.
+    Waybar,
+}
+
+/// Streams until the process is killed. Each connection's events are printed, and the loop
+/// re-reads everything after a gap.
+pub async fn run(sink: Sink, provider: Option<String>) -> Result<Exit, Failure> {
+    let mut out = std::io::stdout();
+    loop {
+        match connect::daemon().await {
+            Ok(proxy) => {
+                if let Err(error) = pump(&proxy, sink, provider.as_deref(), &mut out).await {
+                    eprintln!("{error}");
+                }
+            }
+            Err(error) => eprintln!("{error}"),
+        }
+        emit(&mut out, &Event::Waiting)?;
+        async_io::Timer::after(RETRY).await;
+    }
+}
+
+/// One connection's worth of streaming. Returns when a stream ends, which on the session
+/// bus means the connection is finished with.
+pub async fn pump(
+    proxy: &DaemonProxy<'_>,
+    sink: Sink,
+    provider: Option<&str>,
+    out: &mut impl Write,
+) -> zbus::Result<()> {
+    // Subscribed before the first GetStatus, so a poll finishing between the two arrives as
+    // a signal rather than being missed by both.
+    let mut owner = pin!(proxy.inner().receive_owner_changed().await?);
+    let mut changes = pin!(proxy.receive_provider_changed().await?);
+    let mut removals = pin!(proxy.receive_provider_removed().await?);
+    let mut orders = pin!(proxy.receive_order_changed().await?);
+    let mut updates = pin!(proxy.receive_update_changed().await?);
+    let mut preferences = pin!(proxy.receive_preferences_changed().await?);
+    let mut data = pin!(proxy.receive_data_changed().await?);
+
+    let mut statuses = proxy.get_status().await?;
+    publish(out, sink, provider, &statuses, &Event::Snapshot { accounts: &statuses })?;
+
+    loop {
+        let event = std::future::poll_fn(|context| {
+            if let Poll::Ready(owner) = owner.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Owner(owner));
+            }
+            if let Poll::Ready(change) = changes.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Changed(change));
+            }
+            if let Poll::Ready(removal) = removals.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Removed(removal));
+            }
+            if let Poll::Ready(order) = orders.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Order(order));
+            }
+            if let Poll::Ready(update) = updates.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Update(update));
+            }
+            if let Poll::Ready(changed) = preferences.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Preferences(changed));
+            }
+            if let Poll::Ready(changed) = data.as_mut().poll_next(context) {
+                return Poll::Ready(Signal::Data(changed));
+            }
+            Poll::Pending
+        })
+        .await;
+
+        match event {
+            // The daemon appeared, or a newer one replaced it. Re-read: what it published
+            // while nothing was listening was announced to nobody.
+            Signal::Owner(Some(Some(_))) => {
+                statuses = proxy.get_status().await?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Snapshot { accounts: &statuses },
+                )?;
+            }
+            Signal::Owner(Some(None)) => publish(out, sink, provider, &statuses, &Event::Waiting)?,
+            Signal::Changed(Some(signal)) => {
+                let status = signal.args()?.status;
+                publish(out, sink, provider, &statuses, &Event::Changed { account: &status })?;
+                mirror::apply(&mut statuses, mirror::Change::Upsert(status));
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Removed(Some(signal)) => {
+                let args = signal.args()?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Removed {
+                        provider: args.provider,
+                        account: args.account,
+                    },
+                )?;
+                mirror::apply(
+                    &mut statuses,
+                    mirror::Change::Remove {
+                        provider: args.provider.to_owned(),
+                        account: args.account.to_owned(),
+                    },
+                );
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Order(Some(signal)) => {
+                let providers = signal.args()?.providers;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Order {
+                        providers: &providers,
+                    },
+                )?;
+                mirror::apply(&mut statuses, mirror::Change::Order(providers));
+                republish(out, sink, provider, &statuses)?;
+            }
+            Signal::Update(Some(signal)) => publish(
+                out,
+                sink,
+                provider,
+                &statuses,
+                &Event::Update {
+                    version: signal.args()?.version,
+                },
+            )?,
+            Signal::Preferences(Some(signal)) => {
+                let args = signal.args()?;
+                publish(
+                    out,
+                    sink,
+                    provider,
+                    &statuses,
+                    &Event::Preferences {
+                        preferences: &args.preferences,
+                    },
+                )?;
+            }
+            Signal::Data(Some(signal)) => {
+                let args = signal.args()?;
+                publish(out, sink, provider, &statuses, &Event::Data { data: &args.data })?;
+            }
+            // Any stream ending means this connection is done.
+            Signal::Owner(None)
+            | Signal::Changed(None)
+            | Signal::Removed(None)
+            | Signal::Order(None)
+            | Signal::Update(None)
+            | Signal::Preferences(None)
+            | Signal::Data(None) => return Ok(()),
+        }
+    }
+}
+
+/// Which stream produced something.
+enum Signal {
+    Owner(Option<Option<zbus::names::OwnedUniqueName>>),
+    Changed(Option<ProviderChanged>),
+    Removed(Option<ProviderRemoved>),
+    Order(Option<OrderChanged>),
+    Update(Option<UpdateChanged>),
+    Preferences(Option<PreferencesChanged>),
+    Data(Option<DataChanged>),
+}
+
+/// In event mode, one line per event; in Waybar mode, events are silent and only the card
+/// is printed, from `republish`.
+fn publish(
+    out: &mut impl Write,
+    sink: Sink,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+    event: &Event<'_>,
+) -> Result<(), std::io::Error> {
+    match sink {
+        Sink::Events => emit(out, event),
+        Sink::Waybar => match event {
+            Event::Snapshot { .. } | Event::Waiting => card(out, provider, statuses),
+            _ => Ok(()),
+        },
+    }
+}
+
+/// After a change has been applied to the mirror, a Waybar module wants the whole card
+/// again: its text is the worst window across every account, not the one that changed.
+fn republish(
+    out: &mut impl Write,
+    sink: Sink,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+) -> Result<(), std::io::Error> {
+    match sink {
+        Sink::Events => Ok(()),
+        Sink::Waybar => card(out, provider, statuses),
+    }
+}
+
+fn card(
+    out: &mut impl Write,
+    provider: Option<&str>,
+    statuses: &[ProviderStatus],
+) -> Result<(), std::io::Error> {
+    let selected = format::select(statuses, provider, None);
+    let rendered = format::waybar::render(&selected, Timestamp::now())
+        .map_err(std::io::Error::other)?;
+    writeln!(out, "{rendered}")?;
+    out.flush()
+}
+
+/// Written and flushed per line: stdout is block-buffered when it is a pipe, and a plugin
+/// reading a pipe must not wait for a buffer to fill.
+fn emit(out: &mut impl Write, event: &Event<'_>) -> Result<(), std::io::Error> {
+    writeln!(out, "{}", line(event).map_err(std::io::Error::other)?)?;
+    out.flush()
+}
+```
+
+The `Signal` variants name the generated signal-argument types (`ProviderChanged`,
+`ProviderRemoved`, …). Import them from `tidemark_ipc`: the `#[zbus::proxy]` macro
+generates one type per signal beside the proxy, named after the signal in CamelCase. They
+are public where the trait is, so `use tidemark_ipc::{DataChanged, OrderChanged,
+PreferencesChanged, ProviderChanged, ProviderRemoved, UpdateChanged};` is the import. If a
+name does not resolve, read the compiler's suggestion rather than guessing — the macro's
+naming is the contract here, not ours.
+
+`emit` returning `std::io::Error` and `run` returning `Failure` need
+`impl From<std::io::Error> for Failure` in `exit.rs`:
+
+```rust
+impl From<std::io::Error> for Failure {
+    fn from(error: std::io::Error) -> Self {
+        Self {
+            exit: Exit::Unavailable,
+            message: format!("cannot write the stream: {error}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Extend the grammar and wire the command**
+
+`cli.rs` gains:
+
+```rust
+    /// Print the daemon's changes as they arrive, one JSON object per line.
+    Watch(Watch),
+```
+
+```rust
+#[derive(Debug, clap::Args)]
+pub struct Watch {
+    /// Only this provider slug.
+    #[arg(long)]
+    pub provider: Option<String>,
+    /// `json` prints one event per line; `waybar` prints a card after every change.
+    #[arg(long, value_enum, default_value_t = StreamFormat::Json)]
+    pub format: StreamFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum StreamFormat {
+    Json,
+    Waybar,
+}
+```
+
+`main.rs` gains:
+
+```rust
+        cli::Command::Watch(args) => {
+            let sink = match args.format {
+                cli::StreamFormat::Json => watch::Sink::Events,
+                cli::StreamFormat::Waybar => watch::Sink::Waybar,
+            };
+            watch::run(sink, args.provider).await
+        }
+```
+
+- [ ] **Step 3: Write the fake daemon the integration tests share**
+
+`crates/tidemark-cli/tests/fake/mod.rs`:
+
+```rust
+//! A daemon that answers, and records what it was asked.
+//!
+//! The commands take a proxy, so a test drives the real command bodies against this
+//! instead of the machine's own daemon. There is deliberately no environment variable that
+//! redirects the bus name: testability comes from the parameter, not from a back door a
+//! user could trip over.
+
+use std::sync::{Arc, Mutex};
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::{
+    AccountId, ProviderDefinition, ProviderId, ProviderState, ProviderStatus, ids,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct Calls(Arc<Mutex<Vec<String>>>);
+
+impl Calls {
+    pub fn record(&self, call: impl Into<String>) {
+        self.0.lock().expect("not poisoned").push(call.into());
+    }
+
+    pub fn recorded(&self) -> Vec<String> {
+        self.0.lock().expect("not poisoned").clone()
+    }
+}
+
+pub struct FakeDaemon {
+    pub calls: Calls,
+    pub statuses: Vec<ProviderStatus>,
+}
+
+impl FakeDaemon {
+    pub fn with_one_account() -> Self {
+        let mut status = ProviderStatus::pending(
+            &ProviderId::new("claude".to_owned()),
+            &AccountId::default(),
+        );
+        status.state = ProviderState::Ok.as_wire().to_owned();
+        Self {
+            calls: Calls::default(),
+            statuses: vec![status],
+        }
+    }
+}
+
+#[zbus::interface(name = "io.github.zbndev.Tidemark.Daemon1")]
+impl FakeDaemon {
+    async fn get_status(&self) -> Vec<ProviderStatus> {
+        self.calls.record("GetStatus");
+        self.statuses.clone()
+    }
+
+    async fn list_providers(&self) -> Vec<ProviderDefinition> {
+        self.calls.record("ListProviders");
+        Vec::new()
+    }
+
+    async fn add_provider(&self, provider: &str) {
+        self.calls.record(format!("AddProvider({provider})"));
+    }
+
+    async fn remove_provider(&self, provider: &str, account: &str) {
+        self.calls
+            .record(format!("RemoveProvider({provider},{account})"));
+    }
+
+    async fn add_account(&self, provider: &str, account: &str) {
+        self.calls.record(format!("AddAccount({provider},{account})"));
+    }
+
+    async fn rename_account(&self, provider: &str, account: &str, new: &str) {
+        self.calls
+            .record(format!("RenameAccount({provider},{account},{new})"));
+    }
+
+    async fn set_order(&self, providers: Vec<String>) {
+        self.calls.record(format!("SetOrder({})", providers.join(",")));
+    }
+
+    async fn set_account_order(&self, provider: &str, accounts: Vec<String>) {
+        self.calls.record(format!(
+            "SetAccountOrder({provider},{})",
+            accounts.join(",")
+        ));
+    }
+
+    async fn refresh(&self, provider: &str) {
+        self.calls.record(format!("Refresh({provider})"));
+    }
+
+    async fn set_key(&self, provider: &str, account: &str, key: &str) {
+        // The key's *length* is recorded, never the key: a test that printed a secret
+        // would teach the next person that printing secrets is fine.
+        self.calls.record(format!(
+            "SetKey({provider},{account},{} chars)",
+            key.chars().count()
+        ));
+    }
+
+    async fn sign_out(&self, provider: &str, account: &str) {
+        self.calls.record(format!("SignOut({provider},{account})"));
+    }
+
+    async fn set_option(&self, provider: &str, account: &str, name: &str, value: &str) {
+        self.calls
+            .record(format!("SetOption({provider},{account},{name},{value})"));
+    }
+
+    async fn set_window_notify(&self, provider: &str, account: &str, window: &str, enabled: bool) {
+        self.calls.record(format!(
+            "SetWindowNotify({provider},{account},{window},{enabled})"
+        ));
+    }
+
+    async fn set_proxy(&self, mode: &str, host: &str, port: u16) {
+        self.calls.record(format!("SetProxy({mode},{host},{port})"));
+    }
+
+    #[zbus(signal)]
+    async fn provider_changed(
+        emitter: &zbus::object_server::SignalEmitter<'_>,
+        status: ProviderStatus,
+    ) -> zbus::Result<()>;
+
+    #[zbus(property(emits_changed_signal = "false"))]
+    async fn version(&self) -> String {
+        "0.0.0-test".to_owned()
+    }
+}
+
+/// Serves one fake daemon under a unique name and returns a proxy pointed at it.
+pub async fn serve(daemon: FakeDaemon) -> Option<(zbus::Connection, DaemonProxy<'static>, Calls)> {
+    let calls = daemon.calls.clone();
+    let client = zbus::Connection::session().await.ok()?;
+    let name = format!(
+        "io.github.zbndev.TidemarkCliTest{}x{}",
+        std::process::id(),
+        calls.recorded().len()
+    );
+    let server = zbus::connection::Builder::session()
+        .expect("session builder")
+        .name(name.as_str())
+        .expect("unique test name")
+        .serve_at(ids::OBJECT_PATH, daemon)
+        .expect("serves the object")
+        .build()
+        .await
+        .expect("test service starts");
+    let proxy = DaemonProxy::builder(&client)
+        .destination(name)
+        .expect("valid destination")
+        .build()
+        .await
+        .expect("proxy builds");
+    Some((server, proxy, calls))
+}
+```
+
+A unique bus name per test matters: `cargo test` runs tests in parallel threads on one
+session bus, and two services under the same name would make the second one fail.
+Include the test's own name in the string if collisions still happen.
+
+- [ ] **Step 4: Write the failing integration test**
+
+`crates/tidemark-cli/tests/watching_a_fake_daemon.rs`:
+
+```rust
+mod fake;
+
+use tidemark_types::{AccountId, ProviderId, ProviderState, ProviderStatus};
+
+#[test]
+fn the_stream_opens_with_a_snapshot_and_follows_every_change() {
+    async_io::block_on(async {
+        let Some((server, proxy, _calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let mut out = Vec::new();
+        // One connection's worth of streaming, ended by dropping the service below.
+        let pumping = async {
+            let _ = tidemark_cli::watch::pump(
+                &proxy,
+                tidemark_cli::watch::Sink::Events,
+                None,
+                &mut out,
+            )
+            .await;
+            out
+        };
+
+        let emitting = async {
+            let mut changed = ProviderStatus::pending(
+                &ProviderId::new("claude".to_owned()),
+                &AccountId::default(),
+            );
+            changed.state = ProviderState::RateLimited.as_wire().to_owned();
+            // Give the pump a moment to subscribe before the signal goes out.
+            async_io::Timer::after(std::time::Duration::from_millis(200)).await;
+            fake::emit_change(&server, changed).await;
+            async_io::Timer::after(std::time::Duration::from_millis(200)).await;
+            drop(server);
+        };
+
+        let (printed, ()) = futures_lite::future::zip(pumping, emitting).await;
+        let text = String::from_utf8(printed).expect("utf-8");
+        let mut lines = text.lines();
+        let snapshot: serde_json::Value =
+            serde_json::from_str(lines.next().expect("a snapshot line")).expect("json");
+        assert_eq!(snapshot["event"], "snapshot");
+        assert_eq!(snapshot["accounts"][0]["provider"], "claude");
+
+        let change: serde_json::Value =
+            serde_json::from_str(lines.next().expect("a change line")).expect("json");
+        assert_eq!(change["event"], "changed");
+        assert_eq!(change["account"]["state"], "rate-limited");
+    });
+}
+```
+
+This needs three things the crate does not have yet:
+
+1. A library target, so an integration test can call `watch::pump`. Add to
+   `crates/tidemark-cli/Cargo.toml`:
+
+   ```toml
+   [lib]
+   name = "tidemark_cli"
+   path = "src/lib.rs"
+   ```
+
+   Create `src/lib.rs` holding the module declarations and doc comment currently at the top
+   of `main.rs` (`pub mod cli; pub mod connect; pub mod exit; pub mod format; pub mod guard;
+   pub mod watch;`), and reduce `main.rs` to `use tidemark_cli::…;` plus `fn main` and `run`.
+2. `fake::emit_change(&server, status)`, which emits the signal from the served object:
+
+   ```rust
+   pub async fn emit_change(server: &zbus::Connection, status: ProviderStatus) {
+       let emitter = zbus::object_server::SignalEmitter::new(server, ids::OBJECT_PATH)
+           .expect("valid emitter");
+       FakeDaemon::provider_changed(&emitter, status)
+           .await
+           .expect("signal goes out");
+   }
+   ```
+3. `cargo add -p tidemark-cli --dev futures-lite` for `zip`.
+
+- [ ] **Step 5: Run it**
+
+Run: `cargo test -p tidemark-cli --test watching_a_fake_daemon`
+Expected: PASS, or the skip line with no session bus.
+
+- [ ] **Step 6: Smoke it against the live daemon**
+
+In one terminal: `cargo run -p tidemark-cli -- watch`
+In another: `cargo run -p tidemark-cli -- refresh claude`
+Expected: a `snapshot` line at once, then a `changed` line per poll. Then
+`systemctl --user restart tidemarkd` and expect a `waiting` line followed by a fresh
+`snapshot`.
+
+Also: `cargo run -p tidemark-cli -- watch --format waybar | head -3`
+Expected: one card per change, each a complete JSON object on its own line. `head` closing
+the pipe must not hang the process.
+
+- [ ] **Step 7: Full gate and commit**
+
+```bash
+cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh
+git add crates/tidemark-cli Cargo.lock
+git commit -m "feat(cli): watch the daemon as a stream"
+```
+
+---
+
+## Phase D — everything the window can do
+
+### Task 9: providers, accounts and `refresh`
+
+**Files:**
+- Create: `crates/tidemark-cli/src/commands/mod.rs`
+- Create: `crates/tidemark-cli/src/commands/provider.rs`
+- Create: `crates/tidemark-cli/src/commands/account.rs`
+- Create: `crates/tidemark-cli/tests/managing_a_fake_daemon.rs`
+- Modify: `crates/tidemark-cli/src/lib.rs`, `src/cli.rs`, `src/main.rs`
+
+**Interfaces:**
+- Produces: `commands::provider::run(&DaemonProxy<'_>, cli::ProviderCommand) -> Result<Exit, Failure>` and `commands::account::run(&DaemonProxy<'_>, cli::AccountCommand) -> Result<Exit, Failure>`.
+
+- [ ] **Step 1: Extend the grammar**
+
+In `cli.rs`, add to `Command`:
+
+```rust
+    /// The provider catalog, the configured set, and what is in it.
+    Provider {
+        #[command(subcommand)]
+        command: ProviderCommand,
+    },
+    /// The accounts one provider carries.
+    Account {
+        #[command(subcommand)]
+        command: AccountCommand,
+    },
+    /// Poll now: one provider, or everything.
+    Refresh {
+        /// A provider slug. Omitted, every configured account is polled.
+        provider: Option<String>,
+    },
+```
+
+and the two subcommand enums:
+
+```rust
+#[derive(Debug, Subcommand)]
+pub enum ProviderCommand {
+    /// Every provider this build knows how to configure.
+    Catalog,
+    /// Every configured account, with its state.
+    List,
+    /// Configure a provider, creating its default account.
+    Add { provider: String },
+    /// Remove one configured account, its credentials and its card.
+    Rm { provider: String, account: String },
+    /// Rewrite the order the cards go in. Must name every configured provider.
+    Order { providers: Vec<String> },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AccountCommand {
+    /// Add one more account to a provider the config already has.
+    Add { provider: String, account: String },
+    /// Remove one account. The same call as `provider rm`.
+    Rm { provider: String, account: String },
+    /// Rename an account, carrying its credential and history to the new id.
+    Rename {
+        provider: String,
+        account: String,
+        new: String,
+    },
+    /// Rewrite one provider's account order.
+    Order {
+        provider: String,
+        accounts: Vec<String>,
+    },
+}
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+`crates/tidemark-cli/tests/managing_a_fake_daemon.rs`:
+
+```rust
+mod fake;
+
+use tidemark_cli::cli::{AccountCommand, ProviderCommand};
+use tidemark_cli::commands;
+
+#[test]
+fn adding_and_ordering_reach_the_daemon_with_the_arguments_given() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        commands::provider::run(
+            &proxy,
+            ProviderCommand::Add {
+                provider: "codex".to_owned(),
+            },
+        )
+        .await
+        .expect("add succeeds");
+
+        commands::provider::run(
+            &proxy,
+            ProviderCommand::Order {
+                providers: vec!["codex".to_owned(), "claude".to_owned()],
+            },
+        )
+        .await
+        .expect("order succeeds");
+
+        commands::account::run(
+            &proxy,
+            AccountCommand::Rename {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+                new: "work".to_owned(),
+            },
+        )
+        .await
+        .expect("rename succeeds");
+
+        assert_eq!(
+            calls.recorded(),
+            vec![
+                "AddProvider(codex)".to_owned(),
+                "SetOrder(codex,claude)".to_owned(),
+                "RenameAccount(claude,default,work)".to_owned(),
+            ]
+        );
+        drop(server);
+    });
+}
+
+#[test]
+fn an_order_with_no_providers_is_refused_before_the_daemon_hears_it() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let failure = commands::provider::run(
+            &proxy,
+            ProviderCommand::Order {
+                providers: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("an empty order is not a permutation");
+
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+        drop(server);
+    });
+}
+```
+
+- [ ] **Step 3: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli --test managing_a_fake_daemon`
+Expected: FAIL — `commands` does not exist.
+
+- [ ] **Step 4: Write the commands**
+
+`crates/tidemark-cli/src/commands/mod.rs`:
+
+```rust
+//! One module per entity the daemon owns. Every function takes the proxy rather than
+//! building one, which is what makes them testable against a fake daemon.
+
+pub mod account;
+pub mod provider;
+```
+
+`crates/tidemark-cli/src/commands/provider.rs`:
+
+```rust
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::provider_label;
+
+use crate::cli::ProviderCommand;
+use crate::exit::{Exit, Failure};
+
+pub async fn run(
+    proxy: &DaemonProxy<'_>,
+    command: ProviderCommand,
+) -> Result<Exit, Failure> {
+    match command {
+        ProviderCommand::Catalog => {
+            for definition in proxy.list_providers().await? {
+                println!(
+                    "{:<20} {:<24} {}",
+                    definition.provider, definition.title, definition.credential
+                );
+            }
+        }
+        ProviderCommand::List => {
+            for status in proxy.get_status().await? {
+                println!(
+                    "{:<20} {:<12} {:<20} {}",
+                    status.provider,
+                    status.account,
+                    provider_label(&status.provider),
+                    status.state
+                );
+            }
+        }
+        ProviderCommand::Add { provider } => proxy.add_provider(&provider).await?,
+        ProviderCommand::Rm { provider, account } => {
+            proxy.remove_provider(&provider, &account).await?
+        }
+        // The daemon takes an order as a permutation of the configured set and refuses a
+        // partial one; refusing an empty list here keeps a mistyped shell glob from
+        // becoming a D-Bus error the user has to interpret.
+        ProviderCommand::Order { providers } => {
+            if providers.is_empty() {
+                return Err(Failure::usage(
+                    "provider order needs the whole configured set, in the order you want",
+                ));
+            }
+            proxy.set_order(&providers).await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+```
+
+`crates/tidemark-cli/src/commands/account.rs`:
+
+```rust
+use tidemark_ipc::DaemonProxy;
+
+use crate::cli::AccountCommand;
+use crate::exit::{Exit, Failure};
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: AccountCommand) -> Result<Exit, Failure> {
+    match command {
+        AccountCommand::Add { provider, account } => {
+            proxy.add_account(&provider, &account).await?
+        }
+        AccountCommand::Rm { provider, account } => {
+            proxy.remove_provider(&provider, &account).await?
+        }
+        AccountCommand::Rename {
+            provider,
+            account,
+            new,
+        } => proxy.rename_account(&provider, &account, &new).await?,
+        AccountCommand::Order { provider, accounts } => {
+            if accounts.is_empty() {
+                return Err(Failure::usage(
+                    "account order needs every account of that provider, in the order you want",
+                ));
+            }
+            proxy.set_account_order(&provider, accounts).await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+```
+
+`main.rs` gains the three arms:
+
+```rust
+        cli::Command::Provider { command } => {
+            let proxy = connect::daemon().await?;
+            commands::provider::run(&proxy, command).await
+        }
+        cli::Command::Account { command } => {
+            let proxy = connect::daemon().await?;
+            commands::account::run(&proxy, command).await
+        }
+        cli::Command::Refresh { provider } => {
+            let proxy = connect::daemon().await?;
+            proxy.refresh(provider.as_deref().unwrap_or("")).await?;
+            Ok(Exit::Ok)
+        }
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 6: Smoke it**
+
+```bash
+cargo run -p tidemark-cli -- provider catalog | head -5
+cargo run -p tidemark-cli -- provider list
+cargo run -p tidemark-cli -- refresh
+```
+Expected: the catalog, the configured set, and a poll that shows up in `watch`.
+
+Then verify a real mutation round trip on a provider you do not mind touching:
+
+```bash
+cargo run -p tidemark-cli -- provider add wayfinder
+cargo run -p tidemark-cli -- provider list | grep wayfinder
+cargo run -p tidemark-cli -- provider rm wayfinder default
+```
+Expected: the card appears in the running window and then goes away. Wayfinder needs no
+credential, which is why it is the safe one to test with.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/tidemark-cli Cargo.lock
+git commit -m "feat(cli): manage providers and accounts"
+```
+
+### Task 10: credentials
+
+**Files:**
+- Create: `crates/tidemark-cli/src/secret.rs`
+- Create: `crates/tidemark-cli/src/commands/auth.rs`
+- Create: `crates/tidemark-cli/tests/storing_a_secret.rs`
+- Modify: `crates/tidemark-cli/src/lib.rs`, `src/cli.rs`, `src/main.rs`, `src/commands/mod.rs`
+
+**Interfaces:**
+- Produces: `secret::Source { Stdin, File(PathBuf) }` and `secret::read(Source) -> Result<String, Failure>`.
+- Produces: `commands::auth::run(&DaemonProxy<'_>, cli::AuthCommand) -> Result<Exit, Failure>`.
+
+- [ ] **Step 1: Write the failing secret-input tests**
+
+`crates/tidemark-cli/src/secret.rs`:
+
+```rust
+//! Where a secret is allowed to come from.
+//!
+//! stdin or a file, never an argv value: `/proc/<pid>/cmdline` is readable by every process
+//! of the same user, and a key typed once ends up in shell history. stdin is a file
+//! descriptor rather than a terminal, so a plugin with its own UI writes into a pipe and
+//! never opens a console.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use crate::exit::Failure;
+
+/// One trailing newline is trimmed — `printf` users and `echo` users should get the same
+/// key — and nothing else is touched: a key with meaningful interior characters is the
+/// provider's business, not ours.
+pub fn read(source: Source) -> Result<String, Failure> {
+    let raw = match source {
+        Source::Stdin => {
+            let mut buffer = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buffer)
+                .map_err(|error| Failure::usage(format!("cannot read stdin: {error}")))?;
+            buffer
+        }
+        Source::File(path) => std::fs::read_to_string(&path).map_err(|error| {
+            Failure::usage(format!("cannot read {}: {error}", path.display()))
+        })?,
+    };
+    let trimmed = raw
+        .strip_suffix('\n')
+        .map(|value| value.strip_suffix('\r').unwrap_or(value))
+        .unwrap_or(&raw);
+    if trimmed.is_empty() {
+        return Err(Failure::usage(
+            "no value on stdin: pipe the key in, or pass --key-file",
+        ));
+    }
+    Ok(trimmed.to_owned())
+}
+
+#[derive(Debug)]
+pub enum Source {
+    Stdin,
+    File(PathBuf),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "tidemarkctl-secret-{}-{}",
+            std::process::id(),
+            contents.len()
+        ));
+        std::fs::write(&path, contents).expect("writes");
+        path
+    }
+
+    #[test]
+    fn one_trailing_newline_is_trimmed() {
+        let path = file("sk-abc\n");
+        assert_eq!(read(Source::File(path.clone())).expect("reads"), "sk-abc");
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn a_second_trailing_newline_belongs_to_the_value() {
+        let path = file("sk-abcd\n\n");
+        assert_eq!(read(Source::File(path.clone())).expect("reads"), "sk-abcd\n");
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn nothing_at_all_is_a_usage_error_not_a_cleared_key() {
+        let path = file("\n");
+        let failure = read(Source::File(path.clone())).expect_err("refuses");
+        assert_eq!(failure.exit, crate::exit::Exit::Usage);
+        std::fs::remove_file(path).ok();
+    }
+}
+```
+
+An empty value is refused locally because `SetKey("")` is a request to store nothing, and
+the daemon already refuses it — failing here gives the user the sentence that says what to
+do instead of a D-Bus error.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli secret`
+Expected: FAIL — the module is not declared yet. Add `pub mod secret;` to `lib.rs`, then
+the tests compile and pass.
+
+- [ ] **Step 3: Extend the grammar**
+
+`cli.rs` gains:
+
+```rust
+    /// Credentials: keys, pasted sessions, logins and local sources.
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
+```
+
+```rust
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Store an API key. The key is read from stdin, or from --key-file.
+    SetKey {
+        provider: String,
+        account: String,
+        /// Read the key from this file instead of stdin.
+        #[arg(long)]
+        key_file: Option<std::path::PathBuf>,
+    },
+    /// Store a browser session header. Read like a key.
+    SetSession {
+        provider: String,
+        account: String,
+        #[arg(long)]
+        key_file: Option<std::path::PathBuf>,
+    },
+    /// Remove whatever credential Tidemark holds for an account.
+    SignOut { provider: String, account: String },
+    /// Print the authorize URL, then wait for the browser to come back.
+    Login { provider: String, account: String },
+    /// Abandon a login that is waiting.
+    CancelLogin { provider: String, account: String },
+    /// The local authentication sources the daemon can see, without their credentials.
+    Sources { provider: String, account: String },
+    /// Record which local source this account uses.
+    Select {
+        provider: String,
+        account: String,
+        /// The mode value from `auth sources`.
+        #[arg(long)]
+        mode: String,
+        /// The candidate id, for a mode that offers a choice.
+        #[arg(long)]
+        candidate: Option<String>,
+    },
+}
+```
+
+- [ ] **Step 4: Write the commands**
+
+`crates/tidemark-cli/src/commands/auth.rs`:
+
+```rust
+use std::io::Write;
+
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::{AuthCandidate, AuthSelection};
+
+use crate::cli::AuthCommand;
+use crate::exit::{Exit, Failure};
+use crate::secret;
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: AuthCommand) -> Result<Exit, Failure> {
+    match command {
+        AuthCommand::SetKey {
+            provider,
+            account,
+            key_file,
+        } => {
+            let key = secret::read(source(key_file))?;
+            proxy.set_key(&provider, &account, &key).await?;
+        }
+        AuthCommand::SetSession {
+            provider,
+            account,
+            key_file,
+        } => {
+            let session = secret::read(source(key_file))?;
+            proxy.set_session(&provider, &account, &session).await?;
+        }
+        AuthCommand::SignOut { provider, account } => {
+            proxy.sign_out(&provider, &account).await?
+        }
+        // The URL first and flushed, because the caller — a person or a plugin — cannot act
+        // on it until it is on the pipe, and `AwaitLogin` then blocks for as long as the
+        // browser takes. The daemon never opens a browser and neither does this: it may be
+        // running on a machine with no display.
+        AuthCommand::Login { provider, account } => {
+            let url = proxy.begin_login(&provider, &account).await?;
+            println!("{url}");
+            std::io::stdout().flush()?;
+            proxy.await_login(&provider, &account).await?;
+        }
+        AuthCommand::CancelLogin { provider, account } => {
+            proxy.cancel_login(&provider, &account).await?
+        }
+        AuthCommand::Sources { provider, account } => {
+            for candidate in proxy.get_auth_sources(&provider, &account).await? {
+                print_candidate(&candidate, 0);
+            }
+        }
+        AuthCommand::Select {
+            provider,
+            account,
+            mode,
+            candidate,
+        } => {
+            proxy
+                .select_auth_source(&provider, &account, AuthSelection { mode, candidate })
+                .await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+
+fn source(key_file: Option<std::path::PathBuf>) -> secret::Source {
+    match key_file {
+        Some(path) => secret::Source::File(path),
+        None => secret::Source::Stdin,
+    }
+}
+
+/// Titles and readiness, never a cookie value, a token or a database path — the daemon does
+/// not publish those, and this prints exactly what it publishes.
+fn print_candidate(candidate: &AuthCandidate, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let subtitle = candidate.subtitle.as_deref().unwrap_or("");
+    println!(
+        "{indent}{:<28} {:<20} {}",
+        candidate.id, candidate.state, subtitle
+    );
+    for child in &candidate.children {
+        print_candidate(child, depth + 1);
+    }
+}
+```
+
+`main.rs` gains:
+
+```rust
+        cli::Command::Auth { command } => {
+            let proxy = connect::daemon().await?;
+            commands::auth::run(&proxy, command).await
+        }
+```
+
+`commands/mod.rs` gains `pub mod auth;`.
+
+- [ ] **Step 5: Write the failing integration test**
+
+`crates/tidemark-cli/tests/storing_a_secret.rs`:
+
+```rust
+mod fake;
+
+use tidemark_cli::cli::AuthCommand;
+use tidemark_cli::commands;
+
+#[test]
+fn a_key_from_a_file_reaches_the_daemon_and_is_never_printed() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let path = std::env::temp_dir().join(format!("tidemarkctl-key-{}", std::process::id()));
+        std::fs::write(&path, "sk-secret-value\n").expect("writes the key file");
+
+        commands::auth::run(
+            &proxy,
+            AuthCommand::SetKey {
+                provider: "claude".to_owned(),
+                account: "default".to_owned(),
+                key_file: Some(path.clone()),
+            },
+        )
+        .await
+        .expect("stores the key");
+
+        let recorded = calls.recorded();
+        assert_eq!(recorded, vec!["SetKey(claude,default,15 chars)".to_owned()]);
+        assert!(
+            !recorded.iter().any(|call| call.contains("sk-secret")),
+            "a secret must never reach a log or a test name: {recorded:?}"
+        );
+
+        std::fs::remove_file(path).ok();
+        drop(server);
+    });
+}
+```
+
+`set_key` on the fake needs to be in `fake/mod.rs` from Task 8 — it is. Extend the fake
+with `set_session`, `begin_login`, `await_login`, `cancel_login`, `get_auth_sources` and
+`select_auth_source` only if a test drives them; do not add unused methods.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 7: Smoke it**
+
+```bash
+printf '%s' 'sk-not-a-real-key' | cargo run -p tidemark-cli -- auth set-key zai default
+cargo run -p tidemark-cli -- usage --provider zai
+cargo run -p tidemark-cli -- auth sign-out zai default
+```
+Expected: the card moves to `credential-rejected` (a wrong key is a real answer), then back
+to `no-credential`. Do this on a provider you are not signed into, or restore your key
+afterwards.
+
+Confirm the prohibition holds: `cargo run -p tidemark-cli -- auth set-key zai default sk-x`
+Expected: clap rejects the extra argument — there is no positional slot for a key.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/tidemark-cli
+git commit -m "feat(cli): store credentials without putting them on a command line"
+```
+
+### Task 11: options, notifications, preferences, history
+
+**Files:**
+- Create: `crates/tidemark-cli/src/commands/config.rs`
+- Modify: `crates/tidemark-cli/src/cli.rs`, `src/main.rs`, `src/commands/mod.rs`
+- Modify: `crates/tidemark-cli/tests/managing_a_fake_daemon.rs`
+
+**Interfaces:**
+- Produces: `commands::config::run(&DaemonProxy<'_>, cli::ConfigCommand) -> Result<Exit, Failure>`.
+
+- [ ] **Step 1: Extend the grammar**
+
+`cli.rs` gains four commands:
+
+```rust
+    /// One of a provider's own settings.
+    Option {
+        provider: String,
+        account: String,
+        name: String,
+        value: String,
+    },
+    /// Notifications for one window of one account.
+    Notify {
+        provider: String,
+        account: String,
+        window: String,
+        #[arg(value_parser = switch)]
+        enabled: bool,
+    },
+    /// Application preferences the daemon keeps in config.toml.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+    /// Stored history.
+    History {
+        #[command(subcommand)]
+        command: HistoryCommand,
+    },
+    /// Paths and storage facts.
+    Data,
+    /// A newer published release, if the daemon knows of one.
+    Update,
+```
+
+```rust
+/// `on` and `off` rather than `true` and `false`: the settings pages call these switches.
+fn switch(value: &str) -> Result<bool, String> {
+    match value {
+        "on" => Ok(true),
+        "off" => Ok(false),
+        other => Err(format!("expected `on` or `off`, not `{other}`")),
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigCommand {
+    /// Every preference, as the daemon holds it.
+    Show,
+    /// The one proxy every request and every child process goes through.
+    Proxy {
+        /// off, http, https or socks5.
+        mode: String,
+        /// Required by every mode but `off`.
+        host: Option<String>,
+        /// Required by every mode but `off`.
+        port: Option<u16>,
+    },
+    /// How healthy accounts are paced.
+    Refresh {
+        /// auto or manual.
+        mode: String,
+        /// Minutes between polls in manual mode, 1 to 120.
+        #[arg(long)]
+        minutes: Option<u32>,
+    },
+    /// forever, six-months or one-year.
+    Retention { retention: String },
+    /// system, light or dark.
+    Theme { theme: String },
+    /// app, daemon or off.
+    Startup { mode: String },
+    /// Whether the daemon may ask GitHub for the latest release.
+    ReleaseCheck {
+        #[arg(value_parser = switch)]
+        enabled: bool,
+    },
+    /// Whether the window's close button hides it.
+    MinimizeOnClose {
+        #[arg(value_parser = switch)]
+        enabled: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HistoryCommand {
+    /// The stored points of one window's current segment, oldest first.
+    Segment {
+        provider: String,
+        account: String,
+        window: String,
+    },
+    /// Delete every stored point, segment and notification record.
+    Clear,
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `crates/tidemark-cli/tests/managing_a_fake_daemon.rs`:
+
+```rust
+#[test]
+fn a_proxy_is_sent_as_one_setting_and_a_half_of_one_is_refused() {
+    async_io::block_on(async {
+        let Some((server, proxy, calls)) = fake::serve(fake::FakeDaemon::with_one_account()).await
+        else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+
+        let failure = commands::config::run(
+            &proxy,
+            tidemark_cli::cli::ConfigCommand::Proxy {
+                mode: "socks5".to_owned(),
+                host: Some("127.0.0.1".to_owned()),
+                port: None,
+            },
+        )
+        .await
+        .expect_err("half a proxy is not a proxy");
+        assert_eq!(failure.exit, tidemark_cli::exit::Exit::Usage);
+        assert!(calls.recorded().is_empty(), "{:?}", calls.recorded());
+
+        commands::config::run(
+            &proxy,
+            tidemark_cli::cli::ConfigCommand::Proxy {
+                mode: "socks5".to_owned(),
+                host: Some("127.0.0.1".to_owned()),
+                port: Some(1080),
+            },
+        )
+        .await
+        .expect("a whole proxy is accepted");
+        assert_eq!(
+            calls.recorded(),
+            vec!["SetProxy(socks5,127.0.0.1,1080)".to_owned()]
+        );
+
+        commands::config::run(
+            &proxy,
+            tidemark_cli::cli::ConfigCommand::Proxy {
+                mode: "off".to_owned(),
+                host: None,
+                port: None,
+            },
+        )
+        .await
+        .expect("off needs neither");
+
+        drop(server);
+    });
+}
+```
+
+- [ ] **Step 3: Run and watch it fail**
+
+Run: `cargo test -p tidemark-cli --test managing_a_fake_daemon`
+Expected: FAIL — `commands::config` does not exist.
+
+- [ ] **Step 4: Write the command**
+
+`crates/tidemark-cli/src/commands/config.rs`:
+
+```rust
+use tidemark_ipc::DaemonProxy;
+use tidemark_types::Preferences;
+
+use crate::cli::ConfigCommand;
+use crate::exit::{Exit, Failure};
+
+pub async fn run(proxy: &DaemonProxy<'_>, command: ConfigCommand) -> Result<Exit, Failure> {
+    match command {
+        ConfigCommand::Show => show(&proxy.get_preferences().await?),
+        // The daemon takes the three proxy values as one call because half a proxy is a
+        // proxy nothing can be reached through. Completing them here means the user gets a
+        // sentence instead of a refusal.
+        ConfigCommand::Proxy { mode, host, port } => {
+            if mode == Preferences::PROXY_OFF {
+                proxy.set_proxy(&mode, "", 0).await?;
+            } else {
+                let (Some(host), Some(port)) = (host, port) else {
+                    return Err(Failure::usage(format!(
+                        "the `{mode}` proxy mode needs a host and a port"
+                    )));
+                };
+                proxy.set_proxy(&mode, &host, port).await?;
+            }
+        }
+        ConfigCommand::Refresh { mode, minutes } => {
+            if let Some(minutes) = minutes {
+                proxy.set_refresh_minutes(minutes).await?;
+            }
+            proxy.set_refresh_mode(&mode).await?;
+        }
+        ConfigCommand::Retention { retention } => {
+            proxy.set_history_retention(&retention).await?
+        }
+        ConfigCommand::Theme { theme } => proxy.set_theme(&theme).await?,
+        ConfigCommand::Startup { mode } => proxy.set_startup_mode(&mode).await?,
+        ConfigCommand::ReleaseCheck { enabled } => proxy.set_release_check(enabled).await?,
+        ConfigCommand::MinimizeOnClose { enabled } => {
+            proxy.set_minimize_on_close(enabled).await?
+        }
+    }
+    Ok(Exit::Ok)
+}
+
+/// Named choices are printed as the daemon stores them, so what comes out of `show` is
+/// what goes back into the corresponding subcommand.
+fn show(preferences: &Preferences) {
+    println!("release-check       {}", preferences.release_check);
+    println!("minimize-on-close   {}", preferences.minimize_on_close);
+    println!(
+        "theme               {}",
+        preferences.theme.as_deref().unwrap_or(Preferences::THEME_SYSTEM)
+    );
+    println!("startup             {}", preferences.startup_mode);
+    println!("retention           {}", preferences.history_retention);
+    println!("refresh             {}", preferences.refresh_mode);
+    println!("refresh-minutes     {}", preferences.refresh_minutes);
+    println!("proxy               {}", preferences.proxy_mode);
+    println!("proxy-host          {}", preferences.proxy_host);
+    println!("proxy-port          {}", preferences.proxy_port);
+}
+```
+
+Note the ordering in `Refresh`: the interval is sent before the mode, so switching to
+`manual` with a new interval polls at the interval the user asked for rather than at the
+old one. `set_refresh_mode` polls every account immediately — see `CONTEXT.md` § Polling.
+
+- [ ] **Step 5: Wire the remaining arms in `main.rs`**
+
+```rust
+        cli::Command::Option {
+            provider,
+            account,
+            name,
+            value,
+        } => {
+            let proxy = connect::daemon().await?;
+            proxy.set_option(&provider, &account, &name, &value).await?;
+            Ok(Exit::Ok)
+        }
+        cli::Command::Notify {
+            provider,
+            account,
+            window,
+            enabled,
+        } => {
+            let proxy = connect::daemon().await?;
+            proxy
+                .set_window_notify(&provider, &account, &window, enabled)
+                .await?;
+            Ok(Exit::Ok)
+        }
+        cli::Command::Config { command } => {
+            let proxy = connect::daemon().await?;
+            commands::config::run(&proxy, command).await
+        }
+        cli::Command::History { command } => {
+            let proxy = connect::daemon().await?;
+            match command {
+                cli::HistoryCommand::Segment {
+                    provider,
+                    account,
+                    window,
+                } => {
+                    for point in proxy.current_segment(&provider, &account, &window).await? {
+                        println!(
+                            "{} {}",
+                            point.captured_at,
+                            tidemark_types::present::percent(point.used_percent)
+                        );
+                    }
+                }
+                cli::HistoryCommand::Clear => proxy.clear_history().await?,
+            }
+            Ok(Exit::Ok)
+        }
+        cli::Command::Data => {
+            let proxy = connect::daemon().await?;
+            let data = proxy.get_data_info().await?;
+            println!("config              {}", data.config_path);
+            println!("history             {}", data.history_path);
+            println!("history-bytes       {}", data.history_bytes);
+            println!("key-schema          {}", data.key_schema);
+            println!("token-schema        {}", data.token_schema);
+            println!("release-check       {}", data.release_check_available);
+            Ok(Exit::Ok)
+        }
+        cli::Command::Update => {
+            let proxy = connect::daemon().await?;
+            let version = proxy.get_update().await?;
+            if version.is_empty() {
+                println!("no newer release is known");
+            } else {
+                println!("{version}");
+            }
+            Ok(Exit::Ok)
+        }
+```
+
+`commands/mod.rs` gains `pub mod config;`.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p tidemark-cli`
+Expected: PASS.
+
+- [ ] **Step 7: Smoke it**
+
+```bash
+cargo run -p tidemark-cli -- config show
+cargo run -p tidemark-cli -- data
+cargo run -p tidemark-cli -- update
+cargo run -p tidemark-cli -- config refresh manual --minutes 15
+cargo run -p tidemark-cli -- config show | grep refresh
+cargo run -p tidemark-cli -- config refresh auto
+cargo run -p tidemark-cli -- history segment claude default w18000 | tail -3
+```
+Expected: `config show` reflects each change, the running Preferences dialog updates live
+(it listens to `PreferencesChanged`), and the segment prints timestamps with percentages.
+Put `refresh` back to whatever it was before.
+
+- [ ] **Step 8: Full gate and commit**
+
+```bash
+cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh
+git add crates/tidemark-cli
+git commit -m "feat(cli): options, notifications, preferences and history"
+```
+
+---
+
+## Phase E — shipping it
+
+### Task 12: completions and packaging
+
+**Files:**
+- Modify: `crates/tidemark-cli/Cargo.toml`, `src/cli.rs`, `src/main.rs`
+- Modify: `crates/tidemark/Cargo.toml` (deb and rpm asset lists)
+- Modify: `PKGBUILD`
+- Modify: `nix/package.nix`
+
+**Interfaces:**
+- Produces: `tidemarkctl completions <bash|zsh|fish>` on stdout.
+
+- [ ] **Step 1: Add the completion generator**
+
+`cargo add -p tidemark-cli clap_complete`
+
+`cli.rs` gains:
+
+```rust
+    /// Print a shell completion script on stdout.
+    Completions {
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+```
+
+`main.rs` gains an arm that needs no daemon at all:
+
+```rust
+        cli::Command::Completions { shell } => {
+            let mut command = <cli::Cli as clap::CommandFactory>::command();
+            clap_complete::generate(shell, &mut command, "tidemarkctl", &mut std::io::stdout());
+            Ok(Exit::Ok)
+        }
+```
+
+- [ ] **Step 2: Verify each shell**
+
+```bash
+cargo run -p tidemark-cli -- completions bash | head -5
+cargo run -p tidemark-cli -- completions zsh | head -5
+cargo run -p tidemark-cli -- completions fish | head -5
+```
+Expected: a script per shell, each mentioning `tidemarkctl`.
+
+Load one for real: `source <(cargo run -q -p tidemark-cli -- completions bash)` then type
+`tidemarkctl prov<TAB>`.
+Expected: it completes to `provider`.
+
+- [ ] **Step 3: Add the binary to the Debian package**
+
+In `crates/tidemark/Cargo.toml`, in `[package.metadata.deb] assets`, after the `tidemarkd`
+line:
+
+```toml
+    ["target/release/tidemarkctl", "usr/bin/", "755"],
+```
+
+- [ ] **Step 4: Add it to the RPM**
+
+In the same file, in `[package.metadata.generate-rpm] assets`:
+
+```toml
+    { source = "target/release/tidemarkctl", dest = "/usr/bin/tidemarkctl", mode = "755" },
+```
+
+- [ ] **Step 5: Add it to the Arch package**
+
+In `PKGBUILD`, after the `tidemarkd` install line:
+
+```bash
+    install -Dm755 "$bin/tidemarkctl" "$pkgdir/usr/bin/tidemarkctl"
+```
+
+- [ ] **Step 6: Add it to the Nix package**
+
+In `nix/package.nix`, in `postInstall`, after the `tidemarkd` line:
+
+```nix
+    install -Dm755 target/*/release/tidemarkctl -t "$out/bin"
+```
+
+`cargoBuildFlags` is already `--workspace --bins`, so the binary is built; nothing else in
+the derivation changes. Do **not** wrap it with `wrapGAppsHook4`: it loads no GTK.
+
+- [ ] **Step 7: Prove the packages carry it**
+
+```bash
+cargo build --release --locked --workspace
+cargo deb --no-build -p tidemark
+dpkg --contents target/debian/*.deb | grep tidemarkctl
+```
+Expected: `usr/bin/tidemarkctl` in the listing.
+
+Then the dependency scan that guards these lists:
+Run: `./scripts/check-package-deps.sh`
+Expected: PASS. A third binary must not add a shared-library dependency the metadata does
+not declare; `tidemarkctl` links no GTK, so the set should be unchanged.
+
+- [ ] **Step 8: Confirm the Windows build still builds**
+
+Run: `cargo check --workspace --target x86_64-pc-windows-gnu` if the target is installed;
+otherwise rely on CI and say so in the commit body.
+Expected: `tidemark-cli` compiles. It is not added to any Windows packaging list — check
+`data/packaging` and the NSIS inputs and leave them alone.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/tidemark-cli crates/tidemark/Cargo.toml PKGBUILD nix/package.nix Cargo.lock
+git commit -m "feat(cli): completions, and ship tidemarkctl in every Linux package"
+```
+
+### Task 13: the documentation the contract needs
+
+**Files:**
+- Create: `crates/tidemark-cli/AGENTS.md`
+- Modify: `README.md`
+- Modify: `CONTEXT.md`
+- Modify: `AGENTS.md`
+- Modify: `crates/tidemark-ipc/AGENTS.md` (created in Task 1)
+
+- [ ] **Step 1: Write the README section**
+
+In `README.md`, after the "Getting started" section, add:
+
+````markdown
+## From the command line
+
+`tidemarkctl` talks to the same daemon the window does, so anything the interface can do is
+scriptable — and a panel widget needs no D-Bus code of its own.
+
+```bash
+tidemarkctl usage                      # every account, for a person
+tidemarkctl usage --format json        # {"accounts": [...]}, for a program
+tidemarkctl guard --min-remaining 20 --window w604800 || echo "not this week"
+tidemarkctl watch                      # one JSON object per change, until you stop it
+```
+
+`guard` exits `0` when the quota is there, `1` when it is not, and `69` when there is no
+trustworthy reading to judge — a rejected credential never answers "safe".
+
+Secrets are read from stdin, never from the command line:
+
+```bash
+printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai default
+```
+
+A Waybar module is two files. In `~/.config/waybar/config.jsonc`:
+
+```jsonc
+"custom/tidemark": {
+    "exec": "tidemarkctl watch --format waybar",
+    "return-type": "json",
+    "on-click": "tidemark"
+}
+```
+
+and in your stylesheet, the classes it sets — `ok`, `warning`, `danger` at the same 70% and
+90% the app's own bar changes colour at, plus `stale` when the reading is not fresh:
+
+```css
+#custom-tidemark.warning { color: @warning_color; }
+#custom-tidemark.danger  { color: @error_color; }
+#custom-tidemark.stale   { opacity: 0.5; }
+```
+
+`tidemarkctl completions zsh > ~/.zfunc/_tidemarkctl` installs completions;
+`tidemarkctl --help` lists the rest — `provider`, `account`, `auth`, `notify`, `config`,
+`history`.
+````
+
+- [ ] **Step 2: Update the architecture record**
+
+In `CONTEXT.md` § Architecture, the crate-layout paragraph currently opens with "Four
+crates, not three." Replace that sentence and add the two rows to its table. The new
+opening:
+
+```markdown
+Six crates, and two of them exist to make a rule checkable rather than aspirational: the
+GUI never performs network I/O, and there is exactly one definition of the D-Bus contract.
+```
+
+Table rows to add, in dependency order:
+
+```markdown
+| `tidemark-ipc` | the generated D-Bus proxy | providers, storage, the display |
+| `tidemark-cli` | `tidemarkctl` | `tidemark-core`, GTK, a runtime |
+```
+
+Then, immediately after the "### D-Bus interface" subsection, add "### Command line":
+
+```markdown
+### Command line
+
+`tidemarkctl` is the third client, and the reason the interface was shaped as it was.
+It generates its proxy from `tidemark-ipc`, the same crate the window uses, so a method
+that changes shape breaks the build rather than a user's panel.
+
+Three output formats, and two of them are contracts. `text` is for a person and may be
+reworded. `json` is an object with an `accounts` key — not a bare array, so a key can be
+added later — carrying `ProviderStatus` as serde renders it, absent values still absent.
+`waybar` is `{text, tooltip, class, percentage}`, where `class` is **always an array** so
+its shape does not change when a second class applies: the zone (`ok`, `warning`, `danger`,
+at the same 70/90 the bar uses) and `stale` when the account's state is not `ok`.
+
+`watch` streams NDJSON: a `snapshot` first, then one line per signal, a `waiting` line when
+the daemon leaves the bus, and a fresh `snapshot` after every reconnect — what the daemon
+published while nothing was listening was announced to nobody.
+
+Exit codes are the point of `guard`: `0` safe, `1` below the threshold, `64` bad arguments,
+`69` nothing trustworthy to judge, `70` the daemon refused. Only an `ok` account's reading
+is judged; a last-good number behind a rejected credential would otherwise say "safe"
+about quota nobody can spend.
+
+Secrets are read from stdin or `--key-file`, never from argv: `/proc/<pid>/cmdline` is
+readable by every process of the same user. stdin is a file descriptor rather than a
+terminal, so a plugin with its own UI writes into a pipe without opening a console.
+
+Windows is out of scope for the CLI: there the daemon serves zbus p2p over AF_UNIX, and the
+endpoint discovery lives in the window's own reconnect module. The binary still compiles
+there; it is packaged only on Linux.
+```
+
+- [ ] **Step 3: Write the crate AGENTS files**
+
+`crates/tidemark-ipc/AGENTS.md` and `crates/tidemark-cli/AGENTS.md`, following the shape of
+`crates/tidemark-types/AGENTS.md`: an OVERVIEW line, a WHERE TO LOOK table, CONVENTIONS and
+ANTI-PATTERNS. The anti-patterns that matter, stated plainly:
+
+- `tidemark-ipc`: never add policy — no retry, no reconnect, no transport choice. Never let
+  a second proxy definition exist anywhere in the workspace.
+- `tidemark-cli`: never accept a secret in argv; never format a percentage or a span
+  outside `tidemark_types::present`; never invent a value the daemon did not send; the
+  `json` and `waybar` shapes and the exit codes are a published contract — add keys, never
+  rename or remove them.
+
+- [ ] **Step 4: Update the root knowledge base**
+
+In the root `AGENTS.md`: add `tidemark-ipc` and `tidemark-cli` to the STRUCTURE block, one
+row each to WHERE TO LOOK (`Change the CLI` → `crates/tidemark-cli/`; `Change the D-Bus
+proxy` → `crates/tidemark-ipc/src/lib.rs`), and `tidemarkctl usage --format json` to
+COMMANDS.
+
+- [ ] **Step 5: Verify the documentation against the binary**
+
+Run every command block in the new README section verbatim against the live daemon, and the
+Waybar snippet in a real Waybar if one is running.
+Expected: each works as written. A documented command that does not run is worse than an
+undocumented one.
+
+- [ ] **Step 6: Full gate and commit**
+
+```bash
+cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh
+git add README.md CONTEXT.md AGENTS.md crates/tidemark-cli/AGENTS.md crates/tidemark-ipc/AGENTS.md
+git commit -m "docs: tidemarkctl, and the contract it publishes"
+```
+
+---
+
+## Done when
+
+- `tidemarkctl usage`, `--format json` and `--format waybar` print the same numbers the
+  window shows, with nothing invented where a provider withheld a value.
+- `guard` distinguishes safe, below-threshold and unjudgeable with three different exit
+  codes.
+- `watch` opens with a snapshot, follows every signal, survives `systemctl --user restart
+  tidemarkd`, and drives a Waybar module.
+- Every method on the interface except `RequestActivate` is reachable, including adding a
+  provider, storing a key from a pipe, signing in, and changing preferences.
+- No secret can be passed on a command line.
+- `deb`, `rpm`, `PKGBUILD` and the Nix package carry `tidemarkctl`; the Windows packaging
+  does not, and the Windows build still compiles.
+- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace` and `./scripts/check-layering.sh` all pass.

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -1571,7 +1571,7 @@ git commit -m "feat(cli): guard a long run behind an exit code"
 - Produces: `watch::Event<'a>` serializing as `{"event":"<kind>", …}`, and `watch::line(&Event) -> Result<String, serde_json::Error>`.
 - Produces: `watch::mirror::Change { Upsert(ProviderStatus), Remove { provider, account }, Order(Vec<String>) }` and `watch::mirror::apply(&mut Vec<ProviderStatus>, Change)`.
 
-- [ ] **Step 1: Write the failing mirror tests**
+- [x] **Step 1: Write the failing mirror tests**
 
 `crates/tidemark-cli/src/watch/mirror.rs`:
 
@@ -1651,12 +1651,12 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli watch::mirror`
 Expected: FAIL — `apply` and `Change` are not defined.
 
-- [ ] **Step 3: Write the mirror**
+- [x] **Step 3: Write the mirror**
 
 Above the test module:
 
@@ -1696,7 +1696,7 @@ pub fn apply(statuses: &mut Vec<ProviderStatus>, change: Change) {
 }
 ```
 
-- [ ] **Step 4: Write the failing event-line tests**
+- [x] **Step 4: Write the failing event-line tests**
 
 `crates/tidemark-cli/src/watch/mod.rs`:
 
@@ -1774,12 +1774,28 @@ mod tests {
 }
 ```
 
-- [ ] **Step 5: Run the tests**
+- [x] **Step 5: Run the tests**
 
 Run: `cargo test -p tidemark-cli watch`
 Expected: PASS. `main.rs` needs `mod watch;` for the module to be compiled at all.
 
-- [ ] **Step 6: Commit**
+**Two things this step found:**
+
+1. `a_snapshot_names_itself_and_carries_every_account` failed the same way Task 4's tests
+did — `accounts[0].provider` came out as `{"signature":"s","value":"zai"}`. The event lines
+publish the same wire types, so `payload` moved from `format::json` up to `format` and
+`watch::line` serializes through it: `serde_json::to_string(&format::payload(to_value(event)?))`.
+One peeling rule, one place, and the stream and the snapshot parse alike.
+2. `Event`, `line`, `Change` and `apply` have no caller until Task 8. `Event` takes a plain
+`#[expect(dead_code, …)]` — the whole enum is unused in the binary and five variants are
+unconstructed in the test build, so the expectation is fulfilled either way. The other
+three *are* used by their own tests, where a plain `expect` would itself be an unfulfilled
+expectation and fail `-D warnings`; they take
+`#[cfg_attr(not(test), expect(dead_code, …))]`. `Change` also carries a documented
+`clippy::large_enum_variant` expectation: one status per signal, consumed immediately, so
+boxing buys an allocation and nothing else.
+
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -565,7 +565,7 @@ git commit -m "feat(cli): tidemarkctl skeleton and version"
 - Produces: `format::text::render(&[&ProviderStatus], Timestamp) -> String`.
 - Produces: `cli::Usage { provider, account, format }` and `cli::Format` (variants added per format task).
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 `crates/tidemark-cli/src/format/text.rs`:
 
@@ -650,16 +650,17 @@ mod tests {
 
 The pace assertion is real arithmetic, not a guess: the window is five hours long and
 resets in one, so four fifths of it have elapsed, and 72% consumed is behind that — the
-window is *not* outpacing. **Verify this when the test runs**: if `outpacing` is the wrong
-word for `is_outpacing() == Some(false)`, the test says `on pace` instead. Fix the test to
-match `Window::is_outpacing`'s meaning, never the other way round.
+window is *not* outpacing. **Resolved when the test ran:** the assertion on `outpacing`
+failed against `on pace  (72 / 100 prompts)`, confirming `is_outpacing() == Some(false)`,
+so the test now asserts `on pace` and a second one — same window, 95% consumed — covers
+the `Some(true)` wording.
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli format::text`
 Expected: FAIL — `render` is not defined.
 
-- [ ] **Step 3: Write the renderer**
+- [x] **Step 3: Write the renderer**
 
 Append to `crates/tidemark-cli/src/format/text.rs`, above the test module:
 
@@ -722,7 +723,10 @@ fn line(status: &WindowStatus, now: Timestamp) -> String {
 }
 ```
 
-- [ ] **Step 4: Write the selection helpers**
+- [x] **Step 4: Write the selection helpers**
+
+`format::dominant` has no caller until the waybar and guard tasks, so it carries
+`#[expect(dead_code, reason = …)]`; the task that first calls it deletes the marker.
 
 `crates/tidemark-cli/src/format/mod.rs`:
 
@@ -803,7 +807,7 @@ mod tests {
 tests call them both ways. `is_none_or` is stable in Rust 1.92 and reads better here than
 `map_or(true, …)`, which clippy rejects.
 
-- [ ] **Step 5: Extend the grammar and wire the command**
+- [x] **Step 5: Extend the grammar and wire the command**
 
 In `cli.rs`, add to `Command`:
 
@@ -853,12 +857,12 @@ In `main.rs`, add `mod format;` and the arm:
         }
 ```
 
-- [ ] **Step 6: Run the tests**
+- [x] **Step 6: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 7: Smoke it**
+- [x] **Step 7: Smoke it**
 
 Run: `cargo run -p tidemark-cli -- usage`
 Expected: one block per configured account, matching what the window shows.
@@ -871,7 +875,7 @@ Expected: exit 2 from clap, complaining that `--account` requires `--provider`. 
 usage error is code 2, not 64; that is clap's contract and is left alone — `Exit::Usage` is
 for arguments this program rejects itself.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -3582,7 +3582,19 @@ git commit -m "feat(cli): options, notifications, preferences and history"
 **Interfaces:**
 - Produces: `tidemarkctl completions <bash|zsh|fish>` on stdout.
 
-- [ ] **Step 1: Add the completion generator**
+- [x] **Step 1: Add the completion generator**
+
+Added `clap_complete 4.6.9` with Cargo. A new process-level integration test asks all three
+shells for a script and checks each shell's own marker plus the `provider` subcommand. It
+failed first with `unrecognized subcommand 'completions'`.
+
+**Deviation: the plan's direct `clap_complete::generate(..., stdout())` panics on an early
+reader exit.** The plan's own `| head -5` reproduced it: clap_complete's infallible wrapper
+calls `.expect("failed to write completion file")` on `BrokenPipe`, and the process exited
+101. The command now uses `Generator::try_generate` after setting the binary name and
+building the clap command; `BrokenPipe` is a normal exit 0 and other I/O errors remain
+failures. A second integration test closes the child's stdout after one byte: it failed
+with the panic before the fix and passes afterwards.
 
 `cargo add -p tidemark-cli clap_complete`
 
@@ -3606,7 +3618,17 @@ git commit -m "feat(cli): options, notifications, preferences and history"
         }
 ```
 
-- [ ] **Step 2: Verify each shell**
+- [x] **Step 2: Verify each shell**
+
+All three scripts printed their expected markers:
+
+- bash: `_tidemarkctl()`
+- zsh: `#compdef tidemarkctl`
+- fish: `complete -c tidemarkctl`
+
+The bash script was sourced in a clean shell; `complete -p tidemarkctl` named
+`_tidemarkctl`, and invoking it for `tidemarkctl prov` produced `reply=provider`.
+`set -o pipefail; tidemarkctl completions bash | head -5` exits 0 after the pipe fix.
 
 ```bash
 cargo run -p tidemark-cli -- completions bash | head -5
@@ -3619,7 +3641,7 @@ Load one for real: `source <(cargo run -q -p tidemark-cli -- completions bash)` 
 `tidemarkctl prov<TAB>`.
 Expected: it completes to `provider`.
 
-- [ ] **Step 3: Add the binary to the Debian package**
+- [x] **Step 3: Add the binary to the Debian package**
 
 In `crates/tidemark/Cargo.toml`, in `[package.metadata.deb] assets`, after the `tidemarkd`
 line:
@@ -3628,7 +3650,7 @@ line:
     ["target/release/tidemarkctl", "usr/bin/", "755"],
 ```
 
-- [ ] **Step 4: Add it to the RPM**
+- [x] **Step 4: Add it to the RPM**
 
 In the same file, in `[package.metadata.generate-rpm] assets`:
 
@@ -3636,7 +3658,7 @@ In the same file, in `[package.metadata.generate-rpm] assets`:
     { source = "target/release/tidemarkctl", dest = "/usr/bin/tidemarkctl", mode = "755" },
 ```
 
-- [ ] **Step 5: Add it to the Arch package**
+- [x] **Step 5: Add it to the Arch package**
 
 In `PKGBUILD`, after the `tidemarkd` install line:
 
@@ -3644,7 +3666,7 @@ In `PKGBUILD`, after the `tidemarkd` install line:
     install -Dm755 "$bin/tidemarkctl" "$pkgdir/usr/bin/tidemarkctl"
 ```
 
-- [ ] **Step 6: Add it to the Nix package**
+- [x] **Step 6: Add it to the Nix package**
 
 In `nix/package.nix`, in `postInstall`, after the `tidemarkd` line:
 
@@ -3655,7 +3677,35 @@ In `nix/package.nix`, in `postInstall`, after the `tidemarkd` line:
 `cargoBuildFlags` is already `--workspace --bins`, so the binary is built; nothing else in
 the derivation changes. Do **not** wrap it with `wrapGAppsHook4`: it loads no GTK.
 
-- [ ] **Step 7: Prove the packages carry it**
+Also extended `scripts/test-nix-flake.sh` with
+`test -x "$output/bin/tidemarkctl"`. Without that assertion the repository's Nix package
+test would still pass after silently dropping the new binary.
+
+- [x] **Step 7: Prove the packages carry it**
+
+Built and inspected every Linux payload, not only the Debian example:
+
+- Debian on the Arch host: `usr/bin/tidemarkctl` was present, but the dependency scan
+  correctly failed because Arch's libraries have no Debian package metadata. Rebuilt in
+  the release job's `ubuntu:26.04` environment: the payload contained `tidemarkctl`, the
+  dependency scan reported 26 entries, `libgtk-4-1`, `libadwaita-1-0`, and passed.
+- RPM: `target/generate-rpm/tidemark-0.4.1-1.x86_64.rpm` contains `tidemark`,
+  `tidemarkctl`, and `tidemarkd`. Its dependency metadata was not treated as release proof:
+  the manifest explicitly requires building that scan on Fedora.
+- Arch: `makepkg --force --noconfirm` produced
+  `tidemark-0.4.1-1-x86_64.pkg.tar.zst`; `usr/bin` contains all three binaries.
+- Nix: the Docker-backed `scripts/test-nix-flake.sh` passed after 3m57s, including the new
+  executable assertion, flake evaluation, package build and daemon D-Bus smoke.
+
+**Deviation: `scripts/check-package-deps.sh` requires a package argument.** The command in
+the plan omitted it. Used `scripts/check-package-deps.sh target/debian/*.deb`, matching the
+script's usage and the release workflow.
+
+The first Nix Docker run was cancelled after ten minutes: inspection found its curl process
+idle for 9m21s on the `aws-lc-sys` crate URL. The same URL then completed from the same
+image in 0.55s; a supervised rerun stayed CPU-active and passed. Host Nix was installed via
+`yay` at the user's request, then removed by the user; the package proof is wholly in the
+repository's Docker test and does not depend on host Nix.
 
 ```bash
 cargo build --release --locked --workspace
@@ -3669,14 +3719,24 @@ Run: `./scripts/check-package-deps.sh`
 Expected: PASS. A third binary must not add a shared-library dependency the metadata does
 not declare; `tidemarkctl` links no GTK, so the set should be unchanged.
 
-- [ ] **Step 8: Confirm the Windows build still builds**
+- [x] **Step 8: Confirm the Windows build still builds**
+
+The target is installed, but the full workspace cross-check stops in `glib-sys`/`gio-sys`:
+this Arch host has no Windows GTK pkg-config sysroot. The contract changed here does compile:
+`cargo check -p tidemark-cli --target x86_64-pc-windows-gnu` passed. No file under
+`data/packaging/windows` or the NSIS inputs changed; the full GUI build remains covered by
+the repository's MSYS2 CI job. Recorded the local limitation in the implementation commit
+body.
 
 Run: `cargo check --workspace --target x86_64-pc-windows-gnu` if the target is installed;
 otherwise rely on CI and say so in the commit body.
 Expected: `tidemark-cli` compiles. It is not added to any Windows packaging list — check
 `data/packaging` and the NSIS inputs and leave them alone.
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
+
+Committed as `03cc76d`. Before the commit: `cargo fmt --check`, workspace clippy with
+`-D warnings`, 1527 tests across 23 suites, and the layering check all passed.
 
 ```bash
 git add crates/tidemark-cli crates/tidemark/Cargo.toml PKGBUILD nix/package.nix Cargo.lock

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -47,10 +47,15 @@ clap_complete, serde_json, async-io for `block_on` and the retry timer.
 - Modify: `scripts/check-layering.sh`
 
 **Interfaces:**
-- Produces: `tidemark_ipc::Daemon` (the proxy trait) and `tidemark_ipc::DaemonProxy` (generated), with the same method, property and signal set the GUI has today. Every later task consumes `DaemonProxy`.
+- Produces: `tidemark_ipc::DaemonProxy` (generated) with the same method, property and
+signal set the GUI has today, plus one message struct per signal
+(`ProviderChanged`, `ProviderRemoved`, `OrderChanged`, `UpdateChanged`,
+`PreferencesChanged`, `DataChanged`, `ActivateRequested`). `#[zbus::proxy]` *consumes* the
+trait it is written on, so there is no `tidemark_ipc::Daemon` to re-export. Every later
+task consumes `DaemonProxy`.
 - Produces: `crate::bus::DaemonProxy` in the GUI keeps resolving, via `pub use`, so `detail.rs`, `preferences.rs`, `window.rs`, `provider_settings/mod.rs` and `provider_settings/detail.rs` are not edited at all.
 
-- [ ] **Step 1: Create the crate manifest**
+- [x] **Step 1: Create the crate manifest**
 
 `crates/tidemark-ipc/Cargo.toml`. Copy the `[package]`/`[lints]` shape from
 `crates/tidemark-types/Cargo.toml` so the workspace inheritance matches:
@@ -77,7 +82,7 @@ zbus = { version = "5.13.2", features = ["p2p"] }
 `p2p` is kept because the Windows GUI builds its connection that way and this crate is
 what it builds the proxy from.
 
-- [ ] **Step 2: Add the crate to the workspace**
+- [x] **Step 2: Add the crate to the workspace**
 
 In the root `Cargo.toml`, `members` becomes:
 
@@ -88,15 +93,12 @@ members = [
     "crates/tidemark-core",
     "crates/tidemarkd",
     "crates/tidemark",
-    "crates/tidemark-cli",
 ]
-```
 
-`crates/tidemark-cli` is listed now and created in Task 2; until then
-`cargo` commands must be run with `-p` on an existing crate. If that is inconvenient,
-add the `tidemark-cli` line in Task 2 instead — but do not forget it.
+`crates/tidemark-cli` is **not** listed here: a member that does not exist yet fails every
+`cargo` command in the workspace. Task 2 adds the line when it creates the crate.
 
-- [ ] **Step 3: Move the proxy**
+- [x] **Step 3: Move the proxy**
 
 `crates/tidemark-ipc/src/lib.rs` starts with this module documentation, then contains
 lines 38-186 of `crates/tidemark/src/bus.rs` **verbatim** — the whole `#[zbus::proxy]`
@@ -123,7 +125,7 @@ The trait body references `tidemark_types::HistoryPoint` by full path today
 (`current_segment`'s return type); with the import above, shorten it to `Vec<HistoryPoint>`.
 Nothing else changes.
 
-- [ ] **Step 4: Point the GUI at it**
+- [x] **Step 4: Point the GUI at it**
 
 In `crates/tidemark/Cargo.toml`, beside the other path dependency:
 
@@ -131,25 +133,34 @@ In `crates/tidemark/Cargo.toml`, beside the other path dependency:
 tidemark-ipc = { path = "../tidemark-ipc" }
 ```
 
-In `crates/tidemark/src/bus.rs`, replace lines 38-186 (the attribute and the trait) with:
+In `crates/tidemark/src/bus.rs`, replace lines 38-186 (the attribute and the trait) with a
+re-export of what the macro generated — the proxy and the signal message types `Event`
+matches on:
 
 ```rust
 /// The contract lives in `tidemark-ipc`, shared with `tidemarkctl`. Re-exported here so
 /// this module stays the one place the rest of the interface asks for the daemon.
-pub use tidemark_ipc::{Daemon, DaemonProxy};
+///
+/// `#[zbus::proxy]` consumes the trait it is written on and emits the proxy plus one
+/// message type per signal, so those names come from there too: [`Event`] below matches on
+/// them.
+pub use tidemark_ipc::{
+    ActivateRequested, DaemonProxy, DataChanged, OrderChanged, PreferencesChanged, ProviderChanged,
+    ProviderRemoved, UpdateChanged,
+};
 ```
 
 Keep the `use tidemark_types::{…}` list at the top of `bus.rs`: `Update` and `load` still
 name those types. Remove from it only what the compiler then reports as unused.
 
-- [ ] **Step 5: Build the GUI and run its tests**
+- [x] **Step 5: Build the GUI and run its tests**
 
 Run: `cargo test -p tidemark`
 Expected: PASS, including the five `bus.rs` reconnect tests that build a `DaemonProxy`
 through `DaemonProxy::builder(…)`. If a `cfg(windows)` block fails to resolve
 `DaemonProxy`, check that the `pub use` is outside every `cfg`.
 
-- [ ] **Step 6: Write the contract's own test**
+- [x] **Step 6: Write the contract's own test**
 
 At the end of `crates/tidemark-ipc/src/lib.rs`. This proves the moved proxy still names the
 right interface and path, and still decodes the published dictionaries:
@@ -216,12 +227,12 @@ mod tests {
 
 Add the dev-dependency this needs: `cargo add -p tidemark-ipc --dev async-io`.
 
-- [ ] **Step 7: Run it**
+- [x] **Step 7: Run it**
 
 Run: `cargo test -p tidemark-ipc`
 Expected: PASS (or the skip line on a machine with no session bus).
 
-- [ ] **Step 8: Teach the layering check about the new crate**
+- [x] **Step 8: Teach the layering check about the new crate**
 
 In `scripts/check-layering.sh`, after the `tidemark-types` block, insert:
 
@@ -241,12 +252,12 @@ four crates, with:
 #   tidemark-cli    tidemarkctl. Speaks D-Bus and prints; no runtime, no display.
 ```
 
-- [ ] **Step 9: Run the full gate**
+- [x] **Step 9: Run the full gate**
 
 Run: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`
 Expected: PASS, `layering ok`.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 git add Cargo.toml Cargo.lock crates/tidemark-ipc crates/tidemark/Cargo.toml crates/tidemark/src/bus.rs scripts/check-layering.sh
@@ -274,7 +285,8 @@ git commit -m "refactor(ipc): share the daemon proxy between the window and a CL
 
 - [ ] **Step 1: Create the crate**
 
-`crates/tidemark-cli/Cargo.toml`:
+Add `"crates/tidemark-cli"` to the root `Cargo.toml`'s `members` — Task 1 deferred it, so
+it is this task's line to write — and create `crates/tidemark-cli/Cargo.toml`:
 
 ```toml
 [package]

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -283,7 +283,7 @@ git commit -m "refactor(ipc): share the daemon proxy between the window and a CL
 - Produces: `connect::daemon() -> zbus::Result<DaemonProxy<'static>>`.
 - Produces: `cli::Cli` with `cli::Command`, extended by every later task.
 
-- [ ] **Step 1: Create the crate**
+- [x] **Step 1: Create the crate**
 
 Add `"crates/tidemark-cli"` to the root `Cargo.toml`'s `members` — Task 1 deferred it, so
 it is this task's line to write — and create `crates/tidemark-cli/Cargo.toml`:
@@ -322,7 +322,7 @@ cargo add -p tidemark-cli serde --features derive
 
 Note the absent `p2p`: the CLI only ever talks to a session bus.
 
-- [ ] **Step 2: Write the exit codes**
+- [x] **Step 2: Write the exit codes**
 
 `crates/tidemark-cli/src/exit.rs`:
 
@@ -400,7 +400,12 @@ impl From<serde_json::Error> for Failure {
 }
 ```
 
-- [ ] **Step 3: Write the connection**
+Until a later task constructs them, `Exit::Below`, `Exit::Usage`, `Failure::usage` and
+`Failure::unavailable` are dead code, and the gate denies warnings. Each carries
+`#[expect(dead_code, reason = "…")]`, not `allow`: `expect` warns once the item *is* used,
+so the task that reaches for it is told to delete the marker.
+
+- [x] **Step 3: Write the connection**
 
 `crates/tidemark-cli/src/connect.rs`:
 
@@ -418,7 +423,7 @@ pub async fn daemon() -> zbus::Result<DaemonProxy<'static>> {
 }
 ```
 
-- [ ] **Step 4: Write the failing grammar test**
+- [x] **Step 4: Write the failing grammar test**
 
 `crates/tidemark-cli/src/cli.rs`:
 
@@ -464,12 +469,12 @@ mod tests {
 `debug_assert()` is clap's own grammar validator — it catches a `requires` naming a
 non-existent argument, which is the mistake this grammar will make most often as it grows.
 
-- [ ] **Step 5: Run it and watch it fail**
+- [x] **Step 5: Run it and watch it fail**
 
 Run: `cargo test -p tidemark-cli`
 Expected: FAIL — `main.rs` does not exist yet, so the crate does not build.
 
-- [ ] **Step 6: Write main**
+- [x] **Step 6: Write main**
 
 `crates/tidemark-cli/src/main.rs`:
 
@@ -514,12 +519,12 @@ async fn run(cli: cli::Cli) -> Result<Exit, Failure> {
 }
 ```
 
-- [ ] **Step 7: Run the tests**
+- [x] **Step 7: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 8: Smoke it against the live daemon**
+- [x] **Step 8: Smoke it against the live daemon**
 
 Run: `cargo run -p tidemark-cli -- version`
 Expected: two lines, the second being the running daemon's version.
@@ -527,7 +532,7 @@ Expected: two lines, the second being the running daemon's version.
 Run: `env DBUS_SESSION_BUS_ADDRESS=unix:path=/nonexistent cargo run -p tidemark-cli -- version; echo $?`
 Expected: a message on stderr and `69`.
 
-- [ ] **Step 9: Add the CLI to the layering check**
+- [x] **Step 9: Add the CLI to the layering check**
 
 In `scripts/check-layering.sh`, after the `tidemark-ipc` block:
 
@@ -539,7 +544,7 @@ forbid tidemark-cli 'the CLI prints what the daemon publishes and nothing else' 
 Run: `./scripts/check-layering.sh`
 Expected: `layering ok`.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 git add Cargo.toml Cargo.lock crates/tidemark-cli scripts/check-layering.sh

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -2490,7 +2490,11 @@ pub enum ProviderCommand {
     /// Configure a provider, creating its default account.
     Add { provider: String },
     /// Remove one configured account, its credentials and its card.
-    Rm { provider: String, account: String },
+    Rm {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Rewrite the order the cards go in. Must name every configured provider.
     Order { providers: Vec<String> },
 }
@@ -2500,10 +2504,15 @@ pub enum AccountCommand {
     /// Add one more account to a provider the config already has.
     Add { provider: String, account: String },
     /// Remove one account. The same call as `provider rm`.
-    Rm { provider: String, account: String },
+    Rm {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Rename an account, carrying its credential and history to the new id.
     Rename {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         new: String,
     },
@@ -2755,7 +2764,7 @@ pub async fn run(proxy: &DaemonProxy<'_>, command: AccountCommand) -> Result<Exi
 58 catalog rows, 9 configured accounts, `refresh` accepted. The full mutation round trip on
 `wayfinder`, then put back exactly as found: `provider add wayfinder` → the row appears
 `unreachable` (no credential, as expected); `provider order wayfinder codex claude …` → the
-list comes back with wayfinder first; `provider rm wayfinder default` → gone, and the
+list comes back with wayfinder first; `provider rm wayfinder` → gone, and the
 original order restored.
 
 The refusals are worth recording, because they are the exit-code split working on live
@@ -2914,6 +2923,7 @@ pub enum AuthCommand {
     /// Store an API key. The key is read from stdin, or from --key-file.
     SetKey {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         /// Read the key from this file instead of stdin.
         #[arg(long)]
@@ -2922,23 +2932,41 @@ pub enum AuthCommand {
     /// Store a browser session header. Read like a key.
     SetSession {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         #[arg(long)]
         key_file: Option<std::path::PathBuf>,
     },
     /// Remove whatever credential Tidemark holds for an account.
-    SignOut { provider: String, account: String },
+    SignOut {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Print the authorize URL, then wait for the browser to come back.
-    Login { provider: String, account: String },
+    Login {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
     /// Abandon a login that is waiting.
-    CancelLogin { provider: String, account: String },
-    /// The local authentication sources the daemon can see, without their credentials.
-    Sources { provider: String, account: String },
-    /// Record which local source this account uses.
+    CancelLogin {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
+    /// The dynamic local authentication sources the daemon can see, without credentials.
+    Sources {
+        provider: String,
+        #[arg(long, default_value = "default")]
+        account: String,
+    },
+    /// Record which authentication source this account uses.
     Select {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
-        /// The mode value from `auth sources`.
+        /// `oauth` or `cli`, or a dynamic mode value from `auth sources`.
         #[arg(long)]
         mode: String,
         /// The candidate id, for a mode that offers a choice.
@@ -3128,16 +3156,16 @@ it started with, and `claude` is still `ok`.
 
 ```
 provider add groq
-printf '%s' 'gsk-not-a-real-key' | auth set-key groq default   # 0
+printf '%s' 'gsk-not-a-real-key' | auth set-key groq           # 0
 provider list | grep groq   →  groq  default  Groq  credential-rejected
 usage --provider groq       →  "the credential was rejected (HTTP 401)"
-auth sign-out groq default  →  0, then the row reads no-credential
-provider rm groq default    →  0
+auth sign-out groq          →  0, then the row reads no-credential
+provider rm groq            →  0
 ```
 
-The prohibition holds: `auth set-key zai default sk-x` → clap, exit **2**,
-`unexpected argument 'sk-x' found`. There is no positional slot for a secret, and
-`--help` shows only `<PROVIDER> <ACCOUNT>`.
+The prohibition holds: `auth set-key zai sk-x` → clap, exit **2**, `unexpected argument
+'sk-x' found`. There is no positional slot for a secret, and `--help` shows only
+`<PROVIDER>` plus the optional `--account` and `--key-file`.
 
 Refusals: empty stdin → **64** `no value on stdin: pipe the key in, or pass --key-file`;
 `--key-file /tmp/nope` → **64** naming the path. Neither reached the daemon.
@@ -3145,14 +3173,14 @@ Refusals: empty stdin → **64** `no value on stdin: pipe the key in, or pass --
 `auth sources` needed a provider with a browser selector, so `t3chat` was added, read and
 removed. It printed 11 rows — `browser` with `chrome`, `chromium`, `firefox` and `zen`
 under it, each with its profiles indented one further, plus `paste` with its hint — and no
-cookie value, token or database path anywhere. `auth select t3chat default --mode browser
+cookie value, token or database path anywhere. `auth select t3chat --mode browser
 --candidate firefox` returned 0, and `usage --format json` then showed
 `{"candidate":"firefox/j7aiac5u.default-release","mode":"browser"}`: the daemon resolved
 the browser-level id to the profile leaf, which is the behaviour the GUI's dialog relies on.
 `--mode nonsense` → **70**, `the selected authentication source is not ready`.
 
-`auth login claude default` printed the authorize URL immediately — the flush before the
-blocking `AwaitLogin` works — and stayed waiting. `auth cancel-login claude default` from a
+`auth login claude` printed the authorize URL immediately — the flush before the blocking
+`AwaitLogin` works — and stayed waiting. `auth cancel-login claude` from a
 second process ended it with **70** and the daemon's own sentence, `the login was
 cancelled`. Claude's stored credential was untouched: still `ok`.
 
@@ -3190,6 +3218,7 @@ rather than by a hand-written message.
     /// One of a provider's own settings.
     Option {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         name: String,
         value: String,
@@ -3197,6 +3226,7 @@ rather than by a hand-written message.
     /// Notifications for one window of one account.
     Notify {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         window: String,
         #[arg(value_parser = switch)]
@@ -3272,6 +3302,7 @@ pub enum HistoryCommand {
     /// The stored points of one window's current segment, oldest first.
     Segment {
         provider: String,
+        #[arg(long, default_value = "default")]
         account: String,
         window: String,
     },
@@ -3526,9 +3557,9 @@ data          →  config and history paths, history-bytes 1203760, both keyring
 update        →  0.4.1
 config refresh manual --minutes 15   →  config show says manual / 15
 config refresh auto --minutes 1      →  back to auto / 1
-history segment claude default w18000 | tail -3  →  1788810721 87% / 1788810752 88% /
+history segment claude w18000 | tail -3          →  1788810721 87% / 1788810752 88% /
                                                     1788810985 92%
-history segment claude default w99999            →  no lines, exit 0: a window with no
+history segment claude w99999                    →  no lines, exit 0: a window with no
                                                     stored points is not an error
 ```
 
@@ -3538,22 +3569,22 @@ All three refusal layers, on live data:
 - `config proxy socks5 127.0.0.1` → **64**, `the `socks5` proxy mode needs a host and a
   port`. Never reached the bus.
 - `config theme neon` → **70**, `unknown theme "neon"`. The daemon's list, not ours.
-- `option antigravity default source nonsense` → **70**, `nonsense is not one of the values
-  source can take`.
+- `option antigravity source nonsense` → **70**, `nonsense is not one of the values source
+  can take`.
 
-`notify claude default w604800 on` then `off`: the account's `notify` array went `[]` →
-`["w604800"]` → `[]`. `option antigravity default source cli` took effect and was visible
-in the published option value.
+`notify claude w604800 on` then `off`: the account's `notify` array went `[]` →
+`["w604800"]` → `[]`. `auth select antigravity --mode cli` took effect and was visible in
+the published option value.
 
-**Two things the smoke wrote into the user's config, and how they were undone.** `option`
-pinned `[provider.antigravity] source = "cli"` where nothing had been pinned before (the
+**Two things the smoke wrote into the user's config, and how they were undone.** `auth
+select` pinned `[provider.antigravity] source = "cli"` where nothing had been pinned before (the
 published value was the `auto` sentinel, and `auto` is *not* one of the option's choices —
 there is no CLI way to unset it), and the `notify` round trip left an empty
 `[notify.claude] windows = []` section. Restored by stopping `tidemarkd`, deleting both
 stanzas from `config.toml`, and starting it again; verified afterwards that the option
 publishes `auto` with `auth_source` still `cli`, that claude's `notify` is `[]`, and that
-every other preference reads exactly as it did before. Worth knowing for later: `option`
-can pin a provider setting that no command can unpin.
+every other preference reads exactly as it did before. Worth knowing for later: selecting
+a source can pin a provider setting that no command can unpin.
 
 `history clear` was deliberately not run: it deletes every stored point, and this machine's
 history is 1.2 MB of the user's real readings. Its argument path is one proxy call with no
@@ -3775,7 +3806,7 @@ trustworthy reading to judge — a rejected credential never answers "safe".
 Secrets are read from stdin, never from the command line:
 
 ```bash
-printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai default
+printf '%s' "$ZAI_API_KEY" | tidemarkctl auth set-key zai
 ```
 
 A Waybar module is two files. In `~/.config/waybar/config.jsonc`:
@@ -3906,6 +3937,20 @@ Committed as `e507b52`. Before the commit: `cargo fmt --check`, workspace clippy
 also updates the stale future-CLI comment in `scripts/check-layering.sh`.
 
 ---
+
+## Post-implementation UX correction — 2026-09-08
+
+- [x] Single-account commands expose `--account`, defaulting to `default`; `account add`
+  and `account order` keep the identifiers they create or permute mandatory.
+- [x] `usage`, `guard` and `watch` retain aggregate semantics when no account filter is
+  supplied, preserving their plugin contract.
+- [x] A newly added OAuth-or-CLI provider persists `source = "oauth"` before its first
+  credential probe. Existing accounts with no stored source retain legacy `Auto`.
+- [x] `auth select codex --mode cli` explicitly opts the default account into the vendor
+  CLI credential; extra OAuth accounts cannot change that provider-wide choice.
+- [x] Provider removal continues to delete only Tidemark-owned secrets. The vendor CLI's
+  credential file remains outside Tidemark's ownership.
+
 
 ## Done when
 

--- a/docs/superpowers/plans/2026-09-07-tidemarkctl.md
+++ b/docs/superpowers/plans/2026-09-07-tidemarkctl.md
@@ -1027,7 +1027,7 @@ git commit -m "feat(cli): usage as json"
 **Interfaces:**
 - Produces: `format::waybar::render(&[&ProviderStatus], Timestamp) -> Result<String, serde_json::Error>` emitting `{"text","tooltip","class","percentage"}` with `class` always an array.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 `crates/tidemark-cli/src/format/waybar.rs`:
 
@@ -1120,12 +1120,12 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Run and watch it fail**
+- [x] **Step 2: Run and watch it fail**
 
 Run: `cargo test -p tidemark-cli format::waybar`
 Expected: FAIL — `render` is not defined.
 
-- [ ] **Step 3: Write the renderer**
+- [x] **Step 3: Write the renderer**
 
 Above the test module:
 
@@ -1244,7 +1244,11 @@ fn escape(text: &str) -> String {
 }
 ```
 
-- [ ] **Step 4: Wire it up**
+- [x] **Step 4: Wire it up**
+
+`format::dominant` now has callers, so its `#[expect(dead_code, …)]` from Task 3 is
+deleted here — `expect` reports an unfulfilled expectation, which is what makes the marker
+self-removing.
 
 `format/mod.rs` gains `pub mod waybar;`. `cli::Format` gains `Waybar`. `main.rs`'s match
 gains:
@@ -1256,17 +1260,17 @@ gains:
                 ),
 ```
 
-- [ ] **Step 5: Run the tests**
+- [x] **Step 5: Run the tests**
 
 Run: `cargo test -p tidemark-cli`
 Expected: PASS.
 
-- [ ] **Step 6: Smoke it**
+- [x] **Step 6: Smoke it**
 
 Run: `cargo run -p tidemark-cli -- usage --format waybar | jq .`
 Expected: four keys, `class` an array, `percentage` an integer matching `text`.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add crates/tidemark-cli

--- a/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
+++ b/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
@@ -1,16 +1,16 @@
 # tidemarkctl — the command-line consumer of the daemon
 
 **Date:** 2026-09-07
-**Status:** approved design, not yet implemented
+**Status:** implemented; UX revised 2026-09-08
 **Branch:** `feat/cli`
 
 ## Why
 
-`tidemarkd` publishes everything it knows on the session bus, and the interface was
-shaped for a third consumer from the start: `tidemark-types/src/lib.rs`, `wire.rs` and
-`tidemarkd/src/service.rs` all say in their own comments that a CLI and a Waybar module
-were assumed while the dictionaries were designed. Nothing consumes it that way yet, so
-today the only clients are the GTK window and `busctl`.
+`tidemarkd` publishes everything it knows on the session bus, and the interface was shaped
+for a third consumer from the start: `tidemark-types/src/lib.rs`, `wire.rs` and
+`tidemarkd/src/service.rs` all assumed a CLI and a Waybar module while their dictionaries
+were designed. `tidemarkctl` is that consumer; scripts and panel plugins no longer need to
+generate a D-Bus proxy.
 
 Two things follow from shipping the CLI:
 
@@ -67,21 +67,35 @@ usage    [--provider P] [--account A] [--format text|json|waybar]
 guard    --min-remaining N [--window KEY | --any] [--provider P] [--account A]
 watch    [--provider P] [--format json|waybar]
 refresh  [P]
-provider catalog | list | add P | rm P A | order P...
-account  add P A | rm P A | rename P A NEW | order P A...
-auth     set-key P A [--key-file PATH] | set-session P A [--key-file PATH]
-         sign-out P A | login P A | cancel-login P A | sources P A
-         select P A --mode M [--candidate ID]
-option   set P A NAME VALUE
-notify   set P A WINDOW on|off
+provider catalog | list | add P | rm P [--account A] | order P...
+account  add P A | rm P [--account A] | rename P NEW [--account A] | order P A...
+auth     set-key P [--account A] [--key-file PATH]
+         set-session P [--account A] [--key-file PATH]
+         sign-out P [--account A] | login P [--account A]
+         cancel-login P [--account A] | sources P [--account A]
+         select P [--account A] --mode M [--candidate ID]
+option   P NAME VALUE [--account A]
+notify   P WINDOW on|off [--account A]
 config   show | proxy MODE [HOST PORT] | refresh auto|manual [--minutes N]
          retention R | theme T | startup M | release-check on|off | minimize-on-close on|off
-history  segment P A WINDOW | clear
+history  segment P WINDOW [--account A] | clear
 data
 update
 version
 completions bash|zsh|fish
 ```
+
+On commands that target one existing account, `--account` defaults to `default`. It stays
+required where it is the value being created (`account add`) or part of a complete
+permutation (`account order`). `usage`, `guard` and `watch` are collection commands:
+omitting their account filter continues to select every matching account for panel and
+script integrations.
+
+Adding Claude, Codex or Antigravity stores the explicit `oauth` source before the daemon's
+first credential probe. `provider add codex` therefore creates a `no-credential` account
+until `auth login codex` succeeds; it never silently reads `~/.codex/auth.json`.
+`auth select codex --mode cli` opts into that file. Existing configurations with no stored
+source retain the legacy `Auto` behavior and are not migrated.
 
 `RequestActivate` is deliberately absent: it is the second-instance path that asks a
 running window to come forward, and a CLI has no window to raise.

--- a/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
+++ b/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
@@ -1,0 +1,217 @@
+# tidemarkctl — the command-line consumer of the daemon
+
+**Date:** 2026-09-07
+**Status:** approved design, not yet implemented
+**Branch:** `feat/cli`
+
+## Why
+
+`tidemarkd` publishes everything it knows on the session bus, and the interface was
+shaped for a third consumer from the start: `tidemark-types/src/lib.rs`, `wire.rs` and
+`tidemarkd/src/service.rs` all say in their own comments that a CLI and a Waybar module
+were assumed while the dictionaries were designed. Nothing consumes it that way yet, so
+today the only clients are the GTK window and `busctl`.
+
+Two things follow from shipping the CLI:
+
+- **Panel plugins stop being our work.** CodexBar has no Linux GUI, and Linux got Waybar,
+  three Plasma widgets, a GNOME extension, a Cinnamon applet, Noctalia, SketchyBar and a
+  Stream Deck integration anyway — every one of them built on its bundled CLI. The
+  D-Bus interface alone did not produce that, because a panel author will not generate a
+  proxy to draw one number.
+- **Scripts and CI get a pre-flight gate.** `tidemarkctl guard --min-remaining 20 --window
+  weekly` answers "may I start a long run" with an exit code, which is the only form a
+  shell can act on.
+
+The user's stated goal is stronger than read-only: everything the GUI can do must be
+reachable from `tidemarkctl`, because plugins for Noctalia and Caelestia are planned and
+they must be able to add a provider, store a key and sign in without the window.
+
+## What it is
+
+One new binary, `tidemarkctl`, and one new library crate holding the contract it shares
+with the window.
+
+### Crates
+
+| crate | holds | depends on |
+|---|---|---|
+| `tidemark-ipc` | the single `#[zbus::proxy] trait Daemon` | `tidemark-types`, `zbus` |
+| `tidemark-cli` | `tidemarkctl`: argument grammar, formatters, command bodies | `tidemark-ipc`, `tidemark-types`, `zbus`, `clap`, `clap_complete`, `serde_json`, `futures-lite` |
+
+The proxy **moves** out of `crates/tidemark/src/bus.rs` (lines 38-186 as of `2c19a91`)
+rather than being copied. It already covers the whole interface — 33 methods, the
+`Version` property and seven signals — so a copy would be a second definition of the
+contract, drifting silently and failing at runtime on a user's machine instead of at
+build time on ours. This is the same argument that put the wire vocabulary in its own
+crate: a rule the build enforces beats a rule a hurry can skip.
+
+What stays in `crates/tidemark/src/bus.rs`: `Update`, `watch` (GLib-local), `serve`, the
+`cfg(windows)` `reconnect` module and their tests. The GUI imports
+`tidemark_ipc::DaemonProxy` and is otherwise untouched.
+
+No tokio. The GUI reaches the daemon on zbus 5's async-io backend, which drives its own
+connection thread, and the CLI blocks on futures with `futures-lite`. `scripts/check-layering.sh`
+gains two `forbid` entries — `tidemark-ipc` and `tidemark-cli` must not depend on
+`tidemark-core`, `reqwest`, `hyper`, `rusqlite`, `libsqlite3-sys`, `gtk4`, `gtk4-sys`,
+`libadwaita` **or `tokio`** — so a second runtime cannot arrive unnoticed in a tool whose
+whole value is starting fast.
+
+### Command surface
+
+Grouped by entity, because a flat list of thirty verbs is not a `--help` anybody reads.
+`P` is a provider slug, `A` an account id.
+
+```
+usage    [--provider P] [--account A] [--format text|json|waybar]
+guard    --min-remaining N [--window KEY | --any] [--provider P] [--account A]
+watch    [--provider P] [--format json|waybar]
+refresh  [P]
+provider catalog | list | add P | rm P A | order P...
+account  add P A | rm P A | rename P A NEW | order P A...
+auth     set-key P A [--key-file PATH] | set-session P A [--key-file PATH]
+         sign-out P A | login P A | sources P A | select P A --source S [--browser B] [--profile F]
+option   set P A NAME VALUE
+notify   set P A WINDOW on|off
+config   show | proxy MODE [HOST PORT] | refresh auto|manual [--minutes N]
+         retention R | theme T | startup M | release-check on|off | minimize-on-close on|off
+history  segment P A WINDOW | clear
+data
+update
+version
+completions bash|zsh|fish
+```
+
+`RequestActivate` is deliberately absent: it is the second-instance path that asks a
+running window to come forward, and a CLI has no window to raise.
+
+`provider catalog` is `ListProviders` — every provider this build knows how to configure —
+and `provider list` is the configured subset from `GetStatus`. The daemon keeps those as
+two concepts and so does the CLI.
+
+### Output formats
+
+- **`text`** — for a person. Rendered through `tidemark_types::present::{percent, duration}`,
+  so a number the CLI prints and the same number on a card can never disagree. A value the
+  provider withheld prints as withheld; the CLI never substitutes a zero for a missing
+  reset time, which is the rule the bar and the notifications already follow.
+- **`json`** — an object, `{"accounts": [...]}`, not a bare array, so a key can be added
+  later without breaking a plugin that parsed the old shape. Inside, the serde form of
+  `ProviderStatus` as it already exists. **Absent stays absent:** a window with no
+  `resets_at` has no such key, and no `null` stands in for it.
+- **`waybar`** — `{"text", "tooltip", "class", "percentage"}`.
+  - `text`: the worst window's percentage across the selected accounts.
+  - `percentage`: the same number as an integer, for Waybar's own formatting.
+  - `class`: **always an array**, so the shape does not change when a second class
+    applies. First element is the zone — `ok`, `warning`, `danger` — from the same
+    `WARNING_AT` / `DANGER_AT` constants the bar recolours at and the notifications fire
+    at. `stale` is appended whenever the account's state is not `ok`, so a rate-limited
+    account at 95% is `["danger", "stale"]` rather than losing its zone.
+  - `tooltip`: one line per account with its dominant window and reset, Pango-escaped.
+  - Class names are a public contract — users write CSS against them — and are documented
+    in `README.md` and `CONTEXT.md`, not left to be discovered from the source.
+
+### watch
+
+NDJSON on stdout, one line per event, flushed per line.
+
+```json
+{"event":"snapshot","accounts":[…]}
+{"event":"changed","account":{…}}
+{"event":"removed","provider":"claude","account":"default"}
+{"event":"order","providers":["claude","codex"]}
+{"event":"preferences","preferences":{…}}
+{"event":"data","data":{…}}
+{"event":"update","version":"0.5.0"}
+{"event":"waiting"}
+```
+
+The first line is always a `snapshot`, and a fresh `snapshot` follows every reconnect —
+whatever happened while the daemon was away was announced to nobody, so re-reading is the
+only honest recovery. `waiting` is emitted when the daemon leaves the bus, which is what
+makes a plugin able to dim rather than keep showing numbers from before an upgrade.
+Reconnect waits for the bus name's owner exactly as `bus.rs::serve` does; there is no
+polling. `--format waybar` prints one Waybar object per event instead, which is what a
+`"return-type": "json"` custom module consumes continuously.
+
+`SIGINT` and `SIGTERM` exit 0.
+
+### Exit codes
+
+`guard`, whose codes are its whole output:
+
+| code | meaning |
+|---|---|
+| 0 | at or above the threshold — safe to start |
+| 1 | below the threshold |
+| 64 | invalid arguments (`EX_USAGE`) |
+| 69 | the window is unavailable or the account has no reading (`EX_UNAVAILABLE`) |
+
+Every other command: `0` success, `64` invalid arguments, `69` the daemon could not be
+reached, `70` the daemon returned an error (its message goes to stderr). The daemon is
+reached through D-Bus activation; the CLI never inspects `systemctl` to decide whether it
+is running.
+
+### Secrets
+
+`auth set-key` and `auth set-session` accept a value from **stdin** (one trailing newline
+trimmed) or from `--key-file PATH`. Never from argv, under any flag: `/proc/<pid>/cmdline`
+is readable by every process of the same user, and a key typed once ends up in shell
+history.
+
+stdin is a file descriptor, not a terminal, so this does not force a console on anybody:
+a plugin spawns the process with a pipe and writes the key into it — `Process { stdinEnabled: true }`
+in Quickshell, `QProcess::write`, `subprocess.run(input=…)`. `--key-file` exists for
+frameworks that can hand over a path but not a pipe; the path is in argv, the secret is
+not.
+
+Nothing is ever printed back. `auth sources` shows candidate titles and readiness states,
+which is all the daemon publishes — cookie values, tokens and database paths never cross
+the bus.
+
+`auth login` prints the authorize URL on the first line of stdout and blocks until the
+callback completes, so a plugin reads the line, opens it however its platform opens URLs,
+and shows a spinner until the exit code arrives. The CLI never launches a browser itself,
+matching the daemon's own reason for splitting a login in two: the process that holds the
+credential may have started before there was a display.
+
+## Testing
+
+- **Pure functions.** The three formatters over `Vec<ProviderStatus>` fixtures, including
+  windows with no length and no reset time — the case that proves nothing is invented — and
+  a golden JSON fixture pinning the published shape, because that shape is what plugins
+  parse. The `guard` decision (threshold, window selection, `--any`, unavailability) and
+  its mapping to exit codes.
+- **Grammar.** `clap` parse tests for each group, including that a key cannot be passed on
+  argv.
+- **Integration.** Command bodies take `&DaemonProxy<'_>`, so a test stands up a fake
+  daemon on a private session bus — the pattern `tidemarkd/src/service.rs` tests already
+  use — and drives real commands against it. No environment hook exists to redirect the
+  bus name; testability comes from the parameter, not from a back door.
+- **Smoke, by hand.** `tidemarkctl usage --format text`, `--format json` and
+  `--format waybar` against the live daemon on the development machine, plus `watch` in one
+  terminal while `refresh` runs in another.
+
+## Packaging and documentation
+
+The third binary is added in four places: `[package.metadata.deb] assets` and
+`[package.metadata.generate-rpm] assets` in `crates/tidemark/Cargo.toml`, `PKGBUILD`, and
+`nix/package.nix`'s `postInstall`. `completions` output is installed for bash, zsh and fish
+by the same four.
+
+Documentation: a CLI section in `README.md` with a copy-pasteable Waybar module, a
+`CONTEXT.md` subsection under Architecture covering the format contract, the class names
+and the exit codes, and `AGENTS.md` for both new crates.
+
+## Non-goals
+
+- **No Windows build of the CLI.** There the daemon serves zbus p2p over AF_UNIX and the
+  endpoint discovery lives in `bus.rs`'s `cfg(windows)` `reconnect` module; reusing it is
+  separate work. The NSIS installer does not gain the binary, and the docs say so. The
+  Windows build must keep working exactly as it does — the proxy move is the only change
+  that touches its code path.
+- **No HTTP server.** `codexbar serve` exists because a client may be unable to read a
+  child process's stdout; `watch` covers the plugins we know we are writing, and a
+  listening socket brings an authorization question this project currently does not have.
+- **No cost or spend output.** There is no cost-history surface in Tidemark to print.
+- **No localization.** The CLI is English, like the rest of the repository's text.

--- a/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
+++ b/docs/superpowers/specs/2026-09-07-tidemarkctl-design.md
@@ -70,7 +70,8 @@ refresh  [P]
 provider catalog | list | add P | rm P A | order P...
 account  add P A | rm P A | rename P A NEW | order P A...
 auth     set-key P A [--key-file PATH] | set-session P A [--key-file PATH]
-         sign-out P A | login P A | sources P A | select P A --source S [--browser B] [--profile F]
+         sign-out P A | login P A | cancel-login P A | sources P A
+         select P A --mode M [--candidate ID]
 option   set P A NAME VALUE
 notify   set P A WINDOW on|off
 config   show | proxy MODE [HOST PORT] | refresh auto|manual [--minutes N]

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -55,6 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     install -Dm755 target/*/release/tidemark -t "$out/bin"
     install -Dm755 target/*/release/tidemarkd -t "$out/bin"
+    install -Dm755 target/*/release/tidemarkctl -t "$out/bin"
     install -Dm644 data/applications/io.github.zbndev.Tidemark.desktop -t "$out/share/applications"
     install -Dm644 data/metainfo/io.github.zbndev.Tidemark.metainfo.xml -t "$out/share/metainfo"
     install -d "$out/share/icons"

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -4,6 +4,8 @@
 #   tidemark-types  the shared vocabulary. Reaches nothing.
 #   tidemark-core   network, disk, secrets. Never the display.
 #   tidemarkd       the only process allowed to hold both.
+#   tidemark-ipc    the generated D-Bus proxy, shared by every client.
+#   tidemark-cli    tidemarkctl. Speaks D-Bus and prints; no runtime, no display.
 #   tidemark        the display. Never the network, never the database, never core —
 #                   it speaks D-Bus, which is what keeps a future CLI a third consumer
 #                   rather than a rewrite.
@@ -35,6 +37,12 @@ forbid() {
 # contract, opening a connection is an implementation.
 forbid tidemark-types 'it is the contract, not an implementation' \
     reqwest hyper rusqlite libsqlite3-sys tokio gtk4 gtk4-sys libadwaita zbus
+
+# The contract's client half: it may open a connection, and nothing else. tokio is on the
+# list because zbus can be built on either reactor, and a CLI whose value is starting fast
+# must not acquire a second runtime by accident.
+forbid tidemark-ipc 'the contract carries no implementation' \
+    tidemark-core reqwest hyper rusqlite libsqlite3-sys gtk4 gtk4-sys libadwaita tokio
 
 forbid tidemark-core 'core must build on a machine with no display stack' \
     gtk4 gtk4-sys gdk4-sys libadwaita libadwaita-sys

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -44,6 +44,9 @@ forbid tidemark-types 'it is the contract, not an implementation' \
 forbid tidemark-ipc 'the contract carries no implementation' \
     tidemark-core reqwest hyper rusqlite libsqlite3-sys gtk4 gtk4-sys libadwaita tokio
 
+forbid tidemark-cli 'the CLI prints what the daemon publishes and nothing else' \
+    tidemark-core reqwest hyper rusqlite libsqlite3-sys gtk4 gtk4-sys libadwaita tokio
+
 forbid tidemark-core 'core must build on a machine with no display stack' \
     gtk4 gtk4-sys gdk4-sys libadwaita libadwaita-sys
 

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -7,7 +7,7 @@
 #   tidemark-ipc    the generated D-Bus proxy, shared by every client.
 #   tidemark-cli    tidemarkctl. Speaks D-Bus and prints; no runtime, no display.
 #   tidemark        the display. Never the network, never the database, never core —
-#                   it speaks D-Bus, which is what keeps a future CLI a third consumer
+#                   it speaks D-Bus, which is what keeps `tidemarkctl` a third consumer
 #                   rather than a rewrite.
 #
 # Run from anywhere; exits non-zero on the first violation.

--- a/scripts/test-nix-flake.sh
+++ b/scripts/test-nix-flake.sh
@@ -31,6 +31,7 @@ output=$(nix build --no-link --print-out-paths .#tidemark)
 
 test -x "$output/bin/tidemark"
 test -x "$output/bin/tidemarkd"
+test -x "$output/bin/tidemarkctl"
 test -f "$output/share/applications/io.github.zbndev.Tidemark.desktop"
 test -f "$output/share/metainfo/io.github.zbndev.Tidemark.metainfo.xml"
 test -f "$output/share/icons/hicolor/512x512/apps/io.github.zbndev.Tidemark.png"


### PR DESCRIPTION
## Summary

- move the generated daemon proxy into `tidemark-ipc`, shared by the GTK client and command-line client
- add `tidemarkctl` for snapshots, JSON/Waybar output, quota guards, reconnecting NDJSON streams, provider/account/auth management, preferences, history, and shell completions
- package `tidemarkctl` in Debian, RPM, Arch, and Nix Linux artifacts while keeping Windows packaging unchanged
- document the CLI contracts, exit codes, account defaults, credential ownership, and plugin integration

## Command-line contract

- `usage` renders human-readable text, stable `{"accounts": [...]}` JSON, or a Waybar object with `text`, `tooltip`, `class`, and `percentage`
- `guard` distinguishes safe (`0`), below threshold (`1`), unavailable (`69`), and daemon refusal (`70`)
- `watch` emits an initial snapshot, one NDJSON event per daemon signal, a waiting event during disconnects, and a fresh snapshot after reconnect; Waybar mode re-renders from a client-side mirror
- provider, account, credential, notification, preference, history, update, and data operations all go through D-Bus; the CLI performs no provider I/O and carries no GTK or Tokio dependency
- secrets are accepted only through stdin or `--key-file`, never argv
- single-account operations default `--account` to `default`; aggregate `usage`, `guard`, and `watch` behavior remains unchanged
- newly added OAuth-capable providers select Tidemark OAuth before the first credential probe; `auth select <provider> --mode cli` explicitly opts into vendor CLI credentials

## Packaging

- install `tidemarkctl` in deb, RPM, PKGBUILD, and Nix outputs
- generate bash, zsh, and fish completions
- keep the CLI out of Windows packaging; `tidemark-cli` still cross-checks for `x86_64-pc-windows-gnu`

## Verification

Captured on the final branch head:

```text
cargo fmt --check
PASS

cargo clippy --workspace --all-targets -- -D warnings
PASS

cargo test --workspace
1536 passed across 23 suites

./scripts/check-layering.sh
layering ok
```

Additional implementation-plan proofs cover the live daemon command paths, D-Bus reconnect stream, bash completion loading, Linux package payloads, Nix package smoke, and the Windows CLI cross-check.