### PR TITLE
fix(quota): suppress unavailable quota windows

### DIFF
--- a/crates/tidemark-cli/src/format/json.rs
+++ b/crates/tidemark-cli/src/format/json.rs
@@ -54,6 +54,7 @@ mod tests {
             used_percent: 72.0,
             resets_at: Some(1_785_708_000),
             length_secs: Some(18_000),
+            blocked_by: None,
         }];
         let text = render(&[&status]).expect("serializes");
         let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");

--- a/crates/tidemark-cli/src/format/text.rs
+++ b/crates/tidemark-cli/src/format/text.rs
@@ -88,6 +88,7 @@ mod tests {
             used_percent,
             resets_at,
             length_secs: Some(18_000),
+            blocked_by: None,
         }
     }
 

--- a/crates/tidemark-cli/src/format/waybar.rs
+++ b/crates/tidemark-cli/src/format/waybar.rs
@@ -148,6 +148,7 @@ mod tests {
             used_percent,
             resets_at: Some(NOW + 3_600),
             length_secs: Some(18_000),
+            blocked_by: None,
         }];
         status
     }

--- a/crates/tidemark-cli/src/guard.rs
+++ b/crates/tidemark-cli/src/guard.rs
@@ -106,6 +106,7 @@ mod tests {
             used_percent,
             resets_at: None,
             length_secs: Some(18_000),
+            blocked_by: None,
         }
     }
 

--- a/crates/tidemark-core/src/providers/availability.rs
+++ b/crates/tidemark-core/src/providers/availability.rs
@@ -1,0 +1,68 @@
+//! Provider-declared quota ladders.
+//!
+//! A longer window only disables a shorter one when both belong to the same quota pool.
+//! Window duration alone is insufficient: many providers publish separate model, MCP, or
+//! product allowances with the same cadence.
+
+use tidemark_types::{Snapshot, Window, WindowKey};
+
+/// The providers whose APIs expose one consumable rate-limit ladder as five-hour, weekly,
+/// and, where present, monthly windows. Providers outside this list may expose windows of the
+/// same durations for unrelated products, so their readings must remain independent.
+fn has_limit_ladder(provider: &str) -> bool {
+    matches!(
+        provider,
+        "alibaba"
+            | "antigravity"
+            | "claude"
+            | "clinepass"
+            | "codex"
+            | "commandcode"
+            | "factory"
+            | "kimi"
+            | "minimax"
+            | "ollama"
+            | "opencode"
+            | "opencodego"
+            | "sakana"
+            | "stepfun"
+            | "sub2api"
+            | "zai"
+            | "zenmux"
+    )
+}
+
+/// Returns the full, longer window that makes `candidate` unusable.
+///
+/// The closest full parent wins so a five-hour bar explains its weekly ceiling even when a
+/// monthly ceiling is also full. Kimi is the one documented exception to the pool-key rule:
+/// its burst limiter is `rate/w18000`, while the shared plan allowance is `w604800`.
+pub fn blocked_by<'a>(snapshot: &'a Snapshot, candidate: &Window) -> Option<&'a Window> {
+    if !has_limit_ladder(snapshot.provider.as_str()) {
+        return None;
+    }
+    let candidate_length = candidate.length?.as_secs();
+
+    snapshot
+        .windows
+        .iter()
+        .filter(|window| {
+            window.used_percent >= 100.0
+                && window
+                    .length
+                    .is_some_and(|length| length.as_secs() > candidate_length)
+                && same_ladder(snapshot.provider.as_str(), &candidate.key, &window.key)
+        })
+        .min_by_key(|window| window.length.map(|length| length.as_secs()))
+}
+
+fn same_ladder(provider: &str, candidate: &WindowKey, blocker: &WindowKey) -> bool {
+    (provider == "kimi" && candidate.as_str() == "rate/w18000" && blocker.as_str() == "w604800")
+        || pool(candidate) == pool(blocker)
+}
+
+/// The prefix before the final duration key is a provider-supplied quota-pool identity.
+/// Flat duration keys are the provider's one default pool.
+fn pool(key: &WindowKey) -> Option<&str> {
+    key.as_str().rsplit_once("/w").map(|(pool, _)| pool)
+}

