### PR TITLE
fix(openrouter): show remaining balance without scale

### DIFF
--- a/crates/tidemark-core/src/providers/keyed/openrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/openrouter.rs
@@ -21,19 +21,10 @@
 //!
 //! # The reading
 //!
-//! The account's credits are the reading every OpenRouter key can produce: money added
-//! against money spent, which is a share, so they are drawn — one lengthless window keyed
-//! `credits`, `total_usage` over `total_credits`, because a topped-up balance has no length
-//! to key on and never resets. An account that has spent against no credits at all is drawn
-//! full rather than empty, the same way the other prepaid ports draw a configuration that
-//! reports spend with no allowance behind it.
-//!
-//! A key with a limit adds a second window — spend against a stated budget, keyed `balance`,
-//! lengthless for the same reason. Spend there is the server-reported `limit_remaining`
-//! first, clamped to the limit, so a negative remaining reads as an exhausted quota; then
-//! the usage matching the declared reset window; then cumulative `usage`. A key without a
-//! limit — the common case, and what a plain key reports — is a row saying so and no second
-//! window; the credits window is what the card leads with either way.
+//! The account's credits are a remaining dollar balance, not a quota period: topping up
+//! neither begins a window nor schedules a reset. The card therefore shows the balance as
+//! its headline, as it does for DeepSeek. The `/key` endpoint's optional spending budget
+//! stays in the detail rows, rather than adding a percentage scale to the card.
 //!
 //! # The base URL
 //!
@@ -51,8 +42,7 @@ use serde_json::Value;
 use std::fmt;
 use std::sync::Arc;
 use tidemark_types::{
-    AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp, Window,
-    WindowKey,
+    AccountId, CredentialKind, DetailRow, DetailSection, ProviderId, Snapshot, Timestamp,
 };
 
 /// The slug this provider's history is filed under. Never changes once shipped.
@@ -259,36 +249,6 @@ impl Credits {
     fn balance(self) -> f64 {
         (self.total_credits - self.total_usage).max(0.0)
     }
-
-    /// The credits as a window: spent over added. Lengthless and resetless — money added
-    /// does not roll over into anything — so `named("credits")`, keyed apart from the key's
-    /// own `balance` budget because the two measure different money.
-    ///
-    /// Credits of nought are the degenerate case: nothing spent is an untouched account at
-    /// nought per cent, and spend recorded against no credits at all is drawn full, so a
-    /// configuration that cannot be measured is visible rather than reassuring.
-    fn window(self) -> Window {
-        let used_percent = if self.total_credits > 0.0 {
-            (self.total_usage / self.total_credits * 100.0).clamp(0.0, 100.0)
-        } else if self.total_usage > 0.0 {
-            100.0
-        } else {
-            0.0
-        };
-        Window {
-            key: WindowKey::named("credits"),
-            title: "Credits".to_owned(),
-            subtitle: Some(format!(
-                "{} of {} used · {} left",
-                usd(self.total_usage),
-                usd(self.total_credits),
-                usd(self.balance())
-            )),
-            used_percent,
-            resets_at: None,
-            length: None,
-        }
-    }
 }
 
 /// Reads the credits body. Pure, and strict: this request is the point of the fetch, so
@@ -376,25 +336,6 @@ impl Budget {
         let used = used_for_quota(data, limit)?.filter(|used| *used >= 0.0 && used.is_finite())?;
         Some(Self { limit, used })
     }
-
-    /// The spend limit as a window: a fixed balance, used over limit. Lengthless and
-    /// resetless — the budget does not roll — so `named("balance")`, because a balance
-    /// has no length to key on.
-    fn window(&self) -> Window {
-        Window {
-            key: WindowKey::named("balance"),
-            title: "API key budget".to_owned(),
-            subtitle: Some(format!(
-                "{} of {} used · {} left",
-                usd(self.used),
-                usd(self.limit),
-                usd((self.limit - self.used).max(0.0))
-            )),
-            used_percent: (self.used / self.limit * 100.0).clamp(0.0, 100.0),
-            resets_at: None,
-            length: None,
-        }
-    }
 }
 
 /// How much of the budget is spent, by the source's own precedence: the server-reported
@@ -429,17 +370,11 @@ fn snapshot_for_account(
         KeyState::Data(data) => Budget::of(data),
         KeyState::Degraded(_) => None,
     };
-    // Credits lead: they are the reading the account always has, and the card draws the
-    // first lengthless window it is given.
-    let mut windows = vec![credits.window()];
-    if let Some(budget) = &budget {
-        windows.push(budget.window());
-    }
     Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
         account: account_id.clone(),
         captured_at,
-        windows,
+        windows: Vec::new(),
         details: vec![credits_details(credits), key_details(key, budget.as_ref())],
     }
 }
