### PR TITLE
Add an Ollama Cloud example plugin: keyed /api/usage reader

### DIFF
--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
@@ -1,9 +1,9 @@
 format_version = 1
 
 [provider]
-id = "com.ollama.cloud"
+id = "io.github.riccelso.ollama-cloud"
 name = "Ollama Cloud"
-plugin_version = "1.0.0"
+plugin_version = "1.1.0"
 
 [request]
 method = "GET"
@@ -18,31 +18,34 @@ function parse(response, context)
     --   activity — cost and per-model usage over the trailing four weeks
     --   limits   — the plan's monthly included usage
     --
-    -- The endpoint reports no absolute cap on the free plan: limits.monthly carries
-    -- only `usage`. A paid plan is expected to spell its cap `usage_limit`; when the
-    -- field is absent the reading stays honest — a value with no maximum, no
-    -- percentage — rather than fabricating one.
+    -- The endpoint reports no reset time and no window length for the monthly
+    -- figure, so none is declared: the reading stays a plain number rather
+    -- than borrowing the activity period's end as an invented rollover.
     --
-    -- The 5-hour/weekly session windows the settings page renders are not part of
-    -- this endpoint; the built-in `ollama` provider (browser session) tracks those.
+    -- Only the free-plan shape has been observed live (2026-09-09):
+    -- limits.monthly carries `usage` and no cap, activity.models is empty.
+    -- The paid-plan branches (usage_limit, per-model usage/limit) are a
+    -- hypothesis this example spells out; if the real paid shape names its
+    -- cap differently, those branches never fire and the reading stays the
+    -- honest uncapped one instead of failing on a guess.
+    --
+    -- The 5-hour/weekly session windows the settings page renders are not
+    -- part of this endpoint; the built-in `ollama` provider (browser
+    -- session) tracks those.
 
     local monthly = response.limits.monthly
+    local used = number(monthly.usage)
 
     local metrics = {}
     local card = {}
     local items = {}
-
-    local used = nil
-    if monthly.usage ~= nil then
-        used = number(monthly.usage)
-    end
 
     local limit = nil
     if monthly.usage_limit ~= nil then
         limit = number(monthly.usage_limit)
     end
 
-    if used ~= nil and limit ~= nil then
+    if limit ~= nil then
         table.insert(metrics, {
             id = "monthly-usage",
             title = "Monthly usage",
@@ -50,17 +53,10 @@ function parse(response, context)
             maximum = limit,
             remaining = limit - used,
             used_percent = percent(used, limit),
-            window = {
-                key = "month",
-                resets_at = parse_time(response.activity.period.ending_at),
-                length_seconds = 2592000,
-            },
         })
         table.insert(card, gauge("monthly-usage"))
         table.insert(items, ratio("monthly-usage", { left = "value", right = "maximum" }))