--- a/crates/tidemark-core/src/providers/mod.rs
+++ b/crates/tidemark-core/src/providers/mod.rs
@@ -23,12 +23,15 @@
 //! an entry of an *unrecognized* kind is skipped, because that is a quota type that did
 //! not exist when this was written, not a failure to understand one that did.
 
+mod availability;
+
 pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod http;
 pub mod keyed;
 
+pub use availability::blocked_by;
 pub use keyed::{kimi, zai};
 
 use std::fmt;
@@ -360,6 +363,98 @@ impl ProviderError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tidemark_types::{Window, WindowKey};
+
+    fn window(key: &str, seconds: u64, used_percent: f64) -> Window {
+        Window {
+            key: WindowKey::named(key),
+            title: key.into(),
+            subtitle: None,
+            used_percent,
+            resets_at: None,
+            length: WindowLength::from_secs(seconds),
+        }
+    }
+
+    fn snapshot(provider: &str, windows: Vec<Window>) -> Snapshot {
+        Snapshot {
+            provider: ProviderId::new(provider),
+            account: AccountId::default(),
+            captured_at: Timestamp::from_unix(1_785_700_000).expect("plausible"),
+            windows,
+            details: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn known_limit_ladders_disable_shorter_windows() {
+        for provider in [
+            "alibaba",
+            "antigravity",
+            "claude",
+            "clinepass",
+            "codex",
+            "commandcode",
+            "factory",
+            "minimax",
+            "ollama",
+            "opencode",
+            "opencodego",
+            "sakana",
+            "stepfun",
+            "sub2api",
+            "zai",
+            "zenmux",
+        ] {
+            let snapshot = snapshot(
+                provider,
+                vec![
+                    window("w18000", 18_000, 0.0),
+                    window("w604800", 604_800, 100.0),
+                    window("w2592000", 2_592_000, 100.0),
+                ],
+            );
+            assert_eq!(
+                blocked_by(&snapshot, &snapshot.windows[0]).map(|window| window.key.as_str()),
+                Some("w604800"),
+                "{provider}"
+            );
+            assert_eq!(
+                blocked_by(&snapshot, &snapshot.windows[1]).map(|window| window.key.as_str()),
+                Some("w2592000"),
+                "{provider}"
+            );
+        }
+    }
+
+    #[test]
+    fn kimi_links_its_rate_lane_to_the_plan_allowance() {
+        let snapshot = snapshot(
+            "kimi",
+            vec![
+                window("rate/w18000", 18_000, 0.0),
+                window("w604800", 604_800, 100.0),
+            ],
+        );
+
+        assert_eq!(
+            blocked_by(&snapshot, &snapshot.windows[0]).map(|window| window.key.as_str()),
+            Some("w604800")
+        );
+    }
+
+    #[test]
+    fn a_full_limit_never_crosses_into_a_different_pool() {
+        let snapshot = snapshot(
+            "zai",
+            vec![
+                window("w18000", 18_000, 0.0),
+                window("mcp/w2592000", 2_592_000, 100.0),
+            ],
+        );
+
+        assert!(blocked_by(&snapshot, &snapshot.windows[0]).is_none());
+    }
 
     #[test]
     fn a_credential_never_prints_itself() {

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -402,6 +402,9 @@ pub struct WindowStatus {
     pub resets_at: Option<i64>,
     /// Window length in seconds, when the provider said or it could be derived.
     pub length_secs: Option<u64>,
+    /// Full window key that currently makes this quota unusable. Absent when the quota is
+    /// usable or when an older daemon did not publish dependency information.
+    pub blocked_by: Option<String>,
 }
 
 impl WindowStatus {
@@ -414,6 +417,7 @@ impl WindowStatus {
             used_percent: window.used_percent,
             resets_at: window.resets_at.map(Timestamp::as_unix),
             length_secs: window.length.map(WindowLength::as_secs),
+            blocked_by: None,
         }
     }
 
@@ -1049,6 +1053,12 @@ mod tests {
             .deserialize()
             .expect("decodes without the new key");
         assert_eq!(decoded.account_label, None);
+    }
+
+    #[test]
+    fn an_unblocked_window_publishes_no_blocking_key() {
+        let published = WindowStatus::from_window(&window(None));
+        assert_eq!(published.blocked_by, None);
     }
 
     #[test]

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -219,13 +219,14 @@ fn statuses() -> Vec<ProviderStatus> {
         "claude",
         "max",
         vec![
-            // The case the bar is designed around: a window the provider gave no reset
-            // time for, so there is no pace mark to draw.
-            window("5 hours", 18_000, 12.0, None),
-            window("1 week", 604_800, 61.0, Some(3 * 86_400)),
+            // The rolling allowance appears unused, but the full weekly allowance makes it
+            // unusable until that weekly reset.
+            window("5 hours", 18_000, 0.0, Some(4 * 3_600)),
+            window("1 week", 604_800, 100.0, Some(3 * 86_400)),
             window("1 week (Opus)", 604_800, 4.0, Some(3 * 86_400)),
         ],
     );
+    claude.windows[0].blocked_by = Some("w604800".to_owned());
     claude.next_poll_at = Some(Timestamp::now().as_unix() + 40);
     // Reading Claude Code's own file, which is there and which Tidemark refreshes in
     // place: the case the write-back sentence exists for.

--- a/crates/tidemark/src/bar.rs
+++ b/crates/tidemark/src/bar.rs
@@ -38,6 +38,8 @@ const CLASS_BAR: &str = "quota-bar";
 const CLASS_WARNING: &str = "quota-warning";
 /// Added at [`DANGER_AT`].
 const CLASS_DANGER: &str = "quota-danger";
+/// Standard symbolic padlock centered over a quota that a full parent window blocks.
+const LOCK_ICON: &str = "changes-prevent-symbolic";
 
 /// How loud the fill is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +61,10 @@ pub fn tone(used_percent: f64) -> Tone {
     } else {
         Tone::Normal
     }
+}
+
+fn lock_icon(blocked: bool) -> Option<&'static str> {
+    blocked.then_some(LOCK_ICON)
 }
 
 /// Where the ink goes, in widget coordinates.