@@ -447,7 +382,7 @@ fn snapshot_for_account(
 /// The account's money, in the source's own three rows.
 fn credits_details(credits: &Credits) -> DetailSection {
     DetailSection {
-        title: "Credits".to_owned(),
+        title: DetailSection::BALANCE.to_owned(),
         rows: vec![
             labeled("Remaining", usd(credits.balance())),
             labeled("Used", usd(credits.total_usage)),
@@ -651,49 +586,15 @@ mod tests {
     }
 
     #[test]
-    fn the_credits_are_the_first_window_and_a_key_limit_the_second() {
+    fn the_remaining_balance_is_an_amount_only_reading() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_LIMIT_USAGE)));
-        assert_eq!(snapshot.windows.len(), 2);
-
-        let credits = &snapshot.windows[0];
-        assert_eq!(credits.key.as_str(), "credits");
-        assert_eq!(credits.title, "Credits");
-        assert_eq!(credits.used_percent, 40.0, "$40 spent of the $100 added");
-        assert_eq!(credits.length, None);
-        assert_eq!(credits.resets_at, None);
-        assert_eq!(
-            credits.subtitle.as_deref(),
-            Some("$40.00 of $100.00 used · $60.00 left")
+        assert!(
+            snapshot.windows.is_empty(),
+            "a remaining balance says nothing about a percentage"
         );
-
-        let window = &snapshot.windows[1];
-        assert_eq!(window.key.as_str(), "balance");
-        assert_eq!(window.title, "API key budget");
-        assert_eq!(window.used_percent, 25.0);
-        assert_eq!(window.length, None);
-        assert_eq!(window.resets_at, None);
-        assert_eq!(
-            window.subtitle.as_deref(),
-            Some("$5.00 of $20.00 used · $15.00 left")
-        );
-    }
-
-    #[test]
-    fn credits_with_nothing_behind_them_are_drawn_by_whether_anything_was_spent() {
-        let untouched = Credits {
-            total_credits: 0.0,
-            total_usage: 0.0,
-        };
-        assert_eq!(untouched.window().used_percent, 0.0);
-        let spent = Credits {
-            total_credits: 0.0,
-            total_usage: 4.0,
-        };
-        assert_eq!(
-            spent.window().used_percent,
-            100.0,
-            "spend against no credits is a broken configuration, drawn full"
-        );
+        assert_eq!(snapshot.details[0].title, DetailSection::BALANCE);
+        assert_eq!(row_of(&snapshot, "Remaining").value, "\u{24}60.00");
+        assert_eq!(row_of(&snapshot, "API key budget").value, "\u{24}20.00");
     }
 
     #[test]
@@ -708,11 +609,8 @@ mod tests {
     }
 
     #[test]
-    fn a_key_without_a_limit_still_draws_the_credits_and_says_so() {
+    fn a_key_without_a_limit_still_reports_its_detail() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_EMPTY)));
-        assert_eq!(snapshot.windows.len(), 1);
-        assert_eq!(snapshot.windows[0].key.as_str(), "credits");
-        assert_eq!(snapshot.windows[0].used_percent, 40.0);
         assert_eq!(
             row_of(&snapshot, "API key budget").value,
             "No limit configured"
@@ -720,15 +618,12 @@ mod tests {
     }
 
     #[test]
-    fn the_server_reported_remaining_drives_the_window() {
+    fn the_server_reported_remaining_drives_the_balance_detail() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_REMAINING)));
-        let window = &snapshot.windows[1];
-        assert!(
-            (window.used_percent - 9.0914810042).abs() < 1e-9,
-            "{}",
-            window.used_percent
+        assert_eq!(
+            row_of(&snapshot, "API key remaining").value,
+            format!("{}454.54", char::from(36))
         );
-        assert_eq!(row_of(&snapshot, "API key remaining").value, "$454.54");
         assert_eq!(row_of(&snapshot, "Reset window").value, "monthly");
     }
 
@@ -736,21 +631,20 @@ mod tests {
     fn a_missing_remaining_falls_back_to_the_reset_window_usage() {
         for body in [KEY_MONTHLY_NO_REMAINING, KEY_MONTHLY_ONLY] {
             let snapshot = snapshot_with(&KeyState::Data(key_data(body)));
-            assert_eq!(snapshot.windows.len(), 2, "{body}");
-            assert!(
-                (snapshot.windows[1].used_percent - 9.0914810042).abs() < 1e-9,
-                "{body}: {}",
-                snapshot.windows[1].used_percent
+            assert_eq!(
+                row_of(&snapshot, "API key remaining").value,
+                format!("{}454.54", char::from(36))
             );
-            assert_eq!(row_of(&snapshot, "API key remaining").value, "$454.54");
         }
     }
 
     #[test]
-    fn a_negative_remaining_is_an_exhausted_quota() {
+    fn a_negative_remaining_is_an_exhausted_balance_detail() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_NEGATIVE_REMAINING)));
-        assert_eq!(snapshot.windows[1].used_percent, 100.0);
-        assert_eq!(row_of(&snapshot, "API key remaining").value, "$0.00");
+        assert_eq!(
+            row_of(&snapshot, "API key remaining").value,
+            format!("{}0.00", char::from(36))
+        );
     }
 
     #[test]
@@ -764,11 +658,12 @@ mod tests {
     }
 
     #[test]
-    fn a_degraded_key_request_leaves_the_credits_and_says_why() {
+    fn a_degraded_key_request_leaves_the_balance_details_and_says_why() {
         let snapshot = snapshot_with(&KeyState::Degraded("HTTP 500".to_owned()));
-        assert_eq!(snapshot.windows.len(), 1, "the credits still measure");
-        assert_eq!(snapshot.windows[0].key.as_str(), "credits");
-        assert_eq!(row_of(&snapshot, "Remaining").value, "$60.00");
+        assert_eq!(
+            row_of(&snapshot, "Remaining").value,
+            format!("{}60.00", char::from(36))
+        );
         assert_eq!(
             row_of(&snapshot, "API key budget").value,
             "Unavailable right now · HTTP 500"


### PR DESCRIPTION
## Summary
- publish OpenRouter credits as a balance-only reading instead of percentage windows
- preserve API-key budget and usage data in detail rows
- cover the snapshot shape that drives the card's dollar-balance display

## Verification
- `cargo fmt --check`
- `cargo clippy -p tidemark-core --all-targets -- -D warnings`
- `cargo test -p tidemark-core openrouter::tests`
- `cargo test -p tidemark card::tests::a_balance_only_reading_shows_its_amount_instead_of_a_placeholder`