### PR TITLE
fix(windows): stop asserting scheduling luck in the atomic publish race

### DIFF
--- a/crates/tidemark-core/tests/oauth_file_windows.rs
+++ b/crates/tidemark-core/tests/oauth_file_windows.rs
@@ -156,7 +156,12 @@ fn atomic_replace_exposes_only_complete_states() {
     });
 
     start.wait();
-    let mut observations = 0;
+    // Iterations, not successful reads: while the writer holds its mandatory lock
+    // every read is denied with os error 33, so demanding a successful read here
+    // would assert scheduling luck — landing in the gap between lock release and
+    // `done` — rather than a property of the publish. What this loop guarantees
+    // is weaker and sufficient: every read that did succeed saw a complete state.
+    let mut spins = 0;
     while !done.load(Ordering::Acquire) {
         // Windows byte-range locks are mandatory: while the writer holds the update
         // lock, a reader may be denied outright (os error 33). Being denied is not a
@@ -172,11 +177,11 @@ fn atomic_replace_exposes_only_complete_states() {
                     token == old || token == new,
                     "reader observed a partial state"
                 );
-                observations += 1;
             }
             Err(error) if error.raw_os_error() == Some(33) => {}
             Err(error) => panic!("unexpected reader error: {error}"),
         }
+        spins += 1;
         std::thread::yield_now();
     }
     // After the lock release a successful read is guaranteed, pinning the final state
@@ -193,7 +198,7 @@ fn atomic_replace_exposes_only_complete_states() {
         writer.join().expect("writer thread"),
         UpdateOutcome::Published
     );
-    assert!(observations > 0, "reader observed the publish window");
+    assert!(spins > 0, "reader never raced the publish");
     assert!(
         fs::read_dir(&dir.0)
             .expect("directory readable")


### PR DESCRIPTION
## Summary

The Windows-only `atomic_replace_exposes_only_complete_states` test failed intermittently in CI (seen on the `fix/ollama-free-usage-meter` push run, while the identical PR run on the same commit went green). Root cause: while the writer holds its mandatory byte-range lock, every concurrent read is denied with os error 33, so a successful read can only land in the nanosecond gap between lock release and the `done` flag store — and the test asserted `observations > 0`, i.e. it demanded the scheduler win that race. The assertion tested scheduling luck, not a property of the publish.

## Changes

- `crates/tidemark-core/tests/oauth_file_windows.rs` (test-only, production code untouched): the spin loop now counts iterations instead of successful reads, and asserts `spins > 0` ("reader never raced the publish"). This keeps the loop's original self-check purpose — proving it actually raced the publish rather than spinning in a void — deterministically: after the start barrier the writer spends milliseconds on 128KB of JSON I/O while the reader's first check is microseconds away.
- Untouched and still enforced: every successful read must parse as complete JSON with the old or the new token (no torn states), the post-release read pins the final published state, and no staging file may remain.

## QA & Evidence

- **What was tested:** `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `./scripts/check-layering.sh`.
  **Observed result:** clean; 1737 passed, 0 failed; layering ok.
- **What was tested:** the edited Windows-only test file (`#![cfg(windows)]`, not compilable on Linux) — parsed via rustfmt and reviewed; no other file changed (`git diff --stat`: 1 file, 8+/3-).
  **Observed result:** syntax valid, no leftover references, no new lints possible on this platform.
- **Why sufficient:** the change only weakens a scheduling-dependent assertion into a deterministic equivalent; every correctness assertion of the test is byte-identical. Final word belongs to the Windows CI job on this branch.

## Risks & Residuals

- The fixed test cannot run on Linux (`cfg(windows)`); a typo-class mistake would surface only in Windows CI. Mitigated by review + rustfmt parse + minimal diff.
- If the race ever fails again, it will be a different assertion with a real signal (torn read, wrong final state, leftover staging file) — worth investigating then, not now. Accepted.

## Automated Checks

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
./scripts/check-layering.sh
```

## Related Issues

None — follow-up hygiene from the flaky `windows-tests` failure observed on #65's push run (the same commit went green on the PR run).