@@ -97,7 +103,9 @@ struct Reading {
 /// remaining window, and updates them in place for the life of the card.
 #[derive(Debug, Clone)]
 pub struct QuotaBar {
+    overlay: gtk::Overlay,
     area: gtk::DrawingArea,
+    lock: gtk::Image,
     reading: Rc<Cell<Reading>>,
 }
 
@@ -110,6 +118,16 @@ impl QuotaBar {
             .css_classes([CLASS_BAR])
             .build();
         let reading = Rc::new(Cell::new(Reading::default()));
+        let lock = gtk::Image::builder()
+            .icon_name(LOCK_ICON)
+            .pixel_size(16)
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .visible(false)
+            .build();
+        let overlay = gtk::Overlay::new();
+        overlay.set_child(Some(&area));
+        overlay.add_overlay(&lock);
 
         area.set_draw_func({
             let reading = Rc::clone(&reading);
@@ -124,12 +142,17 @@ impl QuotaBar {
             }
         });
 
-        Self { area, reading }
+        Self {
+            overlay,
+            area,
+            lock,
+            reading,
+        }
     }
 
     /// The widget to pack.
-    pub fn widget(&self) -> &gtk::DrawingArea {
-        &self.area
+    pub fn widget(&self) -> &gtk::Overlay {
+        &self.overlay
     }
 
     /// Shows a reading. `pace` is [`tidemark_types::Window::pace`] — `None` whenever the
@@ -148,6 +171,18 @@ impl QuotaBar {
         }
 
         self.area.queue_draw();
+    }
+
+    /// Dims an unavailable quota while keeping its padlock legible over the bar.
+    pub fn set_blocked(&self, blocked: bool) {
+        self.area.set_opacity(if blocked { 0.5 } else { 1.0 });
+        match lock_icon(blocked) {
+            Some(icon) => {
+                self.lock.set_icon_name(Some(icon));
+                self.lock.set_visible(true);
+            }
+            None => self.lock.set_visible(false),
+        }
     }
 }
 