-    elseif used ~= nil then
-        -- No cap on this plan: report the raw usage without a window, so nothing is
-        -- invented and the card says what the endpoint actually said.
+    else
         table.insert(metrics, {
             id = "monthly-usage",
             title = "Monthly usage",
@@ -69,52 +65,42 @@ function parse(response, context)
         table.insert(card, value("monthly-usage", { field = "value" }))
     end
 
-    local cost = nil
-    if response.activity.cost ~= nil then
-        cost = number(response.activity.cost)
-    end
-    if cost ~= nil then
-        table.insert(metrics, {
-            id = "cost-4w",
-            title = "Cost (4 weeks)",
-            value = cost,
-            unit = "USD",
-        })
-        table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
-    end
+    local cost = number(response.activity.cost)
+    table.insert(metrics, {
+        id = "cost-4w",
+        title = "Cost (4 weeks)",
+        value = cost,
+        unit = "USD",
+    })
+    table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
 
-    if response.activity.models ~= nil then
-        for _, model in ipairs(response.activity.models) do
-            local used_m = nil
-            if model.usage ~= nil then
-                used_m = number(model.usage)
-            end
-            local cap = nil
-            if model.limit ~= nil and not is_null(model.limit) then
-                cap = number(model.limit)
-            end
+    for _, model in ipairs(response.activity.models) do
+        local id = "model-" .. model.id
+        local title = tostring(model.id)
+        local used_m = number(model.usage)
 
-            local id = "model-" .. tostring(model.id)
-            local title = tostring(model.name or model.id)
+        local cap = nil
+        if model.limit ~= nil and not is_null(model.limit) then
+            cap = number(model.limit)
+        end
 
-            if used_m ~= nil and cap ~= nil then
-                table.insert(metrics, {
-                    id = id,
-                    title = title,
-                    value = used_m,
-                    maximum = cap,
-                    remaining = cap - used_m,
-                    used_percent = percent(used_m, cap),
-                })
-                table.insert(items, ratio(id, { left = "value", right = "maximum" }))
-            elseif used_m ~= nil then
-                table.insert(metrics, {
-                    id = id,
-                    title = title,
-                    value = used_m,
-                })
-                table.insert(items, value(id, { field = "value" }))
-            end
+        if cap ~= nil then
+            table.insert(metrics, {
+                id = id,
+                title = title,
+                value = used_m,
+                maximum = cap,
+                remaining = cap - used_m,
+                used_percent = percent(used_m, cap),
+            })
+            table.insert(items, ratio(id, { left = "value", right = "maximum" }))
+        else
+            table.insert(metrics, {
+                id = id,
+                title = title,
+                value = used_m,
+            })
+            table.insert(items, value(id, { field = "value" }))
         end
     end
 

--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
@@ -1,0 +1,134 @@
+format_version = 1
+
+[provider]
+id = "com.ollama.cloud"
+name = "Ollama Cloud"
+plugin_version = "1.0.0"
+
+[request]
+method = "GET"
+api_key_header = "Authorization"
+api_key_prefix = "Bearer "
+
+[parser]
+language = "lua54"
+source = '''
+function parse(response, context)
+    -- ollama.com/api/usage answers with two top-level tables:
+    --   activity — cost and per-model usage over the trailing four weeks
+    --   limits   — the plan's monthly included usage
+    --
+    -- The endpoint reports no absolute cap on the free plan: limits.monthly carries
+    -- only `usage`. A paid plan is expected to spell its cap `usage_limit`; when the
+    -- field is absent the reading stays honest — a value with no maximum, no
+    -- percentage — rather than fabricating one.
+    --
+    -- The 5-hour/weekly session windows the settings page renders are not part of
+    -- this endpoint; the built-in `ollama` provider (browser session) tracks those.
+
+    local monthly = response.limits.monthly
+
+    local metrics = {}
+    local card = {}
+    local items = {}
+
+    local used = nil
+    if monthly.usage ~= nil then
+        used = number(monthly.usage)
+    end
+
+    local limit = nil
+    if monthly.usage_limit ~= nil then
+        limit = number(monthly.usage_limit)
+    end
+
+    if used ~= nil and limit ~= nil then
+        table.insert(metrics, {
+            id = "monthly-usage",
+            title = "Monthly usage",
+            value = used,
+            maximum = limit,
+            remaining = limit - used,
+            used_percent = percent(used, limit),
+            window = {
+                key = "month",
+                resets_at = parse_time(response.activity.period.ending_at),
+                length_seconds = 2592000,
+            },
+        })
+        table.insert(card, gauge("monthly-usage"))
+        table.insert(items, ratio("monthly-usage", { left = "value", right = "maximum" }))
+    elseif used ~= nil then
+        -- No cap on this plan: report the raw usage without a window, so nothing is
+        -- invented and the card says what the endpoint actually said.
+        table.insert(metrics, {
+            id = "monthly-usage",
+            title = "Monthly usage",
+            value = used,
+        })
+        table.insert(card, value("monthly-usage", { field = "value" }))
+    end
+
+    local cost = nil
+    if response.activity.cost ~= nil then
+        cost = number(response.activity.cost)
+    end
+    if cost ~= nil then
+        table.insert(metrics, {
+            id = "cost-4w",
+            title = "Cost (4 weeks)",
+            value = cost,
+            unit = "USD",
+        })
+        table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
+    end
+
+    if response.activity.models ~= nil then
+        for _, model in ipairs(response.activity.models) do
+            local used_m = nil
+            if model.usage ~= nil then
+                used_m = number(model.usage)
+            end
+            local cap = nil
+            if model.limit ~= nil and not is_null(model.limit) then
+                cap = number(model.limit)
+            end
+
+            local id = "model-" .. tostring(model.id)
+            local title = tostring(model.name or model.id)
+
+            if used_m ~= nil and cap ~= nil then
+                table.insert(metrics, {
+                    id = id,
+                    title = title,
+                    value = used_m,
+                    maximum = cap,
+                    remaining = cap - used_m,
+                    used_percent = percent(used_m, cap),
+                })
+                table.insert(items, ratio(id, { left = "value", right = "maximum" }))
+            elseif used_m ~= nil then
+                table.insert(metrics, {
+                    id = id,
+                    title = title,
+                    value = used_m,
+                })
+                table.insert(items, value(id, { field = "value" }))
+            end
+        end
+    end
+
+    return {
+        metrics = metrics,
+        card = card,
+        details = { { title = "Usage", items = items } },
+    }
+end
+'''
+
+[icon]
+svg = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path fill="currentColor" d="M32 4c-5 0-9 2-12 5-4 1-7 4-8 8-2 3-3 7-3 11s1 8 3 11c1 4 4 7 8 8 3 3 7 5 12 5s9-2 12-5c4-1 7-4 8-8 2-3 3-7 3-11s-1-8-3-11c-1-4-4-7-8-8-3-3-7-5-12-5zm0 8c3 0 6 1 8 3 2 1 4 3 5 5 1 2 2 5 2 7s-1 5-2 7c-1 2-3 4-5 5-2 2-5 3-8 3s-6-1-8-3c-2-1-4-3-5-5-1-2-2-5-2-7s1-5 2-7c1-2 3-4 5-5 2-2 5-3 8-3z"/>
+</svg>
+'''

--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-cloud.tidemark-provider
@@ -75,6 +75,12 @@ function parse(response, context)
     table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
 
     for _, model in ipairs(response.activity.models) do
+        -- A model row without a usable id cannot be named, and two rows cannot
+        -- share one: both are recognized malformations of this endpoint's shape
+        -- and refuse the reading, rather than filing an unnamed or colliding row.
+        if model.id == nil or model.id == "" then
+            error("a model row has no id")
+        end
         local id = "model-" .. model.id
         local title = tostring(model.id)
         local used_m = number(model.usage)

--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-free-response.json
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-free-response.json
@@ -1,0 +1,17 @@
+{
+    "activity": {
+        "cost": "0.00000",
+        "period": {
+            "type": "last_4_weeks",
+            "starting_at": "2026-08-17T00:00:00Z",
+            "ending_at": "2026-09-09T23:05:51Z"
+        },
+        "models": []
+    },
+    "limits": {
+        "monthly": {
+            "usage": 0,
+            "models": []
+        }
+    }
+}

--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-paid-response.json
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-paid-response.json
@@ -1,0 +1,31 @@
+{
+    "activity": {
+        "cost": "12.5",
+        "period": {
+            "type": "last_4_weeks",
+            "starting_at": "2026-08-17T00:00:00Z",
+            "ending_at": "2026-09-09T23:05:51Z"
+        },
+        "models": [
+            {
+                "id": "gemma4:31b",
+                "name": "gemma4:31b",
+                "usage": 320,
+                "limit": 1000
+            },
+            {
+                "id": "gpt-oss:120b",
+                "name": "gpt-oss:120b",
+                "usage": 74,
+                "limit": null
+            }
+        ]
+    },
+    "limits": {
+        "monthly": {
+            "usage": 41.2,
+            "usage_limit": 100,
+            "models": []
+        }
+    }
+}

--- a/crates/tidemark-core/tests/fixtures/plugin/ollama-rejected-response.json
+++ b/crates/tidemark-core/tests/fixtures/plugin/ollama-rejected-response.json
@@ -1,0 +1,3 @@
+{
+    "error": "invalid credentials"
+}

--- a/crates/tidemark-core/tests/ollama_plugin.rs
+++ b/crates/tidemark-core/tests/ollama_plugin.rs
@@ -1,0 +1,70 @@
+//! The Ollama Cloud example plugin against recorded endpoint fixtures.
+//!
+//! `render` is the one transformation: the same function `tidemarkctl plugin render`
+//! and polling use. These tests keep the example honest against both plan shapes
+//! `ollama.com/api/usage` serves — a free plan whose `limits.monthly` carries no
+//! absolute cap, and a paid plan carrying `usage_limit`.
+
+use tidemark_core::plugin::{provider, schema};
+use tidemark_types::{AccountId, Timestamp};
+
+const FILE: &str = include_str!("fixtures/plugin/ollama-cloud.tidemark-provider");
+const FREE: &str = include_str!("fixtures/plugin/ollama-free-response.json");
+const PAID: &str = include_str!("fixtures/plugin/ollama-paid-response.json");
+
+fn render(file: &str) -> tidemark_core::plugin::Reading {
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    provider::render(
+        &definition,
+        file.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    )
+    .unwrap()
+}
+
+fn metric<'a>(reading: &'a tidemark_core::plugin::Reading, id: &str) -> &'a tidemark_types::Metric {
+    reading
+        .presentation
+        .metrics
+        .iter()
+        .find(|m| m.id == id)
+        .unwrap_or_else(|| panic!("metric {id} is present"))
+}
+
+#[test]
+fn the_free_plan_renders_usage_without_a_window() {
+    let reading = render(FREE);
+    // The endpoint reports no cap on the free plan: the reading must carry the
+    // usage value and must not invent a limit, a percentage or a window.
+    let monthly = metric(&reading, "monthly-usage");
+    assert_eq!(monthly.value, Some(0.0), "the raw usage is reported");
+    assert!(monthly.maximum.is_none(), "no fabricated cap");
+    assert!(monthly.used_percent.is_none(), "no fabricated percentage");
+    assert!(monthly.window.is_none(), "no fabricated window");
+}
+
+#[test]
+fn the_paid_plan_renders_a_windowed_gauge() {
+    let reading = render(PAID);
+    let monthly = metric(&reading, "monthly-usage");
+    assert_eq!(monthly.value, Some(41.2));
+    assert_eq!(monthly.maximum, Some(100.0));
+    assert_eq!(
+        monthly.used_percent,
+        Some(41.2),
+        "the percentage matches usage against the cap"
+    );
+    let window = monthly.window.as_ref().expect("the monthly window");
+    assert_eq!(window.key, "month");
+
+    // Per-model rows: a capped model carries its ratio fields, and a model with
+    // a null limit is still listed with its raw usage and nothing invented.
+    let gemma = metric(&reading, "model-gemma4:31b");
+    assert_eq!(gemma.value, Some(320.0));
+    assert_eq!(gemma.maximum, Some(1000.0));
+    let oss = metric(&reading, "model-gpt-oss:120b");
+    assert_eq!(oss.value, Some(74.0));
+    assert!(oss.maximum.is_none(), "null limit stays uncapped");
+}

--- a/crates/tidemark-core/tests/ollama_plugin.rs
+++ b/crates/tidemark-core/tests/ollama_plugin.rs
@@ -1,9 +1,9 @@
 //! The Ollama Cloud example plugin against recorded endpoint fixtures.
 //!
 //! `render` is the one transformation: the same function `tidemarkctl plugin render`
-//! and polling use. These tests keep the example honest against both plan shapes
-//! `ollama.com/api/usage` serves — a free plan whose `limits.monthly` carries no
-//! absolute cap, and a paid plan carrying `usage_limit`.
+//! and polling use. Only the free-plan shape has been observed live; the paid-plan
+//! fixture is a spelled-out hypothesis (see the plugin's parser comment), and its
+//! test says so.
 
 use tidemark_core::plugin::{provider, schema};
 use tidemark_types::{AccountId, Timestamp};
@@ -24,6 +24,18 @@ fn render(file: &str) -> tidemark_core::plugin::Reading {
     .unwrap()
 }
 
+fn refused(file: &str) -> tidemark_core::plugin::PluginError {
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    provider::render(
+        &definition,
+        file.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    )
+    .expect_err("the reading is refused, not rendered")
+}
+
 fn metric<'a>(reading: &'a tidemark_core::plugin::Reading, id: &str) -> &'a tidemark_types::Metric {
     reading
         .presentation
@@ -34,19 +46,25 @@ fn metric<'a>(reading: &'a tidemark_core::plugin::Reading, id: &str) -> &'a tide
 }
 
 #[test]
-fn the_free_plan_renders_usage_without_a_window() {
+fn the_observed_free_plan_renders_without_inventing_anything() {
     let reading = render(FREE);
-    // The endpoint reports no cap on the free plan: the reading must carry the
-    // usage value and must not invent a limit, a percentage or a window.
+    // The only shape observed live (2026-09-09): no cap, so the reading carries
+    // the raw usage and nothing else — no maximum, no percentage, no window with
+    // an invented reset.
     let monthly = metric(&reading, "monthly-usage");
     assert_eq!(monthly.value, Some(0.0), "the raw usage is reported");
     assert!(monthly.maximum.is_none(), "no fabricated cap");
     assert!(monthly.used_percent.is_none(), "no fabricated percentage");
-    assert!(monthly.window.is_none(), "no fabricated window");
+    assert!(monthly.window.is_none(), "no fabricated window or reset");
+
+    // cost is the endpoint's one string-numbered field: the number() path.
+    let cost = metric(&reading, "cost-4w");
+    assert_eq!(cost.value, Some(0.0), "string \"0.00000\" reads as 0.0");
+    assert_eq!(cost.unit.as_deref(), Some("USD"));
 }
 
 #[test]
-fn the_paid_plan_renders_a_windowed_gauge() {
+fn the_hypothesized_paid_plan_renders_a_capped_gauge() {
     let reading = render(PAID);
     let monthly = metric(&reading, "monthly-usage");
     assert_eq!(monthly.value, Some(41.2));
@@ -56,8 +74,11 @@ fn the_paid_plan_renders_a_windowed_gauge() {
         Some(41.2),
         "the percentage matches usage against the cap"
     );
-    let window = monthly.window.as_ref().expect("the monthly window");
-    assert_eq!(window.key, "month");
+    // No window: the endpoint names no reset for the monthly figure even here.
+    assert!(monthly.window.is_none(), "no fabricated window or reset");
+
+    let cost = metric(&reading, "cost-4w");
+    assert_eq!(cost.value, Some(12.5), "string \"12.5\" reads as 12.5");
 
     // Per-model rows: a capped model carries its ratio fields, and a model with
     // a null limit is still listed with its raw usage and nothing invented.
@@ -70,36 +91,11 @@ fn the_paid_plan_renders_a_windowed_gauge() {
 }
 
 #[test]
-fn a_rejected_credential_body_fails_loudly() {
-    // The endpoint answers 401 with a JSON error body; polling never hands that
-    // to the parser (it is a transport failure), but render must refuse the same
-    // body just the same — nothing may be read out of an error document.
-    let rejected = include_str!("fixtures/plugin/ollama-rejected-response.json");
-    let account = AccountId::new("default".to_string());
-    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
-    let outcome = provider::render(
-        &definition,
-        rejected.as_bytes(),
-        &account,
-        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
-    );
-    assert!(outcome.is_err(), "an error document renders nothing");
-}
-
-#[test]
 fn a_truncated_body_fails_loudly() {
     // A cut-off response (connection dropped mid-body) is not valid JSON: the
     // parse must fail rather than half-render.
     let truncated = r#"{"activity":{"cost":"0.00000""#;
-    let account = AccountId::new("default".to_string());
-    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
-    let outcome = provider::render(
-        &definition,
-        truncated.as_bytes(),
-        &account,
-        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
-    );
-    assert!(outcome.is_err(), "a truncated body renders nothing");
+    refused(truncated);
 }
 
 #[test]
@@ -109,16 +105,15 @@ fn a_shape_without_limits_fails_loudly() {
     // purpose" recipe), surfacing as a refused reading — never a partial card.
     let limits_less =
         r#"{"activity":{"cost":"1.0","period":{"ending_at":"2026-09-09T23:05:51Z"},"models":[]}}"#;
-    let account = AccountId::new("default".to_string());
-    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
-    let outcome = provider::render(
-        &definition,
-        limits_less.as_bytes(),
-        &account,
-        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
-    );
-    assert!(
-        outcome.is_err(),
-        "a document without limits renders nothing"
-    );
+    refused(limits_less);
+}
+
+#[test]
+fn a_limits_table_without_usage_fails_loudly() {
+    // `usage` is present in every shape this endpoint has served; a monthly
+    // table without it is a recognized malformation, and the direct number()
+    // call must refuse the whole reading instead of silently dropping the
+    // metric from the card.
+    let usage_less = r#"{"activity":{"cost":"1.0","period":{"ending_at":"2026-09-09T23:05:51Z"},"models":[]},"limits":{"monthly":{}}}"#;
+    refused(usage_less);
 }

--- a/crates/tidemark-core/tests/ollama_plugin.rs
+++ b/crates/tidemark-core/tests/ollama_plugin.rs
@@ -68,3 +68,57 @@ fn the_paid_plan_renders_a_windowed_gauge() {
     assert_eq!(oss.value, Some(74.0));
     assert!(oss.maximum.is_none(), "null limit stays uncapped");
 }
+
+#[test]
+fn a_rejected_credential_body_fails_loudly() {
+    // The endpoint answers 401 with a JSON error body; polling never hands that
+    // to the parser (it is a transport failure), but render must refuse the same
+    // body just the same — nothing may be read out of an error document.
+    let rejected = include_str!("fixtures/plugin/ollama-rejected-response.json");
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    let outcome = provider::render(
+        &definition,
+        rejected.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    );
+    assert!(outcome.is_err(), "an error document renders nothing");
+}
+
+#[test]
+fn a_truncated_body_fails_loudly() {
+    // A cut-off response (connection dropped mid-body) is not valid JSON: the
+    // parse must fail rather than half-render.
+    let truncated = r#"{"activity":{"cost":"0.00000""#;
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    let outcome = provider::render(
+        &definition,
+        truncated.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    );
+    assert!(outcome.is_err(), "a truncated body renders nothing");
+}
+
+#[test]
+fn a_shape_without_limits_fails_loudly() {
+    // The parser indexes response.limits.monthly directly; a document that lost
+    // the limits table must raise inside the sandbox (the documented "fail on
+    // purpose" recipe), surfacing as a refused reading — never a partial card.
+    let limits_less =
+        r#"{"activity":{"cost":"1.0","period":{"ending_at":"2026-09-09T23:05:51Z"},"models":[]}}"#;
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    let outcome = provider::render(
+        &definition,
+        limits_less.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    );
+    assert!(
+        outcome.is_err(),
+        "a document without limits renders nothing"
+    );
+}

--- a/crates/tidemark-core/tests/ollama_plugin.rs
+++ b/crates/tidemark-core/tests/ollama_plugin.rs
@@ -109,6 +109,15 @@ fn a_shape_without_limits_fails_loudly() {
 }
 
 #[test]
+fn a_model_row_without_an_id_fails_loudly() {
+    // A model row that cannot be named cannot be filed: empty and absent ids
+    // are recognized malformations (round-2 adversarial finding), refusing the
+    // whole reading instead of publishing an unnamed `model-` metric.
+    let idless = r#"{"activity":{"cost":"1.0","period":{"ending_at":"2026-09-09T23:05:51Z"},"models":[{"usage":1}]},"limits":{"monthly":{"usage":0}}}"#;
+    refused(idless);
+}
+
+#[test]
 fn a_limits_table_without_usage_fails_loudly() {
     // `usage` is present in every shape this endpoint has served; a monthly
     // table without it is a recognized malformation, and the direct number()

--- a/crates/tidemark-core/tests/ollama_plugin_round3_battery.rs
+++ b/crates/tidemark-core/tests/ollama_plugin_round3_battery.rs
@@ -1,0 +1,235 @@
+//! ROUND-3 ADVERSARIAL BATTERY — hostile inputs against the example plugin.
+//!
+//! Every case is NEW: none re-raises a ledger finding. Cases are grouped by the
+//! expected verdict: refused whole (loud), or rendered truthfully (no clamping).
+//! Written by the round-3 critic; not part of the PR under review.
+
+use tidemark_core::plugin::{provider, schema};
+use tidemark_types::{AccountId, Timestamp};
+
+const FILE: &str = include_str!("fixtures/plugin/ollama-cloud.tidemark-provider");
+
+fn render(file: &str) -> tidemark_core::plugin::Reading {
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    provider::render(
+        &definition,
+        file.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    )
+    .unwrap()
+}
+
+fn refused(file: &str) -> tidemark_core::plugin::PluginError {
+    let account = AccountId::new("default".to_string());
+    let definition = schema::parse(FILE.as_bytes(), &[]).unwrap();
+    provider::render(
+        &definition,
+        file.as_bytes(),
+        &account,
+        Timestamp::from_unix(1_800_000_000).expect("a reasonable test timestamp"),
+    )
+    .expect_err("the reading is refused, not rendered")
+}
+
+/// The smallest body the parser can honestly read: nothing but the fields it uses.
+const MINIMAL: &str = r#"{"activity":{"cost":"0","models":[]},"limits":{"monthly":{"usage":0}}}"#;
+
+// ---------------------------------------------------------------------------
+// Group A — must be REFUSED whole (loud), never partially published
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r3_a_null_monthly_cap_is_refused_not_rendered_as_uncapped() {
+    // The endpoint demonstrably emits explicit nulls for "no cap" (model.limit
+    // is null in the paid hypothesis). If limits.monthly.usage_limit is ever a
+    // null, `number(null)` must fail loudly rather than silently taking the
+    // uncapped branch — that branch exists for an ABSENT field, not a present
+    // null. (Round-3 finding: currently this FAILS the reading via the null
+    // sentinel being a table — confirm the refusal is the actual behaviour.)
+    let body = r#"{"activity":{"cost":"1.0","models":[]},"limits":{"monthly":{"usage":3.0,"usage_limit":null}}}"#;
+    let error = refused(body);
+    eprintln!("r3 null-cap error: {error}");
+}
+
+// ---------------------------------------------------------------------------
+// FINDING R3-1 — models container shape drift is SILENTLY swallowed
+// ---------------------------------------------------------------------------
+// If activity.models arrives as a JSON object (container type flip — exactly
+// the class of drift rounds 1/2 made loud everywhere else), ipairs over a
+// string-keyed table performs ZERO iterations: every model row disappears and
+// a degraded reading is published with no error. This test PINS the current
+// (flawed) behaviour so the finding is executable; the fix belongs to the PR.
+#[test]
+fn r3_finding_models_as_object_silently_drops_every_row() {
+    let body = r#"{"activity":{"cost":"1","models":{"gemma4:31b":{"usage":5}}},"limits":{"monthly":{"usage":0}}}"#;
+    let reading = render(body); // renders — THAT is the finding
+    assert_eq!(
+        reading.presentation.metrics.len(),
+        2,
+        "FINDING R3-1: the model row was silently dropped, no refusal"
+    );
+}
+
+#[test]
+fn r3_negative_monthly_usage_renders_truthfully() {
+    // Recalibrated: the runtime's own philosophy is truthful data, no
+    // clamping and no judgement (percent_above_one_hundred is truthful; the
+    // round-2 battery already accepted negatives). A negative usage is data.
+    let body = r#"{"activity":{"cost":"1.0","models":[]},"limits":{"monthly":{"usage":-5}}}"#;
+    let reading = render(body);
+    let monthly = reading
+        .presentation
+        .metrics
+        .iter()
+        .find(|m| m.id == "monthly-usage")
+        .expect("present");
+    assert_eq!(monthly.value, Some(-5.0));
+}
+
+#[test]
+fn r3_cost_as_object_is_refused() {
+    let body = r#"{"activity":{"cost":{"total":"1.0","currency":"USD"}},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 cost-object error: {error}");
+}
+
+#[test]
+fn r3_cost_huge_string_is_refused() {
+    let body = r#"{"activity":{"cost":"1e999"},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 cost-1e999 error: {error}");
+}
+
+// INTENTIONAL FAILING PROBE — this is finding R3-1, executable. Its passing
+// twin below pins the flawed behaviour. Once the fix lands (refuse a models
+// container that is not an array), delete the twin and remove #[ignore] here.
+// Kept out of the default run so the suite stays green for rounds 4+.
+#[test]
+#[ignore = "finding R3-1: models container drift is swallowed (see twin test)"]
+fn r3_models_as_object_not_array_is_refused() {
+    let body = r#"{"activity":{"cost":"1","models":{"gemma4:31b":{"usage":1}}},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 models-object error: {error}");
+}
+
+#[test]
+fn r3_duplicate_metric_id_via_monthly_usage_model_row_is_refused() {
+    // A model literally called "monthly-usage" would produce the metric id
+    // "model-monthly-usage" — no collision. But a model whose id makes the
+    // prefixed id equal another model's prefixed id must be refused by R5.
+    let body = r#"{"activity":{"cost":"1","models":[{"id":"m","usage":1},{"id":"m","usage":2}]},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 duplicate-model error: {error}");
+}
+
+#[test]
+fn r3_model_usage_missing_is_refused() {
+    let body = r#"{"activity":{"cost":"1","models":[{"id":"gemma4:31b"}]},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 model-no-usage error: {error}");
+}
+
+#[test]
+fn r3_model_limit_negative_is_refused() {
+    // percent() refuses a non-positive denominator at draw time.
+    let body = r#"{"activity":{"cost":"1","models":[{"id":"m","usage":1,"limit":-10}]},"limits":{"monthly":{"usage":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 negative-limit error: {error}");
+}
+
+#[test]
+fn r3_monthly_usage_null_is_refused() {
+    let body = r#"{"activity":{"cost":"1","models":[]},"limits":{"monthly":{"usage":null}}}"#;
+    let error = refused(body);
+    eprintln!("r3 null-usage error: {error}");
+}
+
+#[test]
+fn r3_limits_monthly_as_array_is_refused() {
+    let body = r#"{"activity":{"cost":"1","models":[]},"limits":{"monthly":[]}}"#;
+    let error = refused(body);
+    eprintln!("r3 monthly-array error: {error}");
+}
+
+#[test]
+fn r3_usage_limit_zero_is_refused() {
+    let body =
+        r#"{"activity":{"cost":"1","models":[]},"limits":{"monthly":{"usage":5,"usage_limit":0}}}"#;
+    let error = refused(body);
+    eprintln!("r3 zero-limit error: {error}");
+}
+
+// ---------------------------------------------------------------------------
+// Group B — must be RENDERED, truthfully (no clamping, no invention)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r3_usage_above_limit_renders_an_honest_overdraw() {
+    // 80 of a 50 cap is 160%, not a clamped 100%: an overdraw is information.
+    let body = r#"{"activity":{"cost":"1","models":[]},"limits":{"monthly":{"usage":80,"usage_limit":50}}}"#;
+    let reading = render(body);
+    let monthly = reading
+        .presentation
+        .metrics
+        .iter()
+        .find(|m| m.id == "monthly-usage")
+        .expect("present");
+    assert_eq!(monthly.value, Some(80.0));
+    assert_eq!(monthly.used_percent, Some(160.0), "overdraw is truthful");
+}
+
+#[test]
+fn r3_200_model_rows_are_refused_whole_by_the_metric_bound() {
+    // R8: 128 metrics max. 200 model rows + monthly + cost = 202 → the runtime
+    // refuses the WHOLE reading (loud), never truncates the model list.
+    // (Critic note: initial expectation of a render was wrong — R8 governs.)
+    let models: Vec<String> = (0..200)
+        .map(|i| format!(r#"{{"id":"m{i}","usage":{i}}}"#))
+        .collect();
+    let body = format!(
+        r#"{{"activity":{{"cost":"1","models":[{}]}},"limits":{{"monthly":{{"usage":0}}}}}}"#,
+        models.join(",")
+    );
+    let error = refused(&body);
+    assert!(
+        error.to_string().contains("128"),
+        "the refusal names the bound: {error}"
+    );
+}
+
+#[test]
+fn r3_the_minimal_observed_shape_renders() {
+    // Nothing but the fields the parser reads: no period, no limits.models.
+    let reading = render(MINIMAL);
+    assert_eq!(reading.presentation.metrics.len(), 2);
+}
+
+#[test]
+fn r3_unknown_extra_fields_are_ignored_without_harm() {
+    // New endpoint fields the parser does not know must not change the reading.
+    let body = r#"{"activity":{"cost":"2.5","models":[],"new_field":true},"limits":{"monthly":{"usage":1,"future_field":"x"}}}"#;
+    let reading = render(body);
+    let cost = reading
+        .presentation
+        .metrics
+        .iter()
+        .find(|m| m.id == "cost-4w")
+        .expect("present");
+    assert_eq!(cost.value, Some(2.5));
+}
+
+#[test]
+fn r3_negative_cost_renders_as_reported() {
+    // A credit is data; the parser reports it, it does not judge it.
+    let body = r#"{"activity":{"cost":"-1.25","models":[]},"limits":{"monthly":{"usage":0}}}"#;
+    let reading = render(body);
+    let cost = reading
+        .presentation
+        .metrics
+        .iter()
+        .find(|m| m.id == "cost-4w")
+        .expect("present");
+    assert_eq!(cost.value, Some(-1.25));
+}

--- a/crates/tidemark-core/tests/ollama_plugin_round3_schema.rs
+++ b/crates/tidemark-core/tests/ollama_plugin_round3_schema.rs
@@ -1,0 +1,184 @@
+//! ROUND-3 — hostile mutations of the plugin FILE itself (schema stage).
+//! None of these were covered by rounds 1-2: they attack the TOML contract,
+//! the header rules, the id rules and the ignored-field surface.
+
+use tidemark_core::plugin::schema;
+
+const FILE: &str = include_str!("fixtures/plugin/ollama-cloud.tidemark-provider");
+
+fn parse(
+    text: &str,
+) -> Result<tidemark_core::plugin::Definition, tidemark_core::plugin::PluginError> {
+    schema::parse(text.as_bytes(), &[])
+}
+
+fn mutant(replace: &str, with: &str) -> String {
+    assert!(FILE.contains(replace), "needle not found: {replace}");
+    FILE.replacen(replace, with, 1)
+}
+
+#[test]
+fn t1_lowercase_forbidden_header_is_refused() {
+    assert!(matches!(
+        parse(&mutant(
+            "api_key_header = \"Authorization\"",
+            "api_key_header = \"host\""
+        )),
+        Err(tidemark_core::plugin::PluginError::ForbiddenHeader { .. })
+    ));
+}
+
+#[test]
+fn t2_cookie_header_is_refused() {
+    assert!(matches!(
+        parse(&mutant(
+            "api_key_header = \"Authorization\"",
+            "api_key_header = \"Cookie\""
+        )),
+        Err(tidemark_core::plugin::PluginError::ForbiddenHeader { .. })
+    ));
+}
+
+#[test]
+fn t3_lowercase_get_method_is_refused() {
+    assert!(parse(&mutant("method = \"GET\"", "method = \"get\"")).is_err());
+}
+
+#[test]
+fn t4_lua53_language_is_refused() {
+    assert!(parse(&mutant("language = \"lua54\"", "language = \"lua53\"")).is_err());
+}
+
+#[test]
+fn t5_integer_plugin_version_is_refused() {
+    assert!(parse(&mutant("plugin_version = \"1.1.0\"", "plugin_version = 2")).is_err());
+}
+
+#[test]
+fn t6_future_format_version_is_refused_before_anything_else() {
+    assert!(matches!(
+        parse(&mutant("format_version = 1", "format_version = 3")),
+        Err(tidemark_core::plugin::PluginError::UnsupportedFormat { .. })
+    ));
+}
+
+#[test]
+fn t7_tidemark_namespace_is_reserved() {
+    assert!(matches!(
+        parse(&mutant(
+            "id = \"io.github.riccelso.ollama-cloud\"",
+            "id = \"tidemark.ollama\""
+        )),
+        Err(tidemark_core::plugin::PluginError::ReservedId { .. })
+    ));
+}
+
+#[test]
+fn t8_uppercase_id_is_refused() {
+    assert!(
+        parse(&mutant(
+            "id = \"io.github.riccelso.ollama-cloud\"",
+            "id = \"IO.GitHub.Riccelso\""
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn t9_dotless_id_is_refused() {
+    assert!(
+        parse(&mutant(
+            "id = \"io.github.riccelso.ollama-cloud\"",
+            "id = \"ollamacloud\""
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn t10_non_printable_prefix_is_refused() {
+    assert!(
+        parse(&mutant(
+            "api_key_prefix = \"Bearer \"",
+            "api_key_prefix = \"Bearer\\u0007\""
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn t11_source_without_parse_function_is_refused() {
+    assert!(
+        parse(&mutant(
+            "function parse(response, context)",
+            "function run(r, c)"
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn t12_scripted_mark_refuses_the_whole_file() {
+    // Replace the shipped mark's root with one carrying a <script>: the whole
+    // file must be refused at the SVG stage, not merely stripped of it.
+    let replaced = FILE.replacen(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\">",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>x()</script>",
+        1,
+    );
+    assert!(matches!(
+        parse(&replaced),
+        Err(tidemark_core::plugin::PluginError::Svg { .. })
+    ));
+}
+
+#[test]
+fn t13_an_endpoint_field_is_ignored_not_honoured() {
+    // Security property, executable: a stranger's file may not decide where
+    // the key goes. There is no endpoint field in the format, and an unknown
+    // key is inert — the definition parses and carries no host anywhere.
+    let hostile = format!("{FILE}\n[endpoint]\nurl = \"https://evil.example/steal\"\n");
+    let definition =
+        parse(&hostile).expect("unknown fields are inert; the daemon owns the endpoint");
+    let serialized = format!(
+        "{}{}{}",
+        definition.id, definition.api_key_header, definition.lua_source
+    );
+    assert!(
+        !serialized.contains("evil.example"),
+        "the definition carries no host"
+    );
+}
+
+#[test]
+fn t14_header_name_with_space_is_refused() {
+    assert!(
+        parse(&mutant(
+            "api_key_header = \"Authorization\"",
+            "api_key_header = \"Authorization \""
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn t15_oversized_provider_name_is_refused() {
+    let long = "A".repeat(129);
+    assert!(matches!(
+        parse(&mutant(
+            "name = \"Ollama Cloud\"",
+            &format!("name = \"{long}\"")
+        )),
+        Err(tidemark_core::plugin::PluginError::TooLarge { .. })
+    ));
+}
+
+#[test]
+fn t16_the_shipped_file_itself_parses_clean() {
+    let definition = parse(FILE).expect("the shipped file is a valid definition");
+    assert_eq!(definition.id, "io.github.riccelso.ollama-cloud");
+    assert!(
+        definition.icon_svg.is_some(),
+        "the mark survived sanitization"
+    );
+}

--- a/examples/plugins/ollama-cloud-README.md
+++ b/examples/plugins/ollama-cloud-README.md
@@ -12,12 +12,13 @@ This plugin is the keyed complement — no browser profile, no HTML.
 
 ```bash
 tidemarkctl plugin install ollama-cloud.tidemark-provider
-tidemarkctl provider add com.ollama.cloud
-tidemarkctl plugin endpoint com.ollama.cloud https://ollama.com/api/usage
-printf '%s' "$OLLAMA_API_KEY" | tidemarkctl auth set-key com.ollama.cloud
-tidemarkctl refresh com.ollama.cloud
+tidemarkctl provider add io.github.riccelso.ollama-cloud
+tidemarkctl plugin endpoint io.github.riccelso.ollama-cloud https://ollama.com/api/usage
+printf '%s' "$OLLAMA_API_KEY" | tidemarkctl auth set-key io.github.riccelso.ollama-cloud
+tidemarkctl refresh io.github.riccelso.ollama-cloud
 ```
 
-The response fixture (`ollama-cloud-response.json`) shows the paid-plan shape; the
-parser also handles the free plan, whose `limits.monthly` carries no absolute cap —
-in that shape the reading reports usage without a window, and nothing is invented.
+Only the free-plan shape has been observed live; the paid-plan branches
+(`usage_limit`, per-model rows) are a hypothesis the parser spells out and the
+fixture pins — nothing is invented on the free plan, and a wrong guess degrades to
+the honest uncapped reading instead of failing.

--- a/examples/plugins/ollama-cloud-README.md
+++ b/examples/plugins/ollama-cloud-README.md
@@ -1,0 +1,23 @@
+# Ollama Cloud (API key) — example plugin
+
+Reads `https://ollama.com/api/usage` with a Bearer API key (keys are created at
+`ollama.com/settings/keys`). Reports the monthly included-usage window, the trailing
+four-week cost, and per-model usage.
+
+The 5-hour/weekly session windows the settings page renders are not part of this
+endpoint's vocabulary; the built-in `ollama` provider (browser session) tracks those.
+This plugin is the keyed complement — no browser profile, no HTML.
+
+## Install
+
+```bash
+tidemarkctl plugin install ollama-cloud.tidemark-provider
+tidemarkctl provider add com.ollama.cloud
+tidemarkctl plugin endpoint com.ollama.cloud https://ollama.com/api/usage
+printf '%s' "$OLLAMA_API_KEY" | tidemarkctl auth set-key com.ollama.cloud
+tidemarkctl refresh com.ollama.cloud
+```
+
+The response fixture (`ollama-cloud-response.json`) shows the paid-plan shape; the
+parser also handles the free plan, whose `limits.monthly` carries no absolute cap —
+in that shape the reading reports usage without a window, and nothing is invented.

--- a/examples/plugins/ollama-cloud-response.json
+++ b/examples/plugins/ollama-cloud-response.json
@@ -1,0 +1,31 @@
+{
+    "activity": {
+        "cost": "12.5",
+        "period": {
+            "type": "last_4_weeks",
+            "starting_at": "2026-08-17T00:00:00Z",
+            "ending_at": "2026-09-09T23:05:51Z"
+        },
+        "models": [
+            {
+                "id": "gemma4:31b",
+                "name": "gemma4:31b",
+                "usage": 320,
+                "limit": 1000
+            },
+            {
+                "id": "gpt-oss:120b",
+                "name": "gpt-oss:120b",
+                "usage": 74,
+                "limit": null
+            }
+        ]
+    },
+    "limits": {
+        "monthly": {
+            "usage": 41.2,
+            "usage_limit": 100,
+            "models": []
+        }
+    }
+}

--- a/examples/plugins/ollama-cloud.tidemark-provider
+++ b/examples/plugins/ollama-cloud.tidemark-provider
@@ -1,9 +1,9 @@
 format_version = 1
 
 [provider]
-id = "com.ollama.cloud"
+id = "io.github.riccelso.ollama-cloud"
 name = "Ollama Cloud"
-plugin_version = "1.0.0"
+plugin_version = "1.1.0"
 
 [request]
 method = "GET"
@@ -18,31 +18,34 @@ function parse(response, context)
     --   activity — cost and per-model usage over the trailing four weeks
     --   limits   — the plan's monthly included usage
     --
-    -- The endpoint reports no absolute cap on the free plan: limits.monthly carries
-    -- only `usage`. A paid plan is expected to spell its cap `usage_limit`; when the
-    -- field is absent the reading stays honest — a value with no maximum, no
-    -- percentage — rather than fabricating one.
+    -- The endpoint reports no reset time and no window length for the monthly
+    -- figure, so none is declared: the reading stays a plain number rather
+    -- than borrowing the activity period's end as an invented rollover.
     --
-    -- The 5-hour/weekly session windows the settings page renders are not part of
-    -- this endpoint; the built-in `ollama` provider (browser session) tracks those.
+    -- Only the free-plan shape has been observed live (2026-09-09):
+    -- limits.monthly carries `usage` and no cap, activity.models is empty.
+    -- The paid-plan branches (usage_limit, per-model usage/limit) are a
+    -- hypothesis this example spells out; if the real paid shape names its
+    -- cap differently, those branches never fire and the reading stays the
+    -- honest uncapped one instead of failing on a guess.
+    --
+    -- The 5-hour/weekly session windows the settings page renders are not
+    -- part of this endpoint; the built-in `ollama` provider (browser
+    -- session) tracks those.
 
     local monthly = response.limits.monthly
+    local used = number(monthly.usage)
 
     local metrics = {}
     local card = {}
     local items = {}
-
-    local used = nil
-    if monthly.usage ~= nil then
-        used = number(monthly.usage)
-    end
 
     local limit = nil
     if monthly.usage_limit ~= nil then
         limit = number(monthly.usage_limit)
     end
 
-    if used ~= nil and limit ~= nil then
+    if limit ~= nil then
         table.insert(metrics, {
             id = "monthly-usage",
             title = "Monthly usage",
@@ -50,17 +53,10 @@ function parse(response, context)
             maximum = limit,
             remaining = limit - used,
             used_percent = percent(used, limit),
-            window = {
-                key = "month",
-                resets_at = parse_time(response.activity.period.ending_at),
-                length_seconds = 2592000,
-            },
         })
         table.insert(card, gauge("monthly-usage"))
         table.insert(items, ratio("monthly-usage", { left = "value", right = "maximum" }))
-    elseif used ~= nil then
-        -- No cap on this plan: report the raw usage without a window, so nothing is
-        -- invented and the card says what the endpoint actually said.
+    else
         table.insert(metrics, {
             id = "monthly-usage",
             title = "Monthly usage",
@@ -69,52 +65,42 @@ function parse(response, context)
         table.insert(card, value("monthly-usage", { field = "value" }))
     end
 
-    local cost = nil
-    if response.activity.cost ~= nil then
-        cost = number(response.activity.cost)
-    end
-    if cost ~= nil then
-        table.insert(metrics, {
-            id = "cost-4w",
-            title = "Cost (4 weeks)",
-            value = cost,
-            unit = "USD",
-        })
-        table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
-    end
+    local cost = number(response.activity.cost)
+    table.insert(metrics, {
+        id = "cost-4w",
+        title = "Cost (4 weeks)",
+        value = cost,
+        unit = "USD",
+    })
+    table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
 
-    if response.activity.models ~= nil then
-        for _, model in ipairs(response.activity.models) do
-            local used_m = nil
-            if model.usage ~= nil then
-                used_m = number(model.usage)
-            end
-            local cap = nil
-            if model.limit ~= nil and not is_null(model.limit) then
-                cap = number(model.limit)
-            end
+    for _, model in ipairs(response.activity.models) do
+        local id = "model-" .. model.id
+        local title = tostring(model.id)
+        local used_m = number(model.usage)
 
-            local id = "model-" .. tostring(model.id)
-            local title = tostring(model.name or model.id)
+        local cap = nil
+        if model.limit ~= nil and not is_null(model.limit) then
+            cap = number(model.limit)
+        end
 
-            if used_m ~= nil and cap ~= nil then
-                table.insert(metrics, {
-                    id = id,
-                    title = title,
-                    value = used_m,
-                    maximum = cap,
-                    remaining = cap - used_m,
-                    used_percent = percent(used_m, cap),
-                })
-                table.insert(items, ratio(id, { left = "value", right = "maximum" }))
-            elseif used_m ~= nil then
-                table.insert(metrics, {
-                    id = id,
-                    title = title,
-                    value = used_m,
-                })
-                table.insert(items, value(id, { field = "value" }))
-            end
+        if cap ~= nil then
+            table.insert(metrics, {
+                id = id,
+                title = title,
+                value = used_m,
+                maximum = cap,
+                remaining = cap - used_m,
+                used_percent = percent(used_m, cap),
+            })
+            table.insert(items, ratio(id, { left = "value", right = "maximum" }))
+        else
+            table.insert(metrics, {
+                id = id,
+                title = title,
+                value = used_m,
+            })
+            table.insert(items, value(id, { field = "value" }))
         end
     end
 

--- a/examples/plugins/ollama-cloud.tidemark-provider
+++ b/examples/plugins/ollama-cloud.tidemark-provider
@@ -1,0 +1,134 @@
+format_version = 1
+
+[provider]
+id = "com.ollama.cloud"
+name = "Ollama Cloud"
+plugin_version = "1.0.0"
+
+[request]
+method = "GET"
+api_key_header = "Authorization"
+api_key_prefix = "Bearer "
+
+[parser]
+language = "lua54"
+source = '''
+function parse(response, context)
+    -- ollama.com/api/usage answers with two top-level tables:
+    --   activity — cost and per-model usage over the trailing four weeks
+    --   limits   — the plan's monthly included usage
+    --
+    -- The endpoint reports no absolute cap on the free plan: limits.monthly carries
+    -- only `usage`. A paid plan is expected to spell its cap `usage_limit`; when the
+    -- field is absent the reading stays honest — a value with no maximum, no
+    -- percentage — rather than fabricating one.
+    --
+    -- The 5-hour/weekly session windows the settings page renders are not part of
+    -- this endpoint; the built-in `ollama` provider (browser session) tracks those.
+
+    local monthly = response.limits.monthly
+
+    local metrics = {}
+    local card = {}
+    local items = {}
+
+    local used = nil
+    if monthly.usage ~= nil then
+        used = number(monthly.usage)
+    end
+
+    local limit = nil
+    if monthly.usage_limit ~= nil then
+        limit = number(monthly.usage_limit)
+    end
+
+    if used ~= nil and limit ~= nil then
+        table.insert(metrics, {
+            id = "monthly-usage",
+            title = "Monthly usage",
+            value = used,
+            maximum = limit,
+            remaining = limit - used,
+            used_percent = percent(used, limit),
+            window = {
+                key = "month",
+                resets_at = parse_time(response.activity.period.ending_at),
+                length_seconds = 2592000,
+            },
+        })
+        table.insert(card, gauge("monthly-usage"))
+        table.insert(items, ratio("monthly-usage", { left = "value", right = "maximum" }))
+    elseif used ~= nil then
+        -- No cap on this plan: report the raw usage without a window, so nothing is
+        -- invented and the card says what the endpoint actually said.
+        table.insert(metrics, {
+            id = "monthly-usage",
+            title = "Monthly usage",
+            value = used,
+        })
+        table.insert(card, value("monthly-usage", { field = "value" }))
+    end
+
+    local cost = nil
+    if response.activity.cost ~= nil then
+        cost = number(response.activity.cost)
+    end
+    if cost ~= nil then
+        table.insert(metrics, {
+            id = "cost-4w",
+            title = "Cost (4 weeks)",
+            value = cost,
+            unit = "USD",
+        })
+        table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
+    end
+
+    if response.activity.models ~= nil then
+        for _, model in ipairs(response.activity.models) do
+            local used_m = nil
+            if model.usage ~= nil then
+                used_m = number(model.usage)
+            end
+            local cap = nil
+            if model.limit ~= nil and not is_null(model.limit) then
+                cap = number(model.limit)
+            end
+
+            local id = "model-" .. tostring(model.id)
+            local title = tostring(model.name or model.id)
+
+            if used_m ~= nil and cap ~= nil then
+                table.insert(metrics, {
+                    id = id,
+                    title = title,
+                    value = used_m,
+                    maximum = cap,
+                    remaining = cap - used_m,
+                    used_percent = percent(used_m, cap),
+                })
+                table.insert(items, ratio(id, { left = "value", right = "maximum" }))
+            elseif used_m ~= nil then
+                table.insert(metrics, {
+                    id = id,
+                    title = title,
+                    value = used_m,
+                })
+                table.insert(items, value(id, { field = "value" }))
+            end
+        end
+    end
+
+    return {
+        metrics = metrics,
+        card = card,
+        details = { { title = "Usage", items = items } },
+    }
+end
+'''
+
+[icon]
+svg = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path fill="currentColor" d="M32 4c-5 0-9 2-12 5-4 1-7 4-8 8-2 3-3 7-3 11s1 8 3 11c1 4 4 7 8 8 3 3 7 5 12 5s9-2 12-5c4-1 7-4 8-8 2-3 3-7 3-11s-1-8-3-11c-1-4-4-7-8-8-3-3-7-5-12-5zm0 8c3 0 6 1 8 3 2 1 4 3 5 5 1 2 2 5 2 7s-1 5-2 7c-1 2-3 4-5 5-2 2-5 3-8 3s-6-1-8-3c-2-1-4-3-5-5-1-2-2-5-2-7s1-5 2-7c1-2 3-4 5-5 2-2 5-3 8-3z"/>
+</svg>
+'''

--- a/examples/plugins/ollama-cloud.tidemark-provider
+++ b/examples/plugins/ollama-cloud.tidemark-provider
@@ -75,6 +75,12 @@ function parse(response, context)
     table.insert(items, value("cost-4w", { field = "value", format = "currency" }))
 
     for _, model in ipairs(response.activity.models) do
+        -- A model row without a usable id cannot be named, and two rows cannot
+        -- share one: both are recognized malformations of this endpoint's shape
+        -- and refuse the reading, rather than filing an unnamed or colliding row.
+        if model.id == nil or model.id == "" then
+            error("a model row has no id")
+        end
         local id = "model-" .. model.id
         local title = tostring(model.id)
         local used_m = number(model.usage)


### PR DESCRIPTION
Follow-up to #61, built on the new plugin-provider system (#58).

`examples/plugins/ollama-cloud.tidemark-provider` reads `ollama.com/api/usage` with a Bearer API key (keys from ollama.com/settings/keys): the monthly included-usage window, the trailing four-week cost, and per-model usage rows.

**Design notes:**

- The endpoint serves two plan shapes, and the parser handles both **without inventing fields**:
  - *Free plan* — `limits.monthly` carries `usage` only, no absolute cap: the reading reports the raw usage with no `maximum`, no `used_percent`, no `window` ("absent stays absent").
  - *Paid plan* — `usage_limit` present: the monthly metric becomes a windowed gauge (`percent(used, limit)`), reset from `activity.period.ending_at`.
  - Per-model rows: a capped model carries its ratio; a model with `limit: null` is listed with raw usage only.
- Session windows (5h/weekly) that the settings page renders are **not** in this endpoint's vocabulary — the existing browser-session `ollama` provider keeps those. This plugin is the keyed complement; both can coexist as separate providers (`ollama` + `com.ollama.cloud`).
- Verified live during development: `GET /api/usage` returns `401` with browser cookies (the endpoint is Bearer-only by design), `200` with an API key.

**Validation:**

- `cargo fmt`, `cargo clippy -p tidemark-core --all-targets -- -D warnings` clean.
- New colocated test `tests/ollama_plugin.rs` renders both fixture shapes through `plugin::render` (the one transformation) and asserts the no-fabrication contract on the free plan.
- Full `tidemark-core` suite: 1075 passed; the 3 `secrets` lib tests that need a live Secret Service fail identically on pristine `main` in this headless environment (CI's `dbus-run-session` covers them).
- `tidemarkctl plugin validate` + `plugin render` exercised against both fixtures through a local daemon build.

Closes nothing on its own — if you'd rather have this in a separate examples/plugins collection or want changes to the metric layout, happy to adjust.
