### PR TITLE
feat(gui): open the provider row's own controls from a card

### DIFF
--- a/crates/tidemark/src/card.rs
+++ b/crates/tidemark/src/card.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use gtk::gio;
 use gtk::prelude::*;
 use tidemark_types::{
     DetailSection, Emphasis, Field, Metric, MetricWindow, Presentation, ProviderState,
@@ -103,6 +104,110 @@ pub(crate) struct CardExpansion {
     pub(crate) expanded: bool,
     pub(crate) on_toggled: Rc<dyn Fn(bool)>,
 }
+
+/// The name the card's own action group is installed under. Menu items address it, so
+/// the group name and the prefix in every `card.*` action string are the same string.
+const CARD_ACTIONS: &str = "card";
+
+/// One entry of a card's secondary-click menu. Each is a shortcut to the control the
+/// provider settings row draws for the same account — never a second implementation of it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CardAction {
+    AddAccount,
+    Modify,
+    Remove,
+}
+
+impl CardAction {
+    /// The action's name inside the card's group.
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::AddAccount => "add-account",
+            Self::Modify => "modify",
+            Self::Remove => "remove",
+        }
+    }
+
+    /// What the menu item says, in the words the settings row's tooltip uses.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::AddAccount => "Add new account",
+            Self::Modify => "Modify",
+            Self::Remove => "Remove",
+        }
+    }
+
+    fn detailed(self) -> String {
+        format!("{CARD_ACTIONS}.{}", self.name())
+    }
+}
+
+/// Removal is the one entry that undoes rather than configures, so it sits in a section of
+/// its own and the menu draws a separator above it.
+fn menu_sections(entries: &[CardAction]) -> Vec<Vec<CardAction>> {
+    let (destructive, configuring): (Vec<CardAction>, Vec<CardAction>) = entries
+        .iter()
+        .partition(|action| matches!(action, CardAction::Remove));
+    [configuring, destructive]
+        .into_iter()
+        .filter(|section| !section.is_empty())
+        .collect()
+}
+
+fn menu_model(entries: &[CardAction]) -> gio::Menu {
+    let menu = gio::Menu::new();
+    for section in menu_sections(entries) {
+        let group = gio::Menu::new();
+        for action in section {
+            group.append(Some(action.label()), Some(&action.detailed()));
+        }
+        menu.append_section(None, &group);
+    }
+    menu
+}
+
+/// The two keyboard ways to ask for a context menu, which GTK does not route for a plain
+/// widget the way it does for a text view.
+fn menu_key(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
+    key == gtk::gdk::Key::Menu
+        || (key == gtk::gdk::Key::F10 && modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK))
+}
+
+/// Installs one action per entry on the card itself. The identity is fixed for the life of
+/// the card, so the actions are too; only which of them the menu offers changes.
+fn install_card_actions(slot: &gtk::Overlay, identity: &CardIdentity, menu: &CardMenu) {
+    let actions = gio::SimpleActionGroup::new();
+    for action in [
+        CardAction::AddAccount,
+        CardAction::Modify,
+        CardAction::Remove,
+    ] {
+        let entry = gio::SimpleAction::new(action.name(), None);
+        entry.connect_activate({
+            let on_choose = Rc::clone(&menu.on_choose);
+            let identity = identity.clone();
+            move |_, _| {
+                on_choose(action, identity.provider.clone(), identity.account.clone());
+            }
+        });
+        actions.add_action(&entry);
+    }
+    slot.insert_action_group(CARD_ACTIONS, Some(&actions));
+}
+
+/// A card's secondary-click menu. Which entries a provider offers is asked when the menu
+/// opens, not when the card is built, so a catalog that arrives later is already answered
+/// for; what a chosen entry does belongs to the window, exactly as activation does.
+#[derive(Clone)]
+pub(crate) struct CardMenu {
+    pub(crate) entries: CardEntries,
+    pub(crate) on_choose: CardChoice,
+}
+
+/// Which entries one account's menu currently offers, by provider and account id.
+pub(crate) type CardEntries = Rc<dyn Fn(&str, &str) -> Vec<CardAction>>;
+/// What a chosen entry does, with the identity of the card it was chosen on.
+pub(crate) type CardChoice = Rc<dyn Fn(CardAction, String, String)>;
 
 /// The provider context and account name shown at the top of a quota card.
 #[derive(Debug)]
