### PR TITLE
feat(grid): replace the three-column cap with an Auto/Manual preference

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -485,11 +485,12 @@ history that does not exist yet.
 
 ## Interface
 
-- **Grid of provider cards**, one to three columns by width, **in the order the user put
-  them in**. Nothing else ever changes that order: there is no urgency sort underneath it,
-  a new account goes on the end, and the sequence is persisted by the daemon and
-  republished to every client. The grid the tray menu lists and the grid the settings
-  dialog lists are this one.
+- **Grid of provider cards**, columns by width, **in the order the user put them in**.
+  How many columns the width turns into is a preference: Auto (the default) fits as many
+  columns as the window holds, and Manual caps the count at a chosen ceiling. Nothing else
+  ever changes that order: there is no urgency sort underneath it, a new account goes on
+  the end, and the sequence is persisted by the daemon and republished to every client.
+  The grid the tray menu lists and the grid the settings dialog lists are this one.
 - **The grid is a widget of ours, not a `GtkFlowBox`.** Reordering has to be *live* — the
   cards a held card displaces move out of its way before the button is released, and move
   back if the pointer changes its mind — and `gtk_flow_box_invalidate_sort()` sorts a

--- a/crates/tidemark-cli/src/cli.rs
+++ b/crates/tidemark-cli/src/cli.rs
@@ -120,6 +120,14 @@ pub enum ConfigCommand {
         #[arg(long)]
         minutes: Option<u32>,
     },
+    /// How many card columns the window lays out.
+    Columns {
+        /// auto or manual.
+        mode: String,
+        /// Most columns in manual mode, at least 1.
+        #[arg(long)]
+        max: Option<u32>,
+    },
     /// forever, six-months or one-year.
     Retention { retention: String },
     /// system, light or dark.

--- a/crates/tidemark-cli/src/commands/config.rs
+++ b/crates/tidemark-cli/src/commands/config.rs
@@ -36,6 +36,15 @@ pub async fn run(proxy: &DaemonProxy<'_>, command: ConfigCommand) -> Result<Exit
             }
             proxy.set_refresh_mode(&mode).await?;
         }
+        ConfigCommand::Columns { mode, max } => {
+            // The ceiling first, mirroring the refresh shape: the mode is what the
+            // window reads, and the ceiling it would read should already be the new one.
+            if let Some(max) = max {
+                proxy.set_max_columns(max).await?;
+            }
+            proxy.set_columns_auto(&mode == "auto").await?;
+        }
+
         ConfigCommand::Retention { retention } => proxy.set_history_retention(&retention).await?,
         ConfigCommand::Theme { theme } => proxy.set_theme(&theme).await?,
         ConfigCommand::Startup { mode } => proxy.set_startup_mode(&mode).await?,
@@ -66,12 +75,25 @@ fn show(preferences: &Preferences) -> String {
     row("retention", &preferences.history_retention);
     row("refresh", &preferences.refresh_mode);
     row("refresh-minutes", &preferences.refresh_minutes.to_string());
+    row(
+        "columns",
+        columns_mode(preferences.columns_auto.unwrap_or(true)),
+    );
+    row(
+        "columns-max",
+        &preferences.max_columns.unwrap_or(3).to_string(),
+    );
     row("proxy", &preferences.proxy_mode);
     row("proxy-host", &preferences.proxy_host);
     row("proxy-port", &preferences.proxy_port.to_string());
     out
 }
 
+/// The word `config columns` takes for a switch state, so `show` output feeds back in the
+/// way the refresh rows do.
+const fn columns_mode(auto: bool) -> &'static str {
+    if auto { "auto" } else { "manual" }
+}
 const fn switch(enabled: bool) -> &'static str {
     if enabled { "on" } else { "off" }
 }
@@ -102,5 +124,31 @@ mod tests {
             ..Preferences::default()
         };
         assert!(show(&preferences).contains("theme               system"));
+    }
+
+    #[test]
+    fn the_column_settings_print_as_named_modes_with_a_ceiling() {
+        let preferences = Preferences {
+            columns_auto: Some(false),
+            max_columns: Some(7),
+            ..Preferences::default()
+        };
+        let out = show(&preferences);
+        assert!(out.contains("columns             manual"), "{out}");
+        assert!(out.contains("columns-max         7"), "{out}");
+    }
+
+    /// A daemon too old to publish the column settings sends them absent, which means
+    /// Auto over the ceiling the grid was built around.
+    #[test]
+    fn absent_column_settings_read_as_auto_with_the_builtin_ceiling() {
+        let preferences = Preferences {
+            columns_auto: None,
+            max_columns: None,
+            ..Preferences::default()
+        };
+        let out = show(&preferences);
+        assert!(out.contains("columns             auto"), "{out}");
+        assert!(out.contains("columns-max         3"), "{out}");
     }
 }

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -67,6 +67,9 @@ const PROXY_PORT_KEY: &str = "port";
 const REFRESH_TABLE: &str = "refresh";
 const REFRESH_MODE_KEY: &str = "mode";
 const REFRESH_MINUTES_KEY: &str = "minutes";
