### PR TITLE
feat(ui): redesign balance-only cards

### DIFF
--- a/crates/tidemark-core/src/providers/keyed/deepseek.rs
+++ b/crates/tidemark-core/src/providers/keyed/deepseek.rs
@@ -73,9 +73,9 @@ impl Balance {
         if self.currency == "CNY" { "¥" } else { "$" }
     }
 
-    /// An amount in this currency, to the cent, the way the source formats it.
+    /// An amount in this currency, retaining up to four meaningful fraction digits.
     fn amount(&self, value: f64) -> String {
-        format!("{}{value:.2}", self.symbol())
+        super::currency_amount(self.symbol(), value)
     }
 }
 
@@ -128,7 +128,7 @@ pub fn parse_for_account(
         None => vec![
             DetailRow {
                 label: "Balance".to_owned(),
-                value: "$0.00".to_owned(),
+                value: super::currency_amount("$", 0.0),
             },
             DetailRow {
                 label: "Status".to_owned(),
@@ -215,7 +215,7 @@ mod tests {
     }"#;
 
     /// Recorded by CodexBar, same file — "prefers positive CNY balance over empty USD
-    /// balance". Its own test asserts the CNY row wins and the card says `¥100.00`.
+    /// balance". Its own test asserts the CNY row wins; the fixture carries `¥100.00`.
     const EMPTY_USD_BESIDE_FUNDED_CNY: &str = r#"{
       "is_available": true,
       "balance_infos": [
@@ -258,9 +258,9 @@ mod tests {
         assert_eq!(
             rows(&snapshot),
             [
-                ("Balance".to_owned(), "$50.00".to_owned()),
-                ("Paid".to_owned(), "$40.00".to_owned()),
-                ("Granted".to_owned(), "$10.00".to_owned()),
+                ("Balance".to_owned(), "$50".to_owned()),
+                ("Paid".to_owned(), "$40".to_owned()),
+                ("Granted".to_owned(), "$10".to_owned()),
             ]
         );
         assert_eq!(snapshot.provider.as_str(), PROVIDER_ID);
@@ -272,9 +272,9 @@ mod tests {
         assert_eq!(
             rows(&snapshot),
             [
-                ("Balance".to_owned(), "¥100.00".to_owned()),
-                ("Paid".to_owned(), "¥100.00".to_owned()),
-                ("Granted".to_owned(), "¥0.00".to_owned()),
+                ("Balance".to_owned(), "¥100".to_owned()),
+                ("Paid".to_owned(), "¥100".to_owned()),
+                ("Granted".to_owned(), "¥0".to_owned()),
             ],
             "an empty USD row must not hide money in another currency"
         );
@@ -286,7 +286,7 @@ mod tests {
             {"currency":"USD","total_balance":"20.00","granted_balance":"5.00",
              "topped_up_balance":"15.00"}]}"#;
         let snapshot = parse(both, at(1_800_000_000)).expect("parses");
-        assert_eq!(rows(&snapshot)[0].1, "$20.00");
+        assert_eq!(rows(&snapshot)[0].1, "$20");
     }
 
     #[test]
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(
             rows(&snapshot),
             [
-                ("Balance".to_owned(), "$0.00".to_owned()),
+                ("Balance".to_owned(), "$0".to_owned()),
                 (
                     "Status".to_owned(),
                     "Add credits at platform.deepseek.com".to_owned()
@@ -312,7 +312,7 @@ mod tests {
         // with nothing in it, not an unreadable response.
         let none = r#"{"is_available":true,"balance_infos":[]}"#;
         let snapshot = parse(none, at(1_800_000_000)).expect("parses");
-        assert_eq!(rows(&snapshot)[0].1, "$0.00");
+        assert_eq!(rows(&snapshot)[0].1, "$0");
         assert_eq!(rows(&snapshot)[1].0, "Status");
         assert!(snapshot.windows.is_empty());
     }
@@ -326,7 +326,7 @@ mod tests {
         assert_eq!(
             rows(&snapshot),
             [
-                ("Balance".to_owned(), "$5.00".to_owned()),
+                ("Balance".to_owned(), "$5".to_owned()),
                 ("Status".to_owned(), "Unavailable for API calls".to_owned()),
             ]
         );
@@ -365,7 +365,7 @@ mod tests {
             "total_balance":"1.50","granted_balance":"0.00","topped_up_balance":"1.50",
             "frozen_balance":"9.00"}]}"#;
         let snapshot = parse(body, at(1_800_000_000)).expect("parses");
-        assert_eq!(rows(&snapshot)[0].1, "$1.50");
+        assert_eq!(rows(&snapshot)[0].1, "$1.5");
     }
 
     #[test]

--- a/crates/tidemark-core/src/providers/keyed/mod.rs
+++ b/crates/tidemark-core/src/providers/keyed/mod.rs
@@ -504,6 +504,21 @@ pub fn base_url(options: &Options, name: &str, default: &str) -> Result<String, 
     Ok(raw.to_owned())
 }
 
+/// A currency amount with at most four meaningful fraction digits.
+///
+/// Provider balances can be much smaller than one cent. Four digits retain those readings
+/// without padding ordinary whole-dollar and cent values with zeroes.
+fn currency_amount(symbol: &str, value: f64) -> String {
+    let mut amount = format!("{symbol}{value:.4}");
+    while amount.ends_with('0') {
+        amount.pop();
+    }
+    if amount.ends_with('.') {
+        amount.pop();
+    }
+    amount
+}
+
 /// Strips the query string — where [`Auth::Query`] carries the credential — off every
 /// `reqwest::Error` before it can be rendered.
 ///
@@ -580,6 +595,13 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
             .collect()
+    }
+
+    #[test]
+    fn currency_amount_keeps_up_to_four_meaningful_fraction_digits() {
+        assert_eq!(currency_amount("$", 60.0), "$60");
+        assert_eq!(currency_amount("$", 1.93), "$1.93");
+        assert_eq!(currency_amount("$", 454.542_594_979), "$454.5426");
     }
 
     fn snapshot_of(id: &str, captured_at: Timestamp) -> Snapshot {

--- a/crates/tidemark-core/src/providers/keyed/openrouter.rs
+++ b/crates/tidemark-core/src/providers/keyed/openrouter.rs
@@ -455,10 +455,10 @@ fn labeled(label: &str, value: impl ToString) -> DetailRow {
     }
 }
 
-/// The source's currency rendering: dollars, two fraction digits, negatives clamped to
-/// zero — a negative figure is a refund in the pipeline, not money to show.
+/// Dollars with up to four meaningful fraction digits, negatives clamped to zero — a
+/// negative figure is a refund in the pipeline, not money to show.
 fn usd(value: f64) -> String {
-    format!("${:.2}", value.max(0.0))
+    super::currency_amount("$", value.max(0.0))
 }
 
 #[cfg(test)]
@@ -593,19 +593,19 @@ mod tests {
             "a remaining balance says nothing about a percentage"
         );
         assert_eq!(snapshot.details[0].title, DetailSection::BALANCE);
-        assert_eq!(row_of(&snapshot, "Remaining").value, "\u{24}60.00");
-        assert_eq!(row_of(&snapshot, "API key budget").value, "\u{24}20.00");
+        assert_eq!(row_of(&snapshot, "Remaining").value, "\u{24}60");
+        assert_eq!(row_of(&snapshot, "API key budget").value, "\u{24}20");
     }
 
     #[test]
     fn the_credits_become_three_rows() {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_LIMIT_USAGE)));
