### PR TITLE
ci: run one gate per change, not two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ on:
       - '**/*.md'
       - 'docs/**'
   push:
-    # Every branch, and tags excluded by saying so: a tag push belongs to the release
-    # workflow, which runs this same Linux gate itself before it builds anything.
-    branches: ['**']
+    # `main` only, and so tags too are excluded by saying so: a tag push belongs to the
+    # release workflow, which runs this same Linux gate itself before it builds anything.
+    #
+    # A branch push is deliberately not here. A branch with a pull request open is already
+    # covered by the `pull_request` event above, and better: that event builds the merge
+    # commit, so it answers "does this pass *on top of main*" rather than "did it pass on
+    # a branch cut some time ago". Listing every branch here ran both for every push, one
+    # of them redundantly — the two events produce different refs, so `concurrency` below
+    # never collapsed them. Before a pull request exists, the local gate in `CLAUDE.md` is
+    # the one that matters. `nix.yml` has always been shaped this way.
+    branches: [main]
     paths-ignore:
       - '*.md'
       - '**/*.md'


### PR DESCRIPTION
## Summary

- A branch pushed to this repository with a pull request open ran the CI gate **twice** — once for the `push` event, once for the `pull_request` event — on the same tree.
- The `push` trigger now narrows from `branches: ['**']` to `branches: [main]`, which is the shape `nix.yml` has always had. One gate per change; `main` is still gated after a merge.

## Changes

- **`.github/workflows/ci.yml`** — `push` listens on `main` only. The comment above it now records *why* the two events were not already collapsed: they produce different refs (`refs/heads/<branch>` vs `refs/pull/<n>/merge`), so the `ci-${{ github.ref }}` concurrency group below could never have deduplicated them, and says which signal a branch has before a pull request exists.

The `pull_request` event is the one kept because it is the better of the two: it builds the merge commit, so it answers whether the change passes *on top of current main* rather than on top of whatever main was when the branch was cut. A push run only ever answered the weaker question.

## QA & Evidence

- **What was tested:** the duplication itself, on the branch of #67 — `gh run list`
  **Observed result:** two CI runs for one push:
  ```
  CI  pull_request  feat/card-context-menu
  CI  push          feat/card-context-menu
  ```
  and the same pairing on `fix/windows-publish-window-flake` and `fix/ollama-free-usage-meter` before it.
  **Artifact:** the Actions tab of this repository.
  **Why sufficient:** it is the reported behaviour, reproduced on three separate branches, and the trigger block explains it exactly.
- **What was tested:** the workflow file still parses, and the triggers are the intended ones — `python3 -c "import yaml; print(yaml.safe_load(open('.github/workflows/ci.yml'))[True])"`
  **Observed result:** `{'pull_request': {'paths-ignore': [...]}, 'push': {'branches': ['main'], 'paths-ignore': [...]}}`
  **Why sufficient:** the only thing this change can get wrong is the trigger block; that is what was read back.
- **What was tested:** this pull request itself.
  **Observed result:** to be confirmed on this page — the expectation is exactly one CI run, from `pull_request`.
  **Why sufficient:** it is the change demonstrating itself.

## Risks & Residuals

- **A branch pushed with no pull request open gets no CI** — accepted, and it is the whole tradeoff. The local gate in `CLAUDE.md` (`cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && ./scripts/check-layering.sh`) is what covers that window, and opening a draft pull request gets the hosted gate back at any point.
- **Branch protection expecting a check from the push event** — not applicable: the required contexts are satisfied by the `pull_request` run, which is the one that was already reporting on every pull request page.
- **Tag pushes** — unchanged: they were excluded before by `branches` being present at all, and still are. `release.yml` runs this same Linux gate itself before it builds anything.
- **`update-nix-flake.yml`'s automated branch** — unaffected: it opens a pull request, and the `pull_request` event covers it.

## Automated Checks

No Rust or shell files changed, so the workspace gate has nothing to say about this diff; the checks that matter are the parse above and the run count on this page.

## Related Issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbK8Qren7eBokpByb4YrHi