+const GRID_TABLE: &str = "grid";
+const COLUMNS_AUTO_KEY: &str = "auto";
+const MAX_COLUMNS_KEY: &str = "max";
 
 /// Why the settings could not be read or written.
 #[derive(Debug, thiserror::Error)]
@@ -259,6 +262,24 @@ impl Config {
                     )
                 })?,
         };
+        // The same refusal for the column ceiling, with no upper bound to check: the
+        // window's own width caps the real count, so only zero (and nonsense types) is
+        // wrong. Absent in the file is still a decided value here — the wire dictionary's
+        // absent-means-unknown is for reading *other* versions, and this is our own store.
+        let max_columns = match self.preference(GRID_TABLE, MAX_COLUMNS_KEY)? {
+            None => 3,
+            Some(item) => item
+                .as_integer()
+                .and_then(|columns| u32::try_from(columns).ok())
+                .filter(|columns| Preferences::valid_max_columns(*columns))
+                .ok_or_else(|| {
+                    self.invalid_preference(
+                        GRID_TABLE,
+                        MAX_COLUMNS_KEY,
+                        "must be a whole number of at least 1".into(),
+                    )
+                })?,
+        };
         Ok(Preferences {
             release_check: self
                 .preference_bool(UPDATES_TABLE, RELEASE_CHECK_KEY)?
@@ -277,6 +298,11 @@ impl Config {
             proxy_port: self.preference_port(PROXY_TABLE, PROXY_PORT_KEY)?,
             refresh_mode,
             refresh_minutes,
+            columns_auto: Some(
+                self.preference_bool(GRID_TABLE, COLUMNS_AUTO_KEY)?
+                    .unwrap_or(true),
+            ),
+            max_columns: Some(max_columns),
         })
     }
 
@@ -379,6 +405,23 @@ impl Config {
             REFRESH_MINUTES_KEY,
             value(i64::from(minutes)),
         )