-        assert_eq!(row_of(&snapshot, "Remaining").value, "$60.00");
-        assert_eq!(row_of(&snapshot, "Used").value, "$40.00");
-        assert_eq!(row_of(&snapshot, "Total added").value, "$100.00");
-        assert_eq!(row_of(&snapshot, "API key budget").value, "$20.00");
-        assert_eq!(row_of(&snapshot, "API key remaining").value, "$15.00");
-        assert_eq!(row_of(&snapshot, "API key used").value, "$5.00");
+        assert_eq!(row_of(&snapshot, "Remaining").value, "$60");
+        assert_eq!(row_of(&snapshot, "Used").value, "$40");
+        assert_eq!(row_of(&snapshot, "Total added").value, "$100");
+        assert_eq!(row_of(&snapshot, "API key budget").value, "$20");
+        assert_eq!(row_of(&snapshot, "API key remaining").value, "$15");
+        assert_eq!(row_of(&snapshot, "API key used").value, "$5");
     }
 
     #[test]
@@ -622,7 +622,7 @@ mod tests {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_REMAINING)));
         assert_eq!(
             row_of(&snapshot, "API key remaining").value,
-            format!("{}454.54", char::from(36))
+            format!("{}454.5426", char::from(36))
         );
         assert_eq!(row_of(&snapshot, "Reset window").value, "monthly");
     }