@@ -190,6 +295,19 @@ pub struct Card {
     balance_fraction: gtk::Label,
     footer: gtk::Label,
     shown: RefCell<Shown>,
+    /// Built on the first secondary click and reparented to nothing when the card goes.
+    menu: Rc<RefCell<Option<gtk::PopoverMenu>>>,
+}
+
+impl Drop for Card {
+    /// A `GtkPopoverMenu` is parented to the slot rather than packed into it, so nothing
+    /// takes it away when the slot is dropped. Unparenting here is what keeps a removed
+    /// card from leaving a popover behind.
+    fn drop(&mut self) {
+        if let Some(menu) = self.menu.borrow_mut().take() {
+            menu.unparent();
+        }
+    }
 }
 
 /// A drawable widget resolved against its metric. Only old-daemon rows own their data.
@@ -358,6 +476,7 @@ impl Card {
         now: Timestamp,
         title: CardTitle,
         on_activate: Rc<dyn Fn(String, String)>,
+        menu: CardMenu,
         expansion: Option<CardExpansion>,
     ) -> Self {
         // All three ellipsize. None of them is expected to: a provider's name, its plan and
@@ -605,23 +724,77 @@ impl Card {
         let identity = CardIdentity::from(status);
         let invoke: Rc<dyn Fn()> = Rc::new({
             let on_activate = Rc::clone(&on_activate);
+            let identity = identity.clone();
             move || identity.activate(on_activate.as_ref())
         });
         let click = gtk::GestureClick::new();
+        // The primary button only. Without this the same gesture answers the secondary
+        // one too, and a right-click would open the detail dialog under its own menu.
+        click.set_button(gtk::gdk::BUTTON_PRIMARY);
         click.connect_released({
             let invoke = Rc::clone(&invoke);
             move |_, _, _, _| invoke()
         });
         slot.add_controller(click);
+
+        let popover: Rc<RefCell<Option<gtk::PopoverMenu>>> = Rc::new(RefCell::new(None));
+        install_card_actions(&slot, &identity, &menu);
+        let popup: Rc<dyn Fn(f64, f64)> = Rc::new({
+            let slot = slot.clone();
+            let popover = Rc::clone(&popover);
+            let entries = Rc::clone(&menu.entries);
+            let identity = identity.clone();
+            move |x, y| {
+                let shown = entries(&identity.provider, &identity.account);
+                if shown.is_empty() {
+                    return;
+                }
+                let mut held = popover.borrow_mut();
+                let menu = held.get_or_insert_with(|| {
+                    let menu = gtk::PopoverMenu::from_model(None::<&gio::MenuModel>);
+                    menu.set_parent(&slot);
+                    menu.set_has_arrow(false);
+                    menu.set_halign(gtk::Align::Start);
+                    menu
+                });
+                menu.set_menu_model(Some(&menu_model(&shown)));
+                menu.set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
+                menu.popup();
+            }
+        });
+
+        let secondary = gtk::GestureClick::new();
+        secondary.set_button(gtk::gdk::BUTTON_SECONDARY);
+        // On press, not release: that is when every other menu on this desktop appears,
+        // and claiming the sequence keeps the grid's drag out of it.
+        secondary.connect_pressed({
+            let popup = Rc::clone(&popup);
+            move |gesture, _, x, y| {
+                gesture.set_state(gtk::EventSequenceState::Claimed);
+                popup(x, y);
+            }
+        });
+        slot.add_controller(secondary);
+
         let keys = gtk::EventControllerKey::new();
         keys.connect_key_pressed({
             let invoke = Rc::clone(&invoke);
-            move |_, key, _, _| {
+            let popup = Rc::clone(&popup);
+            let slot = slot.clone();
+            move |_, key, _, modifiers| {
                 if matches!(
                     key,
                     gtk::gdk::Key::Return | gtk::gdk::Key::KP_Enter | gtk::gdk::Key::space
                 ) {
                     invoke();
+                    gtk::glib::Propagation::Stop
+                } else if menu_key(key, modifiers) {
+                    // No pointer to point at: the keyboard's menu opens against the middle
+                    // of the card it belongs to.
+                    popup(
+                        f64::from(slot.width()) / 2.0,
+                        f64::from(slot.height()) / 2.0,
+                    );
                     gtk::glib::Propagation::Stop
                 } else {
                     gtk::glib::Propagation::Proceed
@@ -650,6 +823,7 @@ impl Card {
             balance_whole,
             balance_fraction,
             footer,
+            menu: popover,
             shown: RefCell::new(Shown {
                 status: status.clone(),
                 secondary: Vec::new(),
@@ -1256,6 +1430,60 @@ mod tests {
 
         identity.activate(activate.as_ref());
         assert_eq!(calls.borrow().as_slice(), [("zai".into(), "work".into())]);
+    }
+
+    #[test]
+    fn a_card_menu_separates_removal_from_the_entries_that_configure() {
+        let sections = menu_sections(&[
+            CardAction::AddAccount,
+            CardAction::Modify,
+            CardAction::Remove,
+        ]);
+
+        assert_eq!(
+            sections,
+            [
+                vec![CardAction::AddAccount, CardAction::Modify],
+                vec![CardAction::Remove],
+            ]
+        );
+    }
+
+    #[test]
+    fn a_menu_of_removal_alone_draws_no_empty_section_above_it() {
+        assert_eq!(
+            menu_sections(&[CardAction::Remove]),
+            [vec![CardAction::Remove]]
+        );
+    }
+
+    #[test]
+    fn every_card_menu_entry_addresses_the_cards_own_action_group() {
+        // The group is installed under this name on the card, so an item addressing any
+        // other prefix would draw insensitive.
+        for action in [
+            CardAction::AddAccount,
+            CardAction::Modify,
+            CardAction::Remove,
+        ] {
+            assert_eq!(
+                action.detailed(),
+                format!("{CARD_ACTIONS}.{}", action.name())
+            );
+        }
+        assert_eq!(CardAction::AddAccount.label(), "Add new account");
+        assert_eq!(CardAction::Modify.label(), "Modify");
+        assert_eq!(CardAction::Remove.label(), "Remove");
+    }
+
+    #[test]
+    fn the_keyboard_asks_for_a_card_menu_the_two_ways_the_desktop_does() {
+        use gtk::gdk::{Key, ModifierType};
+
+        assert!(menu_key(Key::Menu, ModifierType::empty()));
+        assert!(menu_key(Key::F10, ModifierType::SHIFT_MASK));
+        assert!(!menu_key(Key::F10, ModifierType::empty()));
+        assert!(!menu_key(Key::space, ModifierType::SHIFT_MASK));
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/mod.rs
+++ b/crates/tidemark/src/provider_settings/mod.rs
@@ -20,6 +20,7 @@ use tidemark_types::{
 use self::detail::ProviderDetail;
 use self::list::{ConfiguredList, Picker, RowCallbacks};
 use crate::bus::DaemonProxy;
+use crate::card::CardAction;
 
 /// The account a provider's structural first add holds. The daemon will not rename it,
 /// so the label pen stays off its page.
@@ -174,6 +175,7 @@ fn remove_local_provider<T>(
 #[derive(Debug)]
 pub struct ProviderSettings {
     dialog: adw::PreferencesDialog,
+    tabs: adw::ToggleGroup,
     proxy: DaemonProxy<'static>,
     definitions: RefCell<Vec<ProviderDefinition>>,
     statuses: RefCell<Vec<ProviderStatus>>,
@@ -269,6 +271,7 @@ impl ProviderSettings {
         });
         let settings = Rc::new(Self {
             dialog: dialog.clone(),
+            tabs: tabs.clone(),
             proxy,
             definitions: RefCell::new(Vec::new()),
             statuses: RefCell::new(Vec::new()),
@@ -438,6 +441,42 @@ impl ProviderSettings {
                 action(&settings, provider);
             }
         })
+    }
+
+    /// The three shortcuts a quota card's context menu takes into this dialog. Each is
+    /// the row's own control, reached with the row's identity instead of its button, so
+    /// there is one implementation of adding, editing and removing an account.
+    ///
+    /// The tab is settled first: a subpage covers the list while it is open, and going
+    /// back from a custom provider's page has to land on the tab that provider is on.
+    pub fn shortcut_add_account(self: &Rc<Self>, provider: &str) {
+        self.show_provider_tab(provider);
+        self.add_account(provider.to_owned());
+    }
+
+    pub fn shortcut_open_detail(self: &Rc<Self>, provider: &str, account: &str) {
+        self.show_provider_tab(provider);
+        self.open_detail(provider.to_owned(), account.to_owned());
+    }
+
+    pub fn shortcut_remove(self: &Rc<Self>, provider: &str, account: &str) {
+        self.show_provider_tab(provider);
+        self.confirm_removal(provider.to_owned(), account.to_owned());
+    }
+
+    /// Selects the tab this provider is drawn on. A plugin lives on the custom tab in both
+    /// of its states; everything else is built-in.
+    fn show_provider_tab(&self, provider: &str) {
+        let custom = self
+            .definitions
+            .borrow()
+            .iter()
+            .any(|definition| definition.provider == provider && definition.plugin.is_some());
+        let name = if custom { "custom" } else { "built-in" };
+        // Setting the toggle fires `show_tab` through the notify handler; the explicit
+        // call is what keeps the groups right if the toggle was already on that name.
+        self.tabs.set_active_name(Some(name));
+        self.show_tab(name);
     }
 
     fn open_picker(&self) {
@@ -933,6 +972,21 @@ pub(super) fn opens_detail_after_add(definition: &ProviderDefinition) -> bool {
 /// Whether a user can give this provider another account: a key or a browser login is
 /// something a second account can hold its own copy of, while an external or
 /// credential-free provider reads whatever one thing this machine already has.
+/// The entries a quota card's context menu offers for one provider. The same three rules
+/// the configured row's buttons follow: a second account where the credential can hold
+/// one, a pen where there is something to configure, and removal always.
+pub fn card_actions(definition: Option<&ProviderDefinition>) -> Vec<CardAction> {
+    let mut actions = Vec::new();
+    if definition.is_some_and(multi_account_capable) {
+        actions.push(CardAction::AddAccount);
+    }
+    if definition.is_some_and(opens_detail_after_add) {
+        actions.push(CardAction::Modify);
+    }
+    actions.push(CardAction::Remove);
+    actions
+}
+
 pub(super) fn multi_account_capable(definition: &ProviderDefinition) -> bool {
     matches!(
         definition.credential_kind(),
@@ -1047,8 +1101,8 @@ mod tests {
 
     use super::detail::{AfterBeginAction, after_begin_action};
     use super::{
-        ActiveDetail, DEFAULT_ACCOUNT, DetailCache, PendingLogins, multi_account_capable,
-        name_suggests_usable, opens_detail_after_add, remove_local_provider,
+        ActiveDetail, CardAction, DEFAULT_ACCOUNT, DetailCache, PendingLogins, card_actions,
+        multi_account_capable, name_suggests_usable, opens_detail_after_add, remove_local_provider,
     };
 
     fn definition(credential: CredentialKind) -> ProviderDefinition {
@@ -1109,6 +1163,38 @@ mod tests {
             choices: Vec::new(),
         });
         assert!(opens_detail_after_add(&with_options));
+    }
+
+    #[test]
+    fn a_cards_menu_offers_what_the_settings_row_draws_buttons_for() {
+        // A key provider's row has all three controls, so its card offers all three.
+        assert_eq!(
+            card_actions(Some(&definition(CredentialKind::Key))),
+            [
+                CardAction::AddAccount,
+                CardAction::Modify,
+                CardAction::Remove
+            ]
+        );
+        // Nothing to configure and no second account to hold a credential: the row draws
+        // only its trash, and so the menu is only removal.
+        assert_eq!(
+            card_actions(Some(&definition(CredentialKind::None))),
+            [CardAction::Remove]
+        );
+        // A local source to pick is something to modify, without being something a second
+        // account can hold its own copy of.
+        assert_eq!(
+            card_actions(Some(&keyless_with_browser_auth())),
+            [CardAction::Modify, CardAction::Remove]
+        );
+    }
+
+    #[test]
+    fn a_card_with_no_definition_can_still_be_removed() {
+        // A configured provider the catalog no longer offers: nothing can be added to it
+        // or configured on it, but it is exactly the one a user wants gone.
+        assert_eq!(card_actions(None), [CardAction::Remove]);
     }
 
     #[test]

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -23,12 +23,12 @@ use tidemark_types::{
 
 use crate::about;
 use crate::bus::{self, DaemonProxy, Update};
-use crate::card::{Card, CardExpansion, CardTitle};
+use crate::card::{Card, CardAction, CardExpansion, CardMenu, CardTitle};
 use crate::detail::DetailDialog;
 use crate::grid::CardGrid;
 use crate::model;
 use crate::preferences::PreferencesDialog;
-use crate::provider_settings::ProviderSettings;
+use crate::provider_settings::{self, ProviderSettings};
 use crate::tray::{self, Tray};
 use crate::update::{self, UpdateNotice};
 
@@ -549,17 +549,59 @@ impl MainWindow {
         expansion: Option<CardExpansion>,
     ) -> Rc<Card> {
         let weak = Rc::downgrade(self);
+        let menu = CardMenu {
+            entries: {
+                let weak = weak.clone();
+                Rc::new(move |provider, _| {
+                    let Some(main) = weak.upgrade() else {
+                        return Vec::new();
+                    };
+                    let definitions = main.definitions.borrow();
+                    provider_settings::card_actions(
+                        definitions
+                            .iter()
+                            .find(|definition| definition.provider == provider),
+                    )
+                })
+            },
+            on_choose: {
+                let weak = weak.clone();
+                Rc::new(move |action, provider, account| {
+                    if let Some(main) = weak.upgrade() {
+                        main.run_card_action(action, &provider, &account);
+                    }
+                })
+            },
+        };
         Rc::new(Card::new(
             status,
             now,
             title,
-            Rc::new(move |provider, account| {
-                if let Some(main) = weak.upgrade() {
-                    main.open_detail(&provider, &account);
+            Rc::new({
+                let weak = weak.clone();
+                move |provider, account| {
+                    if let Some(main) = weak.upgrade() {
+                        main.open_detail(&provider, &account);
+                    }
                 }
             }),
+            menu,
             expansion,
         ))
+    }
+
+    /// A card's context menu is a shortcut into the provider settings dialog, never a
+    /// second way of doing what it does: the dialog is opened (or reused) and asked to
+    /// take the row's own action on this account.
+    fn run_card_action(self: &Rc<Self>, action: CardAction, provider: &str, account: &str) {
+        let Some(dialog) = self.open_provider_settings() else {
+            return;
+        };
+        match action {
+            CardAction::AddAccount => dialog.shortcut_add_account(provider),
+            CardAction::Modify => dialog.shortcut_open_detail(provider, account),
+            CardAction::Remove => dialog.shortcut_remove(provider, account),
+        }
     }
 
     /// Opens one dimmed detail dialog and refuses a second until the first closes.
@@ -608,32 +650,36 @@ impl MainWindow {
     fn connect_providers_button(self: &Rc<Self>) {
         let weak: Weak<Self> = Rc::downgrade(self);
         self.providers.connect_clicked(move |_| {
-            let Some(main) = weak.upgrade() else {
-                return;
-            };
-            if !main.provider_settings.is_empty() {
-                return;
+            if let Some(main) = weak.upgrade() {
+                main.open_provider_settings();
             }
-            let Some(proxy) = main.daemon.borrow().clone() else {
-                return;
-            };
-            let on_closed = {
-                let weak = weak.clone();
-                move || {
-                    if let Some(main) = weak.upgrade() {
-                        main.provider_settings.clear();
-                    }
-                }
-            };
-            let dialog = ProviderSettings::present(
-                &main.window,
-                proxy,
-                &main.definitions.borrow(),
-                &main.statuses(),
-                on_closed,
-            );
-            assert!(main.provider_settings.insert_if_empty(dialog));
         });
+    }
+
+    /// Opens the one provider settings dialog, or hands back the open one. `None` means
+    /// there is no daemon to configure anything against.
+    fn open_provider_settings(self: &Rc<Self>) -> Option<Rc<ProviderSettings>> {
+        if let Some(dialog) = self.provider_settings.get() {
+            return Some(dialog);
+        }
+        let proxy = self.daemon.borrow().clone()?;
+        let on_closed = {
+            let weak: Weak<Self> = Rc::downgrade(self);
+            move || {
+                if let Some(main) = weak.upgrade() {
+                    main.provider_settings.clear();
+                }
+            }
+        };
+        let dialog = ProviderSettings::present(
+            &self.window,
+            proxy,
+            &self.definitions.borrow(),
+            &self.statuses(),
+            on_closed,
+        );
+        assert!(self.provider_settings.insert_if_empty(Rc::clone(&dialog)));
+        Some(dialog)
     }
 
     fn connect_preferences_action(self: &Rc<Self>) {


### PR DESCRIPTION
## Summary

- A secondary click on a quota card opens a menu of the three things that account's provider settings row already offers: **Add new account**, **Modify**, **Remove**.
- Every entry is a shortcut *into* the provider settings dialog, not a second implementation of the action: the dialog is opened (or reused) and asked to take the row's own action on the card's identity. Adding, editing and removing therefore stay in one place, including the nuance that removing a plugin's last account takes the installed provider file with it.
- Fixes an existing bug found on the way: the card's click gesture had no button filter, so the secondary button already opened the quota detail dialog. It is now the primary button's alone.

## Changes

- **`card.rs`** — `CardAction` (`AddAccount`/`Modify`/`Remove`) and `CardMenu`, whose two callbacks keep the same split activation already uses: which entries a provider offers is *asked when the menu opens* (so a catalog that arrives later is already answered for), and what a chosen entry does belongs to the window. A `GestureClick` on `BUTTON_SECONDARY` claims its sequence and pops up on press, the way the rest of the desktop's menus do; `Menu` and `Shift+F10` open the same menu against the middle of the card. The `PopoverMenu` is built on first use, parented to the slot, and unparented in `Drop for Card` — a popover is parented rather than packed, so nothing else would take it away. Removal sits in a section of its own, so the menu draws a separator above it.
- **`provider_settings/mod.rs`** — `card_actions(definition)` states, in one place, which of the three a provider offers, under the rules the row's buttons already follow: `multi_account_capable` for the second account, `opens_detail_after_add` for the pen, removal always. Three `pub` shortcuts (`shortcut_add_account`, `shortcut_open_detail`, `shortcut_remove`) call the existing private handlers; each settles the tab first, because a subpage covers the list while it is open and going back from a custom provider's page has to land on the tab that provider is on. The dialog now keeps its `AdwToggleGroup` for that.
- **`window.rs`** — `connect_providers_button` is split into `open_provider_settings() -> Option<Rc<ProviderSettings>>`, which opens the one dialog or hands back the open one; `run_card_action` dispatches an entry to the matching shortcut. `make_card` builds the card's menu from the window's own catalog.

## QA & Evidence

- **What was tested:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `./scripts/check-layering.sh`
  **Observed result:** all clean; 1300+ tests pass across the workspace (189 in the GUI crate), `layering ok`.
  **Artifact:** CI log on this PR.
  **Why sufficient:** covers the whole rule set this change adds — menu composition per definition, section split, action-group addressing, and the keyboard openers are unit-tested as pure functions, and the layering gate confirms the GUI still reaches nothing it should not.
- **What was tested:** new colocated tests — `a_cards_menu_offers_what_the_settings_row_draws_buttons_for`, `a_card_with_no_definition_can_still_be_removed`, `a_card_menu_separates_removal_from_the_entries_that_configure`, `a_menu_of_removal_alone_draws_no_empty_section_above_it`, `every_card_menu_entry_addresses_the_cards_own_action_group`, `the_keyboard_asks_for_a_card_menu_the_two_ways_the_desktop_does`.
  **Observed result:** pass.
  **Artifact:** `crates/tidemark/src/card.rs`, `crates/tidemark/src/provider_settings/mod.rs`.
  **Why sufficient:** the parts that can be wrong without a display — which entries appear, how they are grouped, and what they address — are tested directly; the GTK interaction itself is left to manual QA below.

**Manual QA still to do (not performed here):**

1. Right-click a key-holding provider's card → all three entries; right-click a keyless provider with no options (e.g. Ollama) → removal only.
2. **Modify** → the Providers dialog opens straight on that account's page; Back lands on the right tab (custom for a plugin).
3. **Add new account** → the name form, then that account's page.
4. **Remove** → the confirmation dialog, with the plugin-file wording for a plugin's last account.
5. Left click still opens the quota detail dialog; right click no longer does; the grid's drag-reorder is unaffected.
6. `Shift+F10` and the `Menu` key on a focused card.

## Risks & Residuals

- **A popover left behind when its card is removed** — mitigated: `Drop for Card` unparents it, and a card is dropped when the grid removes it.
- **The context menu diverging from the settings row** — mitigated by construction: the entries come from one `card_actions` rule and each one calls the row's own handler, so there is no second copy of the policy to drift.
- **GTK interaction is not covered by automated tests** — accepted: this repository tests presentation logic, not widget input, and the interaction is listed for manual QA above.
- **The reuse path in `open_provider_settings`** — accepted as defensive: the dialog is modal, so a card cannot be right-clicked while it is open, but returning the open dialog is still the correct answer if that ever changes.

## Related Issues

<!-- none -->

## Automated Checks

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
./scripts/check-layering.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbK8Qren7eBokpByb4YrHi