+    }
+
+    /// Chooses whether the client fits as many card columns as the window allows.
+    pub fn set_columns_auto(&mut self, enabled: bool) -> Result<(), ConfigError> {
+        self.set_preference(GRID_TABLE, COLUMNS_AUTO_KEY, value(enabled))
+    }
+
+    /// Sets the most card columns a window lays out while Auto is off.
+    pub fn set_max_columns(&mut self, columns: u32) -> Result<(), ConfigError> {
+        if !Preferences::valid_max_columns(columns) {
+            return Err(self.invalid_preference(
+                GRID_TABLE,
+                MAX_COLUMNS_KEY,
+                format!("must be at least 1, not {columns}"),
+            ));
+        }
+        self.set_preference(GRID_TABLE, MAX_COLUMNS_KEY, value(i64::from(columns)))
     }
 
     fn preference_bool(
@@ -1780,6 +1823,11 @@ mod tests {
         assert_eq!(config.preferences().expect("readable").proxy_port, 0);
         assert_eq!(config.preferences().expect("readable").refresh_mode, "auto");
         assert_eq!(config.preferences().expect("readable").refresh_minutes, 5);
+        assert_eq!(
+            config.preferences().expect("readable").columns_auto,
+            Some(true)
+        );
+        assert_eq!(config.preferences().expect("readable").max_columns, Some(3));
     }
 
     #[test]
@@ -1827,6 +1875,8 @@ mod tests {
             proxy_port: 1080,
             refresh_mode: "manual".into(),
             refresh_minutes: 30,
+            columns_auto: Some(false),
+            max_columns: Some(7),
         };
 
         config.set_release_check(false).expect("release setting");
@@ -1841,11 +1891,36 @@ mod tests {
             .expect("proxy setting");
         config.set_refresh_mode("manual").expect("refresh mode");
         config.set_refresh_minutes(30).expect("refresh minutes");
+        config.set_columns_auto(false).expect("column mode");
+        config.set_max_columns(7).expect("column ceiling");
 
         let reread = Config::at(path.clone()).expect("reloaded");
         assert_eq!(reread.preferences().expect("readable"), preferences);
         let text = std::fs::read_to_string(path).expect("read back");
         assert!(text.starts_with("# belongs to the user\n"), "{text}");
+    }
+
+    #[test]
+    fn a_column_ceiling_below_one_is_refused_rather_than_clamped() {
+        for (index, wrong) in ["max = 0", "max = -2", "max = \"many\""]
+            .into_iter()
+            .enumerate()
+        {
+            let path = scratch(&format!("preferences-grid-max-{index}"));
+            std::fs::write(&path, format!("[grid]\n{wrong}\n")).expect("seeded");
+            let config = Config::at(path.clone()).expect("valid TOML");
+
+            assert!(
+                config.preferences().is_err(),
+                "{wrong} must not silently become a ceiling"
+            );
+            let _ = std::fs::remove_file(path);
+        }
+
+        let path = scratch("preferences-grid-max-write");
+        std::fs::write(&path, "[grid]\nauto = false\n").expect("seeded");
+        let mut config = Config::at(path).expect("valid TOML");
+        assert!(config.set_max_columns(0).is_err());
     }
 
     #[test]

--- a/crates/tidemark-ipc/src/lib.rs
+++ b/crates/tidemark-ipc/src/lib.rs
@@ -118,6 +118,12 @@ pub trait Daemon {
     /// Sets the fixed interval Manual mode polls at, in minutes.
     fn set_refresh_minutes(&self, minutes: u32) -> zbus::Result<()>;
 
+    /// Chooses whether the client lays out as many card columns as the window fits.
+    fn set_columns_auto(&self, enabled: bool) -> zbus::Result<()>;
+
+    /// Sets the most card columns a window lays out while Auto is off, at least one.
+    fn set_max_columns(&self, columns: u32) -> zbus::Result<()>;
+
     /// All three proxy settings at once: they are one setting, and half of it applied is a
     /// proxy nothing can be reached through.
     fn set_proxy(&self, mode: &str, host: &str, port: u16) -> zbus::Result<()>;

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -488,6 +488,12 @@ pub struct Preferences {
     pub refresh_mode: String,
     /// Minutes between polls in manual mode, 1 to 120. Ignored while the mode is `auto`.
     pub refresh_minutes: u32,
+    /// Whether the client lays out as many card columns as the window fits. Absent means
+    /// auto, so a newer client can still read an older daemon's dictionary.
+    pub columns_auto: Option<bool>,
+    /// Most card columns when [`Self::columns_auto`] is off, at least one. Absent means
+    /// three, the width the grid was built around. Ignored while the mode is `auto`.
+    pub max_columns: Option<u32>,
 }
 
 impl Preferences {
@@ -554,6 +560,13 @@ impl Preferences {
     pub fn valid_refresh_minutes(value: u32) -> bool {
         (1..=120).contains(&value)
     }
+
+    /// Whether a column ceiling is one the daemon will store. No upper bound: the window's
+    /// own width keeps the real count honest, so a ceiling beyond any display is inert
+    /// rather than wrong, while zero would collapse every row into one column by decree.
+    pub fn valid_max_columns(value: u32) -> bool {
+        value >= 1
+    }
 }
 
 impl Default for Preferences {
@@ -569,6 +582,8 @@ impl Default for Preferences {
             proxy_port: 0,
             refresh_mode: Self::REFRESH_AUTO.into(),
             refresh_minutes: 5,
+            columns_auto: Some(true),
+            max_columns: Some(3),
         }
     }
 }
@@ -1224,11 +1239,39 @@ mod tests {
             proxy_port: 1080,
             refresh_mode: "manual".into(),
             refresh_minutes: 30,
+            columns_auto: Some(false),
+            max_columns: Some(7),
         };
 
         let encoded = to_bytes(Context::new_dbus(LE, 0), &original).expect("encodes");
         let (decoded, _): (Preferences, _) = encoded.deserialize().expect("decodes again");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn an_older_preferences_dictionary_without_the_column_settings_still_decodes() {
+        let encoded = to_bytes(Context::new_dbus(LE, 0), &Preferences::default())
+            .expect("the current dictionary encodes");
+        let (mut old_dict, _): (HashMap<String, OwnedValue>, _) =
+            encoded.deserialize().expect("decodes as a dictionary");
+        assert!(old_dict.remove("columns_auto").is_some());
+        assert!(old_dict.remove("max_columns").is_some());
+        let old_encoded =
+            to_bytes(Context::new_dbus(LE, 0), &old_dict).expect("the old dictionary encodes");
+
+        let (decoded, _): (Preferences, _) = old_encoded.deserialize().expect("still decodes");
+        assert_eq!(decoded.columns_auto, None);
+        assert_eq!(decoded.max_columns, None);
+    }
+
+    #[test]
+    fn any_positive_column_count_is_known_and_zero_is_not() {
+        assert!(Preferences::valid_max_columns(1));
+        assert!(Preferences::valid_max_columns(999));
+        assert!(!Preferences::valid_max_columns(0));
+
+        assert_eq!(Preferences::default().columns_auto, Some(true));
+        assert_eq!(Preferences::default().max_columns, Some(3));
     }
 
     #[test]

--- a/crates/tidemark/src/grid.rs
+++ b/crates/tidemark/src/grid.rs
@@ -41,9 +41,6 @@ use gtk::subclass::prelude::*;
 
 /// Space between cards, both ways. What the `GtkFlowBox` used.
 const SPACING: i32 = 12;
-/// Most columns, however wide the window gets. Three 300-pixel cards is already a wide
-/// window, and a fourth column would make each card a strip.
-const MAX_COLUMNS: usize = 3;
 /// How long a displaced card takes to get out of the way. `AdwTabGrid`'s figure.
 const REORDER_MS: u32 = 250;
 /// How long a released card takes to settle into its slot.
@@ -303,6 +300,10 @@ mod imp {
         pub(super) drag: RefCell<Option<Drag>>,
         /// Called once per completed move, with the indices it went between.
         pub(super) on_reorder: RefCell<Option<OnReorder>>,
+        /// The most columns the layout may use, or `None` to fit as many as the width
+        /// allows. `None` until a preference arrives, so a grid that never hears one lays
+        /// itself out the way Auto describes.
+        pub(super) column_cap: Cell<Option<usize>>,
         /// The layout the last allocation settled on, so the drag arithmetic and the
         /// allocation cannot come to different conclusions about where a slot is.
         pub(super) columns: Cell<usize>,
@@ -360,12 +361,16 @@ mod imp {
                 return (0, 0, -1, -1);
             }
             let cell_width = self.cell_width();
+            // The ceiling the preference set, or no ceiling at all: uncapped is what the
+            // Auto mode of the columns preference means, and `usize::MAX` is safe because
+            // `columns` bounds the count by the width before it ever looks at the cap.
+            let max = self.column_cap.get().unwrap_or(usize::MAX);
             match orientation {
                 // One column is the minimum, because a card is as narrow as it is going to
                 // get. The natural width is however many columns there are cards for, up to
-                // the maximum, which is what stops a wide window at three.
+                // the cap, which is what stops a wide window at the preference's ceiling.
                 gtk::Orientation::Horizontal => {
-                    let wanted = count.min(MAX_COLUMNS) as i32;
+                    let wanted = count.min(max) as i32;
                     (
                         cell_width,
                         wanted * cell_width + (wanted - 1) * SPACING,
@@ -375,11 +380,11 @@ mod imp {
                 }
                 _ => {
                     let available = if for_size < 0 {
-                        count.min(MAX_COLUMNS) as i32 * (cell_width + SPACING) - SPACING
+                        count.min(max) as i32 * (cell_width + SPACING) - SPACING
                     } else {
                         for_size
                     };
-                    let columns = columns(available, cell_width, SPACING, MAX_COLUMNS);
+                    let columns = columns(available, cell_width, SPACING, max);
                     let rows = count.div_ceil(columns) as i32;
                     let height = rows * self.natural_height(cell_width) + (rows - 1) * SPACING;
                     (height, height, -1, -1)
@@ -394,7 +399,12 @@ mod imp {
             }
             let cell_width = self.cell_width();
             let cell_height = self.natural_height(cell_width);
-            let columns = columns(width, cell_width, SPACING, MAX_COLUMNS);
+            let columns = columns(
+                width,
+                cell_width,
+                SPACING,
+                self.column_cap.get().unwrap_or(usize::MAX),
+            );
             self.columns.set(columns);
             self.cell
                 .set((f64::from(cell_width), f64::from(cell_height)));
@@ -484,6 +494,17 @@ impl imp::CardGrid {
 impl CardGrid {
     pub fn new() -> Self {
         glib::Object::builder().build()
+    }
+
+    /// Caps how many columns the layout uses, however wide the window gets, or lifts the
+    /// cap (`None`) to fit as many columns as the width holds.
+    ///
+    /// Applied on the next allocation, not this one: card positions are decided in
+    /// [`WidgetImpl::size_allocate`], and every part of the drag arithmetic that names a
+    /// column count reads what the last allocation settled on.
+    pub fn set_max_columns(&self, max: Option<usize>) {
+        self.imp().column_cap.set(max);
+        self.queue_resize();
     }
 
     /// Adds a card at the end. Where a new account goes, always.

--- a/crates/tidemark/src/preferences.rs
+++ b/crates/tidemark/src/preferences.rs
@@ -51,6 +51,7 @@ enum SwitchKind {
     ReleaseCheck,
     MinimizeOnClose,
     RefreshAuto,
+    ColumnsAuto,
 }
 
 /// Whether an incomplete proxy is the user's mistake or just the middle of typing one in.
@@ -71,6 +72,9 @@ pub struct PreferencesDialog {
     minimize_on_close: adw::SwitchRow,
     refresh_auto: adw::SwitchRow,
     refresh_minutes: adw::SpinRow,
+    columns_auto: adw::SwitchRow,
+    max_columns: adw::SpinRow,
+
     theme: adw::ComboRow,
     startup: adw::ComboRow,
     retention: adw::ComboRow,
@@ -154,6 +158,23 @@ impl PreferencesDialog {
             .build();
         refresh_group.add(&refresh_auto);
         refresh_group.add(&refresh_minutes);
+        let columns_auto = adw::SwitchRow::builder()
+            .title("Auto")
+            .subtitle("Column count follows the window width.")
+            .build();
+        let max_columns = adw::SpinRow::new(
+            Some(&gtk::Adjustment::new(3.0, 1.0, 999.0, 1.0, 10.0, 0.0)),
+            1.0,
+            0,
+        );
+        max_columns.set_title("Maximum columns");
+        max_columns.set_subtitle("Most columns when Auto is off.");
+        let columns_group = adw::PreferencesGroup::builder()
+            .title("Card columns")
+            .build();
+        columns_group.add(&columns_auto);
+        columns_group.add(&max_columns);
+
         let general = adw::PreferencesPage::builder()
             .title("General")
             .icon_name("preferences-system-symbolic")
@@ -162,6 +183,7 @@ impl PreferencesDialog {
         general.add(&startup);
         general.add(&theme_group);
         general.add(&refresh_group);
+        general.add(&columns_group);
         dialog.add(&general);
 
         let proxy_mode = adw::ComboRow::builder()
@@ -277,6 +299,9 @@ impl PreferencesDialog {
             minimize_on_close,
             refresh_auto,
             refresh_minutes,
+            columns_auto,
+            max_columns,
+
             theme,
             startup: startup_mode,
             retention,
@@ -296,11 +321,15 @@ impl PreferencesDialog {
         settings.connect_switch(&settings.release_check, SwitchKind::ReleaseCheck);
         settings.connect_switch(&settings.minimize_on_close, SwitchKind::MinimizeOnClose);
         settings.connect_switch(&settings.refresh_auto, SwitchKind::RefreshAuto);
+        settings.connect_switch(&settings.columns_auto, SwitchKind::ColumnsAuto);
+
         settings.connect_theme();
         settings.connect_startup();
         settings.connect_retention();
         settings.connect_proxy();
         settings.connect_refresh_minutes();
+        settings.connect_max_columns();
+
         settings.connect_clear(&clear);
         settings.apply(&preferences, &data);
 
@@ -328,6 +357,11 @@ impl PreferencesDialog {
             .set_active(preferences.refresh_mode == Preferences::REFRESH_AUTO);
         self.refresh_minutes
             .set_value(f64::from(preferences.refresh_minutes));
+        self.columns_auto
+            .set_active(preferences.columns_auto.unwrap_or(true));
+        self.max_columns
+            .set_value(f64::from(preferences.max_columns.unwrap_or(3)));
+
         apply_named_choice(
             &self.theme,
             &THEME_LABELS,
@@ -390,6 +424,7 @@ impl PreferencesDialog {
         }
         self.sync_proxy_editable();
         self.sync_refresh_editable();
+        self.sync_columns_editable();
     }
 
     /// Whether the manual interval row can be typed into, from what the Auto switch
@@ -398,6 +433,13 @@ impl PreferencesDialog {
     fn sync_refresh_editable(&self) {
         self.refresh_minutes
             .set_sensitive(manual_refresh_editable(self.refresh_auto.is_active()));
+    }
+
+    /// Whether the ceiling row can be typed into — the same contract the manual interval
+    /// row follows, read from the switch and not the store.
+    fn sync_columns_editable(&self) {
+        self.max_columns
+            .set_sensitive(manual_columns_editable(self.columns_auto.is_active()));
     }
 
     fn connect_switch(self: &Rc<Self>, row: &adw::SwitchRow, kind: SwitchKind) {
@@ -415,6 +457,10 @@ impl PreferencesDialog {
                     // locks the moment the switch flips and not a reply later.
                     settings.sync_refresh_editable();
                 }
+                if matches!(kind, SwitchKind::ColumnsAuto) {
+                    settings.sync_columns_editable();
+                }
+
                 settings.change_switch(kind, row.is_active());
             }
         });
@@ -431,6 +477,7 @@ impl PreferencesDialog {
                     let mode = refresh_mode_for(enabled);
                     self.proxy.set_refresh_mode(mode).await
                 }
+                SwitchKind::ColumnsAuto => self.proxy.set_columns_auto(enabled).await,
             };
             if let Err(error) = result {
                 let preferences = self.preferences.borrow().clone();
@@ -445,6 +492,7 @@ impl PreferencesDialog {
                     SwitchKind::RefreshAuto => {
                         preferences.refresh_mode = refresh_mode_for(enabled).to_owned();
                     }
+                    SwitchKind::ColumnsAuto => preferences.columns_auto = Some(enabled),
                 }
             }
             if !matches!(kind, SwitchKind::ReleaseCheck)
@@ -460,6 +508,7 @@ impl PreferencesDialog {
             SwitchKind::ReleaseCheck => &self.release_check,
             SwitchKind::MinimizeOnClose => &self.minimize_on_close,
             SwitchKind::RefreshAuto => &self.refresh_auto,
+            SwitchKind::ColumnsAuto => &self.columns_auto,
         }
     }
 
@@ -491,6 +540,37 @@ impl PreferencesDialog {
                     // Either way the row is redrawn from the switch, which is what
                     // restores its sensitivity under the mode that allows typing.
                     settings.sync_refresh_editable();
+                });
+            }
+        });
+    }
+
+    /// Commits the column ceiling each time the stepper settles on a value, under the same
+    /// round-trip insensitivity that bounds the commit rate of the interval row.
+    fn connect_max_columns(self: &Rc<Self>) {
+        self.max_columns.connect_value_notify({
+            let weak = Rc::downgrade(self);
+            move |row| {
+                let Some(settings) = weak.upgrade() else {
+                    return;
+                };
+                if settings.suppress.get() {
+                    return;
+                }
+                let columns = row.value() as u32;
+                row.set_sensitive(false);
+                glib::spawn_future_local(async move {
+                    if let Err(error) = settings.proxy.set_max_columns(columns).await {
+                        let preferences = settings.preferences.borrow().clone();
+                        let data = settings.data.borrow().clone();
+                        settings.apply(&preferences, &data);
+                        settings.toast(&error.to_string());
+                    } else {
+                        settings.preferences.borrow_mut().max_columns = Some(columns);
+                    }
+                    // Either way the row is redrawn from the switch, which is what
+                    // restores its sensitivity under the mode that allows typing.
+                    settings.sync_columns_editable();
                 });
             }
         });
@@ -857,6 +937,12 @@ fn refresh_mode_for(auto_active: bool) -> &'static str {
     }
 }
 
+/// Whether the ceiling row belongs to the mode the Auto switch shows right now — the same
+/// moment-between-a-toggle-and-the-answer the manual interval row handles.
+fn manual_columns_editable(auto_active: bool) -> bool {
+    !auto_active
+}
+
 fn format_bytes(bytes: u64) -> String {
     const KIB: u64 = 1024;
     const MIB: u64 = 1024 * KIB;
@@ -916,6 +1002,18 @@ mod tests {
         assert!(
             manual_refresh_editable(false),
             "manual needs a pace to read"
+        );
+    }
+
+    #[test]
+    fn the_maximum_columns_row_follows_the_auto_switch() {
+        // The same contract as the manual interval row: the switch flips before the
+        // daemon answers, so the ceiling row must lock against what the switch says and
+        // not what the store still holds.
+        assert!(!manual_columns_editable(true), "auto decides the count");
+        assert!(
+            manual_columns_editable(false),
+            "manual needs a ceiling to read"
         );
     }
 

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -662,6 +662,13 @@ impl MainWindow {
                 .as_deref()
                 .unwrap_or(AppPreferences::THEME_SYSTEM),
         );
+        // Absent means Auto: an older daemon never says, and the grid's uncapped default
+        // is the layout Auto describes. A ceiling of zero cannot arrive — the daemon
+        // refuses it before the dictionary is ever published.
+        let columns_auto = preferences.columns_auto.unwrap_or(true);
+        self.grid.set_max_columns(
+            (!columns_auto).then(|| preferences.max_columns.unwrap_or(3) as usize),
+        );
         *self.preferences.borrow_mut() = preferences;
         if let Some(dialog) = self.preferences_dialog.get() {
             dialog.apply(&self.preferences.borrow(), &self.data_info.borrow());

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -66,6 +66,9 @@ pub enum Preference {
     HistoryRetention(String),
     RefreshMode(String),
     RefreshMinutes(u32),
+    /// How the client lays out its card columns: fit-to-width, or capped.
+    ColumnsAuto(bool),
+    MaxColumns(u32),
     /// The one preference that changes how this process reaches the network, rather than
     /// what it does with what it reaches.
     Proxy {
@@ -1304,9 +1307,11 @@ impl Engine {
             Preference::MinimizeOnClose(enabled) => config.set_minimize_on_close(enabled),
             Preference::Theme(theme) => config.set_theme(&theme),
             Preference::StartupMode(mode) => config.set_startup_mode(&mode),
-            Preference::HistoryRetention(retention) => config.set_history_retention(&retention),
             Preference::RefreshMode(mode) => config.set_refresh_mode(&mode),
             Preference::RefreshMinutes(minutes) => config.set_refresh_minutes(minutes),
+            Preference::ColumnsAuto(enabled) => config.set_columns_auto(enabled),
+            Preference::MaxColumns(columns) => config.set_max_columns(columns),
+            Preference::HistoryRetention(retention) => config.set_history_retention(&retention),
             Preference::Proxy { mode, host, port } => config.set_proxy(&mode, &host, port),
         }
         .map_err(|error| error.to_string())?;
@@ -4946,13 +4951,23 @@ mod tests {
             .set_preference(Preference::StartupMode(Preferences::STARTUP_DAEMON.into()))
             .await
             .expect("startup mode changed");
-        let preferences = harness
+        harness
             .engine
             .set_preference(Preference::HistoryRetention(
                 Preferences::RETENTION_SIX_MONTHS.into(),
             ))
             .await
             .expect("history retention changed");
+        harness
+            .engine
+            .set_preference(Preference::ColumnsAuto(false))
+            .await
+            .expect("column mode changed");
+        let preferences = harness
+            .engine
+            .set_preference(Preference::MaxColumns(7))
+            .await
+            .expect("column ceiling changed");
 
         assert_eq!(
             preferences,
@@ -4967,6 +4982,8 @@ mod tests {
                 proxy_port: 0,
                 refresh_mode: Preferences::REFRESH_AUTO.into(),
                 refresh_minutes: 5,
+                columns_auto: Some(false),
+                max_columns: Some(7),
             }
         );
         assert_eq!(

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -1416,6 +1416,37 @@ impl Daemon {
         self.publish_preferences(&emitter, preferences).await
     }
 
+    /// Chooses whether the client lays out as many card columns as the window fits.
+    async fn set_columns_auto(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        enabled: bool,
+    ) -> fdo::Result<()> {
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::ColumnsAuto(enabled))
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
+    /// Sets the most card columns a window lays out while Auto is off.
+    async fn set_max_columns(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        columns: u32,
+    ) -> fdo::Result<()> {
+        if !Preferences::valid_max_columns(columns) {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "max columns must be at least 1, not {columns}"
+            )));
+        }
+        let _guard = self.preference_mutation.lock().await;
+        let preferences = self
+            .preference_request(Preference::MaxColumns(columns))
+            .await?;
+        self.publish_preferences(&emitter, preferences).await
+    }
+
     /// Points every outbound request and every child process at a proxy, or at none.
     ///
     /// Takes all three values together because they are one setting: applying a mode
@@ -4460,6 +4491,77 @@ mod tests {
             .await
             .expect("task did not panic")
             .expect("accepted");
+    }
+
+    #[tokio::test]
+    async fn a_column_change_reaches_the_engine_and_publishes_the_dict() {
+        let (daemon, _secrets, mut commands) = daemon_over(Vec::new()).await;
+        let daemon = Arc::new(daemon);
+        let Ok(connection) = zbus::Connection::session().await else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+        let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH).expect("a valid path");
+
+        let changing = {
+            let daemon = Arc::clone(&daemon);
+            let emitter = emitter.clone();
+            tokio::spawn(async move { daemon.set_columns_auto(emitter, false).await })
+        };
+        let Command::SetPreference { preference, reply } = commands
+            .recv()
+            .await
+            .expect("the change reaches the engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert!(matches!(preference, Preference::ColumnsAuto(false)));
+        reply
+            .send(Ok(Preferences::default()))
+            .expect("caller waits for reply");
+        changing
+            .await
+            .expect("task did not panic")
+            .expect("accepted");
+
+        let changing = {
+            let daemon = Arc::clone(&daemon);
+            tokio::spawn(async move { daemon.set_max_columns(emitter, 7).await })
+        };
+        let Command::SetPreference { preference, reply } = commands
+            .recv()
+            .await
+            .expect("the change reaches the engine")
+        else {
+            panic!("unexpected command");
+        };
+        assert!(matches!(preference, Preference::MaxColumns(7)));
+        reply
+            .send(Ok(Preferences::default()))
+            .expect("caller waits for reply");
+        changing
+            .await
+            .expect("task did not panic")
+            .expect("accepted");
+    }
+
+    #[tokio::test]
+    async fn a_zero_column_ceiling_is_refused_before_the_engine_hears_it() {
+        let (daemon, _secrets, mut commands) = daemon_over(Vec::new()).await;
+        let Ok(connection) = zbus::Connection::session().await else {
+            eprintln!("skipped: no session bus reachable");
+            return;
+        };
+        let emitter = SignalEmitter::new(&connection, ids::OBJECT_PATH).expect("a valid path");
+
+        assert!(matches!(
+            daemon.set_max_columns(emitter, 0).await,
+            Err(fdo::Error::InvalidArgs(_))
+        ));
+        assert!(
+            commands.try_recv().is_err(),
+            "a refused value must not reach the engine"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- The card grid's three-column ceiling was a hardcoded constant (`MAX_COLUMNS = 3` in `grid.rs`). It is now a daemon-stored preference, threaded through the same chain as refresh/minimize-on-close.
- **Auto** (default) fits as many columns as the window width holds; **Manual** caps the count at a chosen ceiling of at least one. At the default 1000px window width Auto still lays out three columns (3 × ~312px), so default-sized windows do not change; wider windows now gain columns instead of centering a fixed block.
- The setting is exposed in Preferences → General as a new "Card columns" group (Auto switch + Maximum columns spin) with the same interaction as "Providers refresh": the spin locks while Auto is on, and unlocks the moment the switch flips.

## Changes

- **Vocabulary** (`tidemark-types/src/wire.rs`): `Preferences` gains `columns_auto: Option<bool>` and `max_columns: Option<u32>`, plus `valid_max_columns` (≥ 1, no upper bound — the window's own width keeps the real count honest).
- **Daemon** (`tidemark-core`/`tidemarkd`): new `[grid]` config table (`auto`, `max`) with the repo's present-but-invalid-refused rule; `Preference::ColumnsAuto`/`MaxColumns` through the engine; `SetColumnsAuto`/`SetMaxColumns` on the D-Bus interface republishing `preferences_changed` (ipc proxy updated in step).
- **GUI** (`tidemark`): `CardGrid` carries a `column_cap` (`None` = fit-to-width, the no-preference-yet default) used by `measure`/`size_allocate` instead of the constant; `MainWindow::apply_preferences` pushes the preference into the grid live; the preferences dialog wires the new group.
- **CLI** (`tidemarkctl`): `config columns <auto|manual> [--max N]` mirrors `config refresh`, and `config show` prints `columns` / `columns-max` rows whose words feed straight back into the subcommand.
- **Docs**: `CONTEXT.md` § Interface now describes the preference instead of "one to three columns".

## QA & Evidence

- **What was tested:** `cargo test --workspace`
  **Observed result:** 1552 tests pass, including the new ones: absent-dictionary decode and validity in `wire.rs`; round-trip, zero/negative/non-integer refusal and defaults in `config.rs`; engine serialization of both variants; service InvalidArgs-before-the-engine and engine round trip; the dialog's lock contract; CLI `show` rows with present and absent fields.
  **Artifact:** local run, no persisted log
  **Why sufficient:** every seam of the chain (wire ↔ config ↔ engine ↔ D-Bus ↔ CLI) has a colocated behavioral test; the GTK layout itself is display code exercised manually below.
- **What was tested:** manual QA of the running app by the owner (Auto at several window widths, switch to Manual, ceiling spin, persistence across restart)
  **Observed result:** confirmed working by the owner
  **Artifact:** none (hands-on)
  **Why sufficient:** the only untestable-without-a-display part is the widget relayout, which the owner drove directly.

## Risks & Residuals

- **Older daemon, newer client:** the two fields arrive absent; the window reads that as Auto with the legacy ceiling of three for Manual. Covered by `an_older_preferences_dictionary_without_the_column_settings_still_decodes` — **mitigated**.
- **Newer daemon, older client:** two extra keys in an `a{sv}` dictionary the old client ignores by design — **not applicable**.
- **Spin tops at 999 while the daemon accepts any ceiling ≥ 1:** a value beyond 999 set via CLI displays as 999 if it is then edited in the dialog; inert in practice since no display fits even 20 columns — **accepted**.

## Automated Checks

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
./scripts/check-layering.sh
```

All four run on this branch and green.

## Related Issues

None open.