@@ -221,6 +256,12 @@ mod tests {
 
     const WIDTH: f64 = 200.0;
     const HEIGHT: f64 = 12.0;
+
+    #[test]
+    fn only_a_blocked_bar_selects_the_lock_icon() {
+        assert_eq!(lock_icon(false), None);
+        assert_eq!(lock_icon(true), Some("changes-prevent-symbolic"));
+    }
 
     fn at(used: f64, pace: Option<f64>) -> Geometry {
         geometry(WIDTH, HEIGHT, used, pace)

--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -143,6 +143,15 @@ fn account_toggle_state(extra_accounts: usize, expanded: bool) -> AccountToggleS
     }
 }
 
+/// The full window that currently makes this status window unavailable.
+fn blocking_key<'a>(status: &'a ProviderStatus, key: &str) -> Option<&'a str> {
+    status
+        .windows
+        .iter()
+        .find(|window| window.key == key)
+        .and_then(|window| window.blocked_by.as_deref())
+}
+
 /// A provider card.
 #[derive(Debug)]
 pub struct Card {
@@ -535,7 +544,7 @@ impl Card {
                 self.bar.widget().set_visible(true);
                 self.dominant_title.set_label(&dominant.title);
                 self.set_balance_line(balance);
-                self.rebuild_rows(rest)
+                self.rebuild_rows(rest, status)
             }
             (None, Some(balance)) => {
                 self.reading.set_visible(false);
@@ -544,7 +553,7 @@ impl Card {
                 self.footer.set_vexpand(false);
                 self.set_absolutes(None);
                 self.set_balance_line(None);
-                self.rebuild_rows(&[])
+                self.rebuild_rows(&[], status)
             }
             (None, None) => {
                 self.reading.set_visible(false);
@@ -558,7 +567,7 @@ impl Card {
                 // the settings pane.
                 self.blank.set_tooltip_text(Some(&message));
                 self.blank.set_label(&message);
-                self.rebuild_rows(&[])
+                self.rebuild_rows(&[], status)
             }
         };
 
@@ -590,17 +599,25 @@ impl Card {
             return;
         };
 
+        let blocked = blocking_key(&shown.status, dominant.key.as_str()).is_some();
+        let opacity = if blocked { 0.5 } else { 1.0 };
         self.headline
             .set_label(&format::percent(dominant.used_percent));
+        self.headline.set_opacity(opacity);
         self.bar.set(dominant.used_percent, dominant.pace(now));
-        match dominant.seconds_until_reset(now) {
-            Some(seconds) => {
-                self.reset.set_label(&format::resets_in(seconds));
-                self.reset.set_visible(true);
+        self.bar.set_blocked(blocked);
+        if blocked {
+            self.reset.set_visible(false);
+        } else {
+            match dominant.seconds_until_reset(now) {
+                Some(seconds) => {
+                    self.reset.set_label(&format::resets_in(seconds));
+                    self.reset.set_visible(true);
+                }
+                // No reset time is the ordinary case for the window this card leads with. The
+                // line is removed rather than filled with a guess.
+                None => self.reset.set_visible(false),
             }
-            // No reset time is the ordinary case for the window this card leads with. The
-            // line is removed rather than filled with a guess.
-            None => self.reset.set_visible(false),
         }
 
         for (bar, window) in shown.secondary.iter().zip(rest) {
@@ -671,7 +688,7 @@ impl Card {
     }
 
     /// Replaces the thin rows, returning their bars in the same order.
-    fn rebuild_rows(&self, windows: &[Window]) -> Vec<QuotaBar> {
+    fn rebuild_rows(&self, windows: &[Window], status: &ProviderStatus) -> Vec<QuotaBar> {
         while let Some(child) = self.rows.first_child() {
             self.rows.remove(&child);
         }
@@ -691,6 +708,9 @@ impl Card {
                     .build();
                 let bar = QuotaBar::new(ROW_BAR);
                 bar.widget().set_valign(gtk::Align::Center);
+                let blocked = blocking_key(status, window.key.as_str()).is_some();
+                let opacity = if blocked { 0.5 } else { 1.0 };
+                bar.set_blocked(blocked);
                 let value = gtk::Label::builder()
                     .label(format::percent(window.used_percent))
                     .halign(gtk::Align::End)
@@ -698,6 +718,7 @@ impl Card {
                     .xalign(1.0)
                     .css_classes(["dim-label", "caption", "numeric"])
                     .build();
+                value.set_opacity(opacity);
 
                 let row = gtk::Box::builder().spacing(8).build();
                 row.append(&title);
@@ -811,6 +832,7 @@ mod tests {
             used_percent,
             resets_at: Some(CAPTURED_AT + 3_600),
             length_secs,
+            blocked_by: None,
         }
     }
 
@@ -819,6 +841,15 @@ mod tests {
         status.captured_at = Some(CAPTURED_AT);
         status.windows = windows;
         status
+    }
+    #[test]
+    fn a_blocked_five_hour_window_exposes_its_full_parent() {
+        let mut five_hour = window(Some(18_000), 0.0);
+        five_hour.key = "w18000".into();
+        five_hour.blocked_by = Some("w604800".into());
+        let status = status_with(vec![five_hour]);
+
+        assert_eq!(blocking_key(&status, "w18000"), Some("w604800"));
     }
 
     #[test]

--- a/crates/tidemark/src/chart.rs
+++ b/crates/tidemark/src/chart.rs
@@ -245,6 +245,7 @@ mod tests {
             used_percent: 50.0,
             resets_at: Some(18_000),
             length_secs: Some(18_000),
+            blocked_by: None,
         }
     }
 

--- a/crates/tidemark/src/detail.rs
+++ b/crates/tidemark/src/detail.rs
@@ -407,6 +407,7 @@ mod tests {
                 used_percent: 42.0,
                 resets_at: Some(1_785_718_000),
                 length_secs: *length_secs,
+                blocked_by: None,
             })
             .collect();
         status

--- a/crates/tidemark/src/provider_settings/model.rs
+++ b/crates/tidemark/src/provider_settings/model.rs
@@ -485,6 +485,7 @@ mod tests {
                 used_percent: 0.0,
                 resets_at: None,
                 length_secs: None,
+                blocked_by: None,
             })
             .collect();
         status.notify = notify.iter().map(|key| (*key).to_string()).collect();

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use tidemark_core::config::Config;
 use tidemark_core::providers::http::{self, Proxy};
 use tidemark_core::providers::keyed::session;
-use tidemark_core::providers::{Credential, Provider, ProviderError, Source};
+use tidemark_core::providers::{Credential, Provider, ProviderError, Source, blocked_by};
 use tidemark_core::secrets::{Kind, SecretError, Secrets};
 use tidemark_core::storage::{History, IngestReport};
 use tidemark_types::{
@@ -1681,6 +1681,14 @@ impl Engine {
                 account.failures = 0;
                 account.retry_after = None;
                 account.status.set_reading(&snapshot);
+                for published in &mut account.status.windows {
+                    published.blocked_by = snapshot
+                        .windows
+                        .iter()
+                        .find(|window| window.key.as_str() == published.key)
+                        .and_then(|window| blocked_by(&snapshot, window))
+                        .map(|blocker| blocker.key.to_string());
+                }
             }
             Err(error) => {
                 let state = state_for(&error);
@@ -1765,6 +1773,9 @@ impl Engine {
             else {
                 continue;
             };
+            if blocked_by(snapshot, window).is_some() {
+                continue;
+            }
 
             let mut already = Vec::new();
             for kind in notify::Kind::ALL {
@@ -4699,12 +4710,39 @@ mod tests {
         harness.engine.poll_due(Instant::now()).await;
         assert!(harness.notices.summaries().is_empty());
     }
+    #[tokio::test]
+    async fn a_full_week_is_published_as_the_five_hour_window_parent() {
+        let mut reading = two_windows(0.0, 100.0, 3600);
+        reading.provider = ProviderId::new("codex");
+        let mut harness = with_provider(Fake::new(vec![Ok(reading)]));
+
+        harness.engine.poll_due(Instant::now()).await;
+
+        let published = harness.published();
+        let five_hour = published[0]
+            .windows
+            .iter()
+            .find(|window| window.key == "w18000")
+            .expect("five-hour window");
+        assert_eq!(five_hour.blocked_by.as_deref(), Some("w604800"));
+    }
 
     fn notifying(provider: Arc<dyn Provider>) -> Harness {
         Harness::new(
             vec![Account::with_client(provider).with_notify(vec!["w18000".to_owned()])],
             unlocked(),
         )
+    }
+
+    #[tokio::test]
+    async fn a_full_week_silences_notifications_for_its_five_hour_quota() {
+        let mut reading = two_windows(85.0, 100.0, 3600);
+        reading.provider = ProviderId::new("codex");
+        let mut harness = notifying(Fake::new(vec![Ok(reading)]));
+
+        harness.engine.poll_due(Instant::now()).await;
+
+        assert!(harness.notices.summaries().is_empty());
     }
 
     #[tokio::test]

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -4070,6 +4070,7 @@ mod tests {
             used_percent: 42.0,
             resets_at: None,
             length_secs: Some(18_000),
+            blocked_by: None,
         }];
         let (daemon, _secrets, mut commands) = daemon_over(vec![zai]).await;
         let daemon = Arc::new(daemon);


### PR DESCRIPTION
## Summary

- Prevents a shorter quota from appearing usable when a full weekly or monthly quota blocks it.
- Closes #53.

## Changes

- Model supported provider quota ladders and keep distinct model, product, and MCP pools independent.
- Publish the blocking parent over D-Bus and suppress notifications for the unavailable child window.
- Dim unavailable quota bars, hide their reset time, and center GTK's symbolic lock icon over the bar.

## QA & Evidence

- **What was tested:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `./scripts/check-layering.sh`.
  **Observed result:** Formatting and Clippy completed without diagnostics; 1545 tests passed; layering check reported `layering ok`.
  **Artifact:** Local validation output; CI will rerun these commands.
  **Why sufficient:** Covers compilation, unit/integration behavior, lint policy, and crate-boundary policy.

- **What was tested:** Tidemark connected to the updated mock daemon in an isolated D-Bus session.
  **Observed result:** A 0% five-hour Claude quota blocked by a full weekly quota was dimmed, had no reset label, and displayed a centered lock.
  **Artifact:** Not attached per author request.
  **Why sufficient:** Exercises the daemon wire state and the rendered GTK card together.

## Risks & Residuals

- **Risk:** Equal-duration windows can be unrelated model, product, or MCP pools.
  **Conclusion:** Mitigated: blocking applies only to the supported provider ladders and matching pool keys; Kimi's documented cross-key relationship is explicit.

- **Risk:** A provider may later change its quota hierarchy.
  **Conclusion:** Accepted: the mapping is isolated in the core provider policy and covered by regression tests.

## Automated Checks

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
./scripts/check-layering.sh
```

## Related Issues

Closes #53