@@ -633,7 +633,7 @@ mod tests {
             let snapshot = snapshot_with(&KeyState::Data(key_data(body)));
             assert_eq!(
                 row_of(&snapshot, "API key remaining").value,
-                format!("{}454.54", char::from(36))
+                format!("{}454.5426", char::from(36))
             );
         }
     }
@@ -643,7 +643,7 @@ mod tests {
         let snapshot = snapshot_with(&KeyState::Data(key_data(KEY_NEGATIVE_REMAINING)));
         assert_eq!(
             row_of(&snapshot, "API key remaining").value,
-            format!("{}0.00", char::from(36))
+            format!("{}0", char::from(36))
         );
     }
 
@@ -654,7 +654,7 @@ mod tests {
         assert_eq!(row_of(&snapshot, "This week").value, "$0.74");
         assert_eq!(row_of(&snapshot, "This month").value, "$4.56");
         assert_eq!(row_of(&snapshot, "Rate limit").value, "120 requests / 10s");
-        assert_eq!(row_of(&snapshot, "API key remaining").value, "$19.50");
+        assert_eq!(row_of(&snapshot, "API key remaining").value, "$19.5");
     }
 
     #[test]
@@ -662,7 +662,7 @@ mod tests {
         let snapshot = snapshot_with(&KeyState::Degraded("HTTP 500".to_owned()));
         assert_eq!(
             row_of(&snapshot, "Remaining").value,
-            format!("{}60.00", char::from(36))
+            format!("{}60", char::from(36))
         );
         assert_eq!(
             row_of(&snapshot, "API key budget").value,

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -161,6 +161,9 @@ pub struct Card {
     absolutes: gtk::Label,
     rows: gtk::Box,
     balance: gtk::Label,
+    balance_only: gtk::Box,
+    balance_whole: gtk::Label,
+    balance_fraction: gtk::Label,
     footer: gtk::Label,
     shown: RefCell<Shown>,
 }
@@ -329,6 +332,42 @@ impl Card {
             .css_classes(["quota-balance"])
             .build();
 
+        // A balance with no quota windows is the card's primary reading. Keep it separate
+        // from the ordinary headline row: the amount sits vertically centred at the left,
+        // with its fraction on the same baseline in quieter type and its meaning below.
+        let balance_whole = gtk::Label::builder()
+            .halign(gtk::Align::Start)
+            .valign(gtk::Align::Baseline)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .css_classes(["numeric", "quota-balance-whole"])
+            .build();
+        let balance_fraction = gtk::Label::builder()
+            .halign(gtk::Align::Start)
+            .valign(gtk::Align::Baseline)
+            .css_classes(["numeric", "quota-balance-fraction"])
+            .build();
+        let balance_amount = gtk::Box::builder()
+            .spacing(0)
+            .valign(gtk::Align::Baseline)
+            .build();
+        balance_amount.append(&balance_whole);
+        balance_amount.append(&balance_fraction);
+        let balance_caption = gtk::Label::builder()
+            .label(DetailSection::BALANCE)
+            .halign(gtk::Align::Start)
+            .css_classes(["dim-label"])
+            .build();
+        let balance_only = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(0)
+            .halign(gtk::Align::Start)
+            .valign(gtk::Align::Center)
+            .vexpand(true)
+            .build();
+        balance_only.append(&balance_amount);
+        balance_only.append(&balance_caption);
+        balance_only.set_visible(false);
+
         // Pinned to the bottom so that cards sharing a row line their footers up: the grid
         // gives every card the height of the tallest one, and without this the extra space
         // would fall in a different place on every card.
@@ -346,6 +385,7 @@ impl Card {
         body.append(&title_row);
         body.append(&reading);
         body.append(&blank);
+        body.append(&balance_only);
         body.append(&rows);
         body.append(&balance);
         body.append(&footer);
@@ -422,6 +462,9 @@ impl Card {
             absolutes,
             rows,
             balance,
+            balance_only,
+            balance_whole,
+            balance_fraction,
             footer,
             shown: RefCell::new(Shown {
                 status: status.clone(),
@@ -487,18 +530,18 @@ impl Card {
             (Some((dominant, rest)), _) => {
                 self.reading.set_visible(true);
                 self.blank.set_visible(false);
+                self.set_balance_only(None);
+                self.footer.set_vexpand(true);
                 self.bar.widget().set_visible(true);
                 self.dominant_title.set_label(&dominant.title);
                 self.set_balance_line(balance);
                 self.rebuild_rows(rest)
             }
             (None, Some(balance)) => {
-                self.reading.set_visible(true);
+                self.reading.set_visible(false);
                 self.blank.set_visible(false);
-                self.headline.set_label(balance);
-                self.dominant_title.set_label(DetailSection::BALANCE);
-                self.bar.widget().set_visible(false);
-                self.reset.set_visible(false);
+                self.set_balance_only(Some(balance));
+                self.footer.set_vexpand(false);
                 self.set_absolutes(None);
                 self.set_balance_line(None);
                 self.rebuild_rows(&[])
@@ -506,6 +549,8 @@ impl Card {
             (None, None) => {
                 self.reading.set_visible(false);
                 self.blank.set_visible(true);
+                self.set_balance_only(None);
+                self.footer.set_vexpand(true);
                 self.set_balance_line(None);
                 let message = blank_message(status);
                 // The card shows the first `BLANK_LINES` of it; the tooltip is where the
@@ -594,6 +639,33 @@ impl Card {
             None => {
                 self.balance.set_label("");
                 self.balance.set_visible(false);
+            }
+        }
+    }
+
+    /// Shows the primary amount for a card that has no quota windows.
+    fn set_balance_only(&self, amount: Option<&str>) {
+        match amount {
+            Some(amount) => {
+                let (whole, fraction) = balance_parts(amount);
+                self.balance_whole.set_label(whole);
+                match fraction {
+                    Some(fraction) => {
+                        self.balance_fraction.set_label(fraction);
+                        self.balance_fraction.set_visible(true);
+                    }
+                    None => {
+                        self.balance_fraction.set_label("");
+                        self.balance_fraction.set_visible(false);
+                    }
+                }
+                self.balance_only.set_visible(true);
+            }
+            None => {
+                self.balance_whole.set_label("");
+                self.balance_fraction.set_label("");
+                self.balance_fraction.set_visible(false);
+                self.balance_only.set_visible(false);
             }
         }
     }
@@ -688,6 +760,26 @@ fn balance_for(status: &ProviderStatus) -> Option<&str> {
         .flatten()
 }
 
+/// Splits a formatted balance at its decimal point so the fraction can use smaller type.
+///
+/// Only the currency shape the adapters publish is split. Arbitrary provider prose stays
+/// intact rather than shrinking everything after its last full stop.
+fn balance_parts(amount: &str) -> (&str, Option<&str>) {
+    let Some(point) = amount.rfind('.') else {
+        return (amount, None);
+    };
+    let (whole, fraction) = amount.split_at(point);
+    let digits = &fraction[1..];
+    if !whole.is_empty()
+        && (1..=4).contains(&digits.len())
+        && digits.bytes().all(|digit| digit.is_ascii_digit())
+    {
+        (whole, Some(fraction))
+    } else {
+        (amount, None)
+    }
+}
+
 /// What to say on a card that has no quota window or amount-only balance.
 fn blank_message(status: &ProviderStatus) -> String {
     status
@@ -765,6 +857,12 @@ mod tests {
         status.set_state(ProviderState::Ok, None);
 
         assert_eq!(balance_for(&status), Some("$1.93"));
+    }
+
+    #[test]
+    fn a_balance_amount_separates_its_fraction_for_smaller_type() {
+        assert_eq!(balance_parts("$454.5426"), ("$454", Some(".5426")));
+        assert_eq!(balance_parts("$60"), ("$60", None));
     }
 
     #[test]

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -215,6 +215,18 @@ pub(crate) const STYLE: &str = "
     font-size: 1.2em;
 }
 
+/* A balance-only card treats money as its primary reading. The fraction is a little quieter
+   without losing the shared baseline, while the whole amount remains the visual anchor. */
+.quota-balance-whole {
+    font-weight: 700;
+    font-size: 2.5em;
+}
+
+.quota-balance-fraction {
+    font-weight: 700;
+    font-size: 2em;
+}
+
 /* The credential pill sits in a preferences row of its own so that it gets the full width
    of the group — a header suffix ellipsized both of its labels, and neither `Tidemark
    login` nor `Claude Code login` can be shortened without becoming a guess. A plain


### PR DESCRIPTION
## Summary
- format OpenRouter and DeepSeek balances with up to four meaningful fractional digits and omit trailing zeroes
- give balance-only cards a larger, vertically centered, left-aligned amount with a smaller fractional part and a Balance caption below
- preserve the existing layout for cards that also contain quota windows

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1537 passed)
- `./scripts/check-layering.sh`
- balance-only presentation visually verified