### PR TITLE
fix(codex): support Business spend controls

### DIFF
--- a/crates/tidemark-core/src/providers/codex.rs
+++ b/crates/tidemark-core/src/providers/codex.rs
@@ -55,7 +55,7 @@ use crate::oauth_file::{
 };
 use crate::secrets::{self, Secrets};
 use base64::Engine;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tidemark_types::{
@@ -590,6 +590,15 @@ fn parse_for_account(
             &mut windows,
         )?;
     }
+    if let Some(window) = envelope
+        .spend_control
+        .as_ref()
+        .map(|control| control.window(captured_at))
+        .transpose()?
+        .flatten()
+    {
+        windows.push(window);
+    }
 
     Ok(Snapshot {
         provider: ProviderId::new(PROVIDER_ID),
@@ -718,15 +727,89 @@ struct Credits {
 #[derive(Debug, Deserialize)]
 struct SpendControl {
     #[serde(default)]
+    reached: bool,
+    #[serde(default)]
     individual_limit: Option<IndividualLimit>,
+}
+
+impl SpendControl {
+    fn window(&self, captured_at: Timestamp) -> Result<Option<Window>, ProviderError> {
+        let Some(limit) = self.individual_limit.as_ref() else {
+            return Ok(None);
+        };
+        let Some((used, maximum)) = limit.amounts() else {
+            return Ok(None);
+        };
+        if used < 0.0 || maximum < 0.0 {
+            return Err(ProviderError::malformed(
+                "a Codex spend limit contains a negative amount",
+            ));
+        }
+        let used_percent = if maximum > 0.0 {
+            used / maximum * 100.0
+        } else if self.reached {
+            100.0
+        } else {
+            0.0
+        };
+        let resets_at = limit
+            .reset_at
+            .and_then(|seconds| Timestamp::from_unix(seconds).ok())
+            .or_else(|| {
+                limit
+                    .reset_after_seconds
+                    .filter(|seconds| *seconds >= 0)
+                    .map(|seconds| captured_at.saturating_add_seconds(seconds))
+            });
+        let mut subtitle = format!("{} of {}", trim_number(used), trim_number(maximum));
+        if self.reached {
+            subtitle.push_str(" · Reached");
+        }
+        Ok(Some(Window {
+            key: WindowKey::named("monthly_credits"),
+            title: "Monthly credits".to_owned(),
+            subtitle: Some(subtitle),
+            used_percent: used_percent.clamp(0.0, 100.0),
+            resets_at,
+            length: None,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Numeric(f64);
+
+impl<'de> Deserialize<'de> for Numeric {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let number = match &value {
+            serde_json::Value::Number(number) => number.as_f64(),
+            serde_json::Value::String(raw) => raw.trim().parse::<f64>().ok(),
+            _ => None,
+        };
+        number
+            .filter(|number| number.is_finite())
+            .map(Self)
+            .ok_or_else(|| de::Error::custom(format!("{value} is not a finite number")))
+    }
 }
 
 #[derive(Debug, Deserialize)]
 struct IndividualLimit {
     #[serde(default)]
-    limit: Option<f64>,
+    limit: Option<Numeric>,
     #[serde(default)]
-    used: Option<f64>,
+    used: Option<Numeric>,
+    #[serde(default)]
+    reset_after_seconds: Option<i64>,
+    #[serde(default)]
+    reset_at: Option<i64>,
+}
+
+impl IndividualLimit {
+    fn amounts(&self) -> Option<(f64, f64)> {
+        Some((self.used?.0, self.limit?.0))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -750,16 +833,18 @@ fn details(envelope: &Envelope) -> Vec<DetailSection> {
         });
     }
 
-    if let Some(credits) = envelope
+    if let Some(value) = envelope
         .credits
         .as_ref()
         .filter(|credits| credits.has_credits || credits.unlimited)
+        .and_then(|credits| {
+            if credits.unlimited {
+                Some("Unlimited".to_owned())
+            } else {
+                number_text(credits.balance.as_ref())
+            }
+        })
     {
-        let value = if credits.unlimited {
-            "Unlimited".to_owned()
-        } else {
-            number_text(credits.balance.as_ref()).unwrap_or_else(|| "0".to_owned())
-        };
         sections.push(DetailSection {
             title: "Credits".to_owned(),
             rows: vec![DetailRow {
@@ -796,7 +881,7 @@ fn details(envelope: &Envelope) -> Vec<DetailSection> {
         .spend_control
         .as_ref()
         .and_then(|control| control.individual_limit.as_ref())
-        .and_then(|limit| Some((limit.used?, limit.limit?)))
+        .and_then(IndividualLimit::amounts)
     {
         sections.push(DetailSection {
             title: "Spend".to_owned(),

--- a/crates/tidemark-core/tests/codex_provider.rs
+++ b/crates/tidemark-core/tests/codex_provider.rs
@@ -39,6 +39,63 @@ const LIVE_SHAPE: &str = r#"{
   "rate_limit_reset_credits": {"available_count": 0, "applicable_available_count": 0}
 }"#;
 
+// The response attached to issue #54, with its identifying fields redacted by the reporter.
+// Business sends the enforced spend amounts as JSON strings, unlike the numeric fixture below.
+const BUSINESS_SHAPE: &str = r#"{
+  "user_id": "[REDACTED]",
+  "account_id": "[REDACTED]",
+  "email": "[REDACTED]",
+  "plan_type": "self_serve_business_prolite",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window": {
+      "used_percent": 12,
+      "limit_window_seconds": 604800,
+      "reset_after_seconds": 492878,
+      "reset_at": 1789481868
+    },
+    "secondary_window": null
+  },
+  "code_review_rate_limit": null,
+  "additional_rate_limits": null,
+  "model_usage": {
+    "gpt-6-astra": {
+      "available": true,
+      "available_at": null,
+      "credits_would_enable": false
+    }
+  },
+  "credits": {
+    "has_credits": true,
+    "unlimited": false,
+    "overage_limit_reached": false,
+    "balance": null,
+    "approx_local_messages": null,
+    "approx_cloud_messages": null
+  },
+  "spend_control": {
+    "reached": true,
+    "individual_limit": {
+      "source": "account_user_spend_controls",
+      "unit": "credit",
+      "limit": "150",
+      "used": "155.13599956035614",
+      "remaining": "0",
+      "used_percent": 103,
+      "remaining_percent": 0,
+      "reset_after_seconds": 1823810,
+      "reset_at": 1790812801
+    }
+  },
+  "rate_limit_reached_type": null,
+  "promo": null,
+  "rate_limit_reset_credits": {
+    "available_count": 3,
+    "applicable_available_count": 0
+  }
+}"#;
+
 fn captured_at() -> Timestamp {
     Timestamp::from_unix(1_787_255_524).expect("plausible")
 }
@@ -365,6 +422,43 @@ fn a_spend_control_limit_is_kept_as_a_detail() {
 
     assert_eq!(snapshot.details[0].title, "Spend");
     assert_eq!(snapshot.details[0].rows[0].value, "42.5 of 100");
+}
+
+#[test]
+fn the_reported_business_response_draws_its_enforced_monthly_credit_limit() {
+    let snapshot = codex::parse(BUSINESS_SHAPE, captured_at()).expect("business response parses");
+
+    let keys: Vec<&str> = snapshot
+        .windows
+        .iter()
+        .map(|window| window.key.as_str())
+        .collect();
+    assert_eq!(keys, ["w604800", "monthly_credits"]);
+    assert_eq!(snapshot.windows[0].used_percent, 12.0);
+
+    let monthly = &snapshot.windows[1];
+    assert_eq!(monthly.title, "Monthly credits");
+    assert_eq!(monthly.subtitle.as_deref(), Some("155.14 of 150 · Reached"));
+    assert_eq!(monthly.used_percent, 100.0);
+    assert_eq!(
+        monthly.resets_at.map(Timestamp::as_unix),
+        Some(1_790_812_801)
+    );
+    assert_eq!(monthly.length, None);
+
+    let titles: Vec<&str> = snapshot
+        .details
+        .iter()
+        .map(|section| section.title.as_str())
+        .collect();
+    assert_eq!(titles, [DetailSection::PLAN, "Reset credits", "Spend"]);
+    assert_eq!(
+        snapshot.details[0].rows[0].value,
+        "Self Serve Business Prolite"
+    );
+    assert_eq!(snapshot.details[1].rows[0].value, "3");
+    assert_eq!(snapshot.details[1].rows[1].value, "0");
+    assert_eq!(snapshot.details[2].rows[0].value, "155.14 of 150");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Accept the numeric-string spend amounts returned by Codex Business without changing the numeric shape used by ordinary Codex accounts.
- Surface an enforced individual spend limit as a monthly credits window, preserving overage and reset information while keeping the gauge within its 0–100% contract.
- Keep an undisclosed `credits.balance: null` absent instead of displaying a fabricated zero balance.

## Changes

- **Codex response parsing:** deserialize `individual_limit.limit` and `used` from either finite JSON numbers or finite numeric strings; malformed recognized values still fail the response.
- **Quota presentation:** append a stable `monthly_credits` window when the response contains a readable individual limit. Its subtitle retains the actual amount and `Reached` state, while its bar percentage is clamped to 100%.
- **Optional credits:** emit the Credits detail section only when an unlimited state or readable balance is present.
- **Regression coverage:** add the complete sanitized response supplied in issue #54 and assert the weekly window, monthly spend window, reset, plan, reset credits, overage text, and omitted null balance.

## QA & Evidence

- **What was tested:** `cargo test -p tidemark-core --test codex_provider the_reported_business_response_draws_its_enforced_monthly_credit_limit`
  **Observed result:** The exact issue response passed: 1 test passed, 0 failed. Before the fix, the same test failed on `invalid type: string "150", expected f64`.
  **Artifact:** Sanitized fixture and assertions are committed in `crates/tidemark-core/tests/codex_provider.rs`.
  **Why sufficient:** This invokes `codex::parse`, the same `parse_for_account` path used after the production `wham/usage` fetch.

- **What was tested:** full local workspace gate listed below.
  **Observed result:** 1,732 tests passed across 25 suites, 1 test ignored; Clippy and formatting completed without warnings; layering check reported `layering ok`.
  **Artifact:** Sanitized local terminal transcript; GitHub Actions will rerun the committed tree.
  **Why sufficient:** Covers normal Codex fixtures and all workspace consumers in addition to the new Business response.

## Risks & Residuals

- **No live Business account:** accepted. Authentication and server-side enforcement could not be exercised locally; the exact raw response supplied by the reporter is retained as the regression fixture.
- **Normal Codex compatibility:** mitigated. Existing number-valued spend controls and ordinary Plus/Pro response fixtures pass unchanged; the new window exists only when `individual_limit` is present.
- **New history identity:** mitigated. `monthly_credits` is a stable semantic key and sorts after declared-duration windows, preserving the existing headline window.
- **Manual UI QA:** not performed. The repository delegates manual application checks to the maintainer; verify the compact `Monthly credits` row and the detail subtitle on a live Business account.

## Automated Checks

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
./scripts/check-layering.sh
```

## Related Issues

Closes #54