### PR TITLE
feat(gui): preview the changelog before leaving for a browser

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,6 +157,12 @@ the credential on the way, and looks again for the vendor login a provider can r
 of ours — a refresh is what a user reaches for straight after running `claude` in a
 terminal. `Version` says what is on the other end.
 
+`GetUpdate` says whether a newer release was found and `UpdateChanged(version)` announces
+it; `GetReleaseNotes` returns that release's notes as its publisher wrote them — Markdown,
+unrendered. The notes are a separate call rather than a second field on the announcement
+because a client needs the version to decide whether to offer anything at all, and the
+notes only once a reader asks for them.
+
 Credentials are the daemon's, so changing them is the daemon's too: `SetKey`, `SignOut`,
 `SetOption`, `SetWindowNotify`, and the two halves of a login. Nothing there is specific to the GUI — a
 `busctl` line does the same thing — which is why it is on the interface rather than inside
@@ -680,6 +686,13 @@ history that does not exist yet.
   request at runtime and clears any published update notice. The daemon's `update-check`
   Cargo feature is enabled by default for upstream builds; a distribution can build with
   `--no-default-features`, in which case Preferences shows the switch off and unavailable.
+- **An update offer is a preview, not an updater.** The header button opens the release
+  notes in a dialog — Markdown rendered into Pango markup, bare URLs linked, raw HTML
+  dropped — and its two buttons are Cancel and Download on GitHub. Tidemark is installed by
+  a package manager, an installer or a distribution, so the dialog ends at the release page
+  rather than pretending this process can replace itself. A release published without notes
+  opens that page directly: a dialog whose only content is "no notes" is a click that told
+  the reader nothing.
 - **`libayatana-appindicator-glib` is GPL-3** and cannot be linked into an MIT project. The
   protocol is spoken through `ksni`, which is Unlicense — public domain, so compatible —
   and which is built on the same zbus the interface already reaches the daemon over.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4046,7 @@ dependencies = [
  "libadwaita",
  "pango 0.22.8",
  "pangocairo",
+ "pulldown-cmark",
  "semver",
  "tidemark-ipc",
  "tidemark-types",
@@ -4534,6 +4546,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/tidemark-ipc/src/lib.rs
+++ b/crates/tidemark-ipc/src/lib.rs
@@ -39,6 +39,11 @@ pub trait Daemon {
 
     /// A newer published application release, or an empty string when none is known.
     fn get_update(&self) -> zbus::Result<String>;
+
+    /// That release's notes as its publisher wrote them — Markdown, unrendered — or an
+    /// empty string when no newer release is known or it carried none.
+    fn get_release_notes(&self) -> zbus::Result<String>;
+
     /// Application-wide preferences stored by the daemon.
     fn get_preferences(&self) -> zbus::Result<Preferences>;
 

--- a/crates/tidemark/AGENTS.md
+++ b/crates/tidemark/AGENTS.md
@@ -15,6 +15,7 @@ GTK/libadwaita presentation and desktop lifecycle; score 12, a distinct IPC-clie
 | Quota rendering | `src/card.rs`, `src/bar.rs` | Incremental card updates, pure bar geometry |
 | History detail | `src/detail.rs`, `src/chart.rs` | Async history selection and pure chart geometry |
 | Pure presentation | `src/model.rs`, `src/format.rs` | Ordering, catalog titles, chips, relative times |
+| Release notes preview | `src/release_notes.rs`, `src/markdown.rs`, `src/update.rs` | Changelog dialog, Markdown to Pango markup, release URL |
 | Theme and marks | `src/style.rs`, `src/theme.rs`, `src/mark.rs` | Semantic CSS and optional provider icons |
 | Tray integration | `src/tray.rs` | Shared model with ksni / Windows backends |
 | Windows lifetime and fonts | `src/daemon_job.rs`, `src/single_instance.rs`, `src/font.rs` | Safe ownership around platform APIs |

--- a/crates/tidemark/AGENTS.md
+++ b/crates/tidemark/AGENTS.md
@@ -34,7 +34,7 @@ GTK/libadwaita presentation and desktop lifecycle; score 12, a distinct IPC-clie
 ## ANTI-PATTERNS
 - Do not infer authentication capabilities from provider/browser names or inspect credential files in widgets.
 - Do not replace `CardGrid` with FlowBox sorting or detached drag-source icons.
-- Do not interpret daemon strings as markup or use color as the only status explanation.
+- Do not interpret daemon strings as markup or use color as the only status explanation; release notes are the one exception, and `src/markdown.rs` escapes them before adding markup of its own.
 - Do not coerce unknown server choices into known ones; keep them visible and disabled.
 - Do not let stale history replies update a newer selection; preserve `RequestGeneration` checks.
 - Do not close to tray unless a host accepted the icon; tray failure is nonfatal.
@@ -45,4 +45,5 @@ GTK/libadwaita presentation and desktop lifecycle; score 12, a distinct IPC-clie
 - `cargo test -p tidemark` covers colocated model, geometry, and state-machine tests.
 - Manual GUI data: stop the real user service with `systemctl --user stop tidemarkd`, then run `cargo run -p tidemark --example mock-daemon`.
 - In another terminal of the same graphical/bus session, run `cargo run -p tidemark`.
+- Update-button dialog: the mock daemon above already offers a release with notes. Against the real release instead, lower `[workspace.package] version` in the root `Cargo.toml` — the check compares `tidemarkd`'s own version to GitHub's latest — then run `cargo run -p tidemarkd` and wait 60 s for the first check.
 - Package asset lists in this crate's Cargo metadata mirror `PKGBUILD`; package both daemon and GUI from a prior workspace release build.

--- a/crates/tidemark/Cargo.toml
+++ b/crates/tidemark/Cargo.toml
@@ -23,6 +23,10 @@ gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }
 # Pango 1.56 adds FontMap::add_font_file, which lets the Windows build make its
 # bundled Rubik available to GTK without installing it for the user.
 pango = { version = "0.22.3", features = ["v1_56"] }
+# CommonMark for the release-notes dialog: the notes come from whoever published the
+# release, so the shape of `**bold**` and `[text](url)` is a parser's decision rather than
+# ours. Parser only — no HTML writer, no SIMD — because what it feeds is Pango markup.
+pulldown-cmark = { version = "0.13.4", default-features = false }
 semver = "1.0.28"
 tidemark-ipc = { path = "../tidemark-ipc" }
 tidemark-types = { path = "../tidemark-types" }

--- a/crates/tidemark/examples/mock-daemon.rs
+++ b/crates/tidemark/examples/mock-daemon.rs
@@ -85,6 +85,25 @@ impl MockDaemon {
         "0.2.0".into()
     }
 
+    /// The shape GitHub's generated notes have, plus the hand-written parts a release
+    /// usually opens with: this is what the release-notes dialog is looked at against.
+    async fn get_release_notes(&self) -> String {
+        [
+            "Cards keep the provider name on one baseline again, and the changelog is now",
+            "readable *without* leaving the window.",
+            "",
+            "## What's Changed",
+            "* fix(ui): keep the provider name on the card baseline by @zbndev in https://github.com/zbndev/tidemark/pull/69",
+            "* feat(gui): preview the changelog before downloading by @zbndev in https://github.com/zbndev/tidemark/pull/70",
+            "",
+            "### Known issues",
+            "* `tidemarkctl update` still prints the version only.",
+            "",
+            "**Full Changelog**: https://github.com/zbndev/tidemark/compare/v0.1.0...v0.2.0",
+        ]
+        .join("\n")
+    }
+
     async fn refresh(&self, provider: &str) -> fdo::Result<()> {
         println!("refresh({provider:?})");
         Ok(())

--- a/crates/tidemark/src/main.rs
+++ b/crates/tidemark/src/main.rs
@@ -31,9 +31,11 @@ mod font;
 mod format;
 mod grid;
 mod mark;
+mod markdown;
 mod model;
 mod preferences;
 mod provider_settings;
+mod release_notes;
 #[cfg(windows)]
 mod single_instance;
 mod style;

--- a/crates/tidemark/src/markdown.rs
+++ b/crates/tidemark/src/markdown.rs
@@ -1,0 +1,491 @@
+//! Markdown, as far as a release-notes dialog needs it.
+//!
+//! Release notes are written by whoever published the release and arrive over the bus
+//! verbatim. They are neither trusted markup nor a document worth a full renderer: what
+//! this produces is a flat list of [`Block`]s, each carrying Pango markup for one label.
+//! Parsing is CommonMark by way of `pulldown-cmark`, so emphasis, links and code spans are
+//! decided by a parser rather than by regular expressions that would disagree with GitHub's
+//! own rendering of the same text.
+//!
+//! Two deliberate departures from a browser:
+//!
+//! * **Raw HTML is dropped, never shown.** Release bodies carry `<!-- -->` comments and the
+//!   occasional `<details>`; Pango would reject the tags and printing them verbatim is
+//!   noise. Their text content still comes through as text.
+//! * **Bare URLs become links.** GitHub's generated notes are mostly bare pull-request
+//!   URLs, which CommonMark leaves as plain text. A preview of those notes where the links
+//!   are dead would send every reader to the browser this dialog exists to postpone.
+//!
+//! Everything that reaches a label is escaped here. A release body containing `<b>` or a
+//! stray `&` is text, and Pango failing to parse a label's markup would drop the label's
+//! contents entirely.
+
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+/// One block of a rendered document: one widget's worth.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Block {
+    /// A heading and its depth, 1 to 6.
+    Heading { level: u8, markup: String },
+    /// A run of prose.
+    Paragraph { markup: String },
+    /// One list item, with the marker its list gives it and how deeply it is nested.
+    Item {
+        depth: usize,
+        marker: String,
+        markup: String,
+    },
+    /// A fenced or indented code block, verbatim and unescaped.
+    Code { text: String },
+    /// A thematic break.
+    Rule,
+}
+
+/// The blocks of one Markdown document, in reading order.
+pub(crate) fn blocks(markdown: &str) -> Vec<Block> {
+    Render::default().run(markdown)
+}
+
+#[derive(Debug, Default)]
+struct Render {
+    blocks: Vec<Block>,
+    /// The inline run being accumulated: Pango markup, already escaped.
+    markup: String,
+    /// Plain text seen since the last markup was written, not yet escaped into `markup`.
+    ///
+    /// A parser splits text at every position emphasis *could* have started, so
+    /// `example.com/a_b` arrives in three pieces. Bare URLs are recognised across the whole
+    /// run rather than per piece, which is what this buffer is for.
+    pending: String,
+    /// One entry per open list. `Some(n)` is an ordered list's next number.
+    lists: Vec<Option<u64>>,
+    /// One entry per open list item: its marker, and whether it has already been pushed
+    /// (which happens when a nested list interrupts it).
+    items: Vec<(String, bool)>,
+    /// The heading being accumulated, if any.
+    heading: Option<u8>,
+    /// The code block being accumulated, if any.
+    code: Option<String>,
+    /// How many links are open, so text inside one is never linkified again.
+    links: usize,
+}
+
+impl Render {
+    fn run(mut self, markdown: &str) -> Vec<Block> {
+        // Strikethrough and task lists are GitHub's, are used in release notes, and cost
+        // nothing to accept. Tables are not enabled: a table rendered as one label per row
+        // of pipes is no worse than the source, and a dialog is not where a layout engine
+        // earns its keep.
+        let options = Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
+        for event in Parser::new_ext(markdown, options) {
+            self.event(event);
+        }
+        self.blocks
+    }
+
+    fn event(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start(tag),
+            Event::End(tag) => self.end(tag),
+            Event::Text(text) => match &mut self.code {
+                Some(code) => code.push_str(&text),
+                None => self.pending.push_str(&text),
+            },
+            Event::Code(code) => {
+                self.flush_text();
+                self.markup.push_str("<tt>");
+                escape(&code, &mut self.markup);
+                self.markup.push_str("</tt>");
+            }
+            // A line break inside a paragraph is a space, the way every Markdown renderer
+            // reflows it: the label decides where the line ends, from the width it is given.
+            // Both go through the text buffer, because a URL ends at whitespace either way.
+            Event::SoftBreak => self.pending.push(' '),
+            Event::HardBreak => self.pending.push('\n'),
+            Event::TaskListMarker(done) => {
+                self.flush_text();
+                self.markup.push_str(if done { "☑ " } else { "☐ " });
+            }
+            Event::Rule => self.blocks.push(Block::Rule),
+            // Raw HTML, footnote references and maths: dropped rather than shown. See the
+            // module documentation.
+            Event::Html(_)
+            | Event::InlineHtml(_)
+            | Event::InlineMath(_)
+            | Event::DisplayMath(_)
+            | Event::FootnoteReference(_) => {}
+        }
+    }
+
+    /// Escapes the buffered text into the markup run, linkifying bare URLs outside links.
+    fn flush_text(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+        let pending = std::mem::take(&mut self.pending);
+        if self.links > 0 {
+            escape(&pending, &mut self.markup);
+        } else {
+            linkify(&pending, &mut self.markup);
+        }
+    }
+
+    fn start(&mut self, tag: Tag<'_>) {
+        // Text before this tag belongs to the run that ends here, and a URL never spans a
+        // tag boundary, so the buffer is settled first.
+        self.flush_text();
+        match tag {
+            Tag::Heading { level, .. } => {
+                self.markup.clear();
+                self.heading = Some(depth(level));
+            }
+            // A loose list item's text arrives wrapped in a paragraph. Inside an item that
+            // is a continuation line, not a new block.
+            Tag::Paragraph if self.in_item() => {
+                if !self.markup.is_empty() {
+                    self.markup.push('\n');
+                }
+            }
+            Tag::Paragraph => self.markup.clear(),
+            Tag::List(start) => {
+                // A nested list interrupts its parent item: whatever that item said before
+                // the nesting is its own line, and the parent's own end must not repeat it.
+                self.flush_item();
+                self.lists.push(start);
+            }
+            Tag::Item => {
+                self.markup.clear();
+                let marker = match self.lists.last_mut() {
+                    Some(Some(number)) => {
+                        let marker = format!("{number}.");
+                        *number += 1;
+                        marker
+                    }
+                    _ => "•".to_owned(),
+                };
+                self.items.push((marker, false));
+            }
+            Tag::CodeBlock(_) => self.code = Some(String::new()),
+            Tag::Emphasis => self.markup.push_str("<i>"),
+            Tag::Strong => self.markup.push_str("<b>"),
+            Tag::Strikethrough => self.markup.push_str("<s>"),
+            Tag::Link { dest_url, .. } => {
+                self.links += 1;
+                self.markup.push_str("<a href=\"");
+                escape(&dest_url, &mut self.markup);
+                self.markup.push_str("\">");
+            }
+            // An image cannot be fetched by a dialog that does no I/O, so only its
+            // alternative text — which arrives as the tag's own contents — is kept.
+            // Block quotes, footnote definitions and table parts contribute their text to
+            // the blocks they contain.
+            _ => {}
+        }
+    }
+
+    fn end(&mut self, tag: TagEnd) {
+        self.flush_text();
+        match tag {
+            TagEnd::Heading(_) => {
+                if let Some(level) = self.heading.take() {
+                    let markup = self.take();
+                    self.push(Block::Heading { level, markup });
+                }
+            }
+            TagEnd::Paragraph if self.in_item() => {}
+            TagEnd::Paragraph => {
+                let markup = self.take();
+                self.push(Block::Paragraph { markup });
+            }
+            TagEnd::List(_) => {
+                self.lists.pop();
+            }
+            TagEnd::Item => {
+                self.flush_item();
+                self.items.pop();
+            }
+            TagEnd::CodeBlock => {
+                if let Some(text) = self.code.take() {
+                    self.push(Block::Code {
+                        text: text.trim_end().to_owned(),
+                    });
+                }
+            }
+            TagEnd::Emphasis => self.markup.push_str("</i>"),
+            TagEnd::Strong => self.markup.push_str("</b>"),
+            TagEnd::Strikethrough => self.markup.push_str("</s>"),
+            TagEnd::Link => {
+                self.links = self.links.saturating_sub(1);
+                self.markup.push_str("</a>");
+            }
+            _ => {}
+        }
+    }
+
+    fn in_item(&self) -> bool {
+        self.items.last().is_some_and(|(_, pushed)| !pushed)
+    }
+
+    /// Emits the item being accumulated, if it has anything to say.
+    fn flush_item(&mut self) {
+        let depth = self.lists.len().saturating_sub(1);
+        let Some((marker, pushed)) = self.items.last_mut() else {
+            return;
+        };
+        if *pushed || self.markup.trim().is_empty() {
+            return;
+        }
+        let marker = marker.clone();
+        *pushed = true;
+        let markup = self.take();
+        self.push(Block::Item {
+            depth,
+            marker,
+            markup,
+        });
+    }
+
+    fn take(&mut self) -> String {
+        self.flush_text();
+        std::mem::take(&mut self.markup).trim().to_owned()
+    }
+
+    /// Keeps empty blocks out: a stray blank paragraph is vertical space nobody asked for.
+    fn push(&mut self, block: Block) {
+        let empty = match &block {
+            Block::Heading { markup, .. } | Block::Paragraph { markup } => markup.is_empty(),
+            Block::Item { markup, .. } => markup.is_empty(),
+            Block::Code { text } => text.is_empty(),
+            Block::Rule => false,
+        };
+        if !empty {
+            self.blocks.push(block);
+        }
+    }
+}
+
+fn depth(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+/// Appends `text` as Pango markup, escaping everything markup would otherwise read.
+///
+/// `"` is escaped too, because the same function writes link destinations into an
+/// attribute, where a quotation mark would end it. An apostrophe is not: attributes here
+/// are double-quoted, and "What's Changed" is a heading, not an entity.
+fn escape(text: &str, out: &mut String) {
+    for character in text.chars() {
+        match character {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(character),
+        }
+    }
+}
+
+/// Appends `text`, turning bare `http(s)` URLs into links.
+fn linkify(text: &str, out: &mut String) {
+    let mut rest = text;
+    while let Some(start) = url_start(rest) {
+        escape(&rest[..start], out);
+        let (url, tail) = split_url(&rest[start..]);
+        out.push_str("<a href=\"");
+        escape(url, out);
+        out.push_str("\">");
+        escape(url, out);
+        out.push_str("</a>");
+        rest = tail;
+    }
+    escape(rest, out);
+}
+
+/// Where the next bare URL begins, if any. Only at a word boundary: `nothttps://x` is a
+/// word, not a link.
+fn url_start(text: &str) -> Option<usize> {
+    let mut from = 0;
+    while let Some(offset) = text[from..].find("http") {
+        let at = from + offset;
+        let boundary = text[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|character| !character.is_alphanumeric());
+        let scheme = text[at..].starts_with("https://") || text[at..].starts_with("http://");
+        if boundary && scheme {
+            return Some(at);
+        }
+        from = at + "http".len();
+    }
+    None
+}
+
+/// Splits a bare URL from the text after it.
+///
+/// A URL ends at whitespace, and trailing sentence punctuation belongs to the sentence
+/// rather than to the link. A closing bracket is only kept when the URL opened one, which
+/// is what keeps `(see https://example.com/a)` from linking the parenthesis.
+fn split_url(text: &str) -> (&str, &str) {
+    let end = text.find(char::is_whitespace).unwrap_or(text.len());
+    let mut url = &text[..end];
+    while let Some(last) = url.chars().next_back() {
+        let trailing = match last {
+            '.' | ',' | ';' | ':' | '!' | '?' | '\'' | '"' | '*' | '_' => true,
+            ')' => url.matches('(').count() < url.matches(')').count(),
+            ']' => url.matches('[').count() < url.matches(']').count(),
+            _ => false,
+        };
+        if !trailing {
+            break;
+        }
+        url = &url[..url.len() - last.len_utf8()];
+    }
+    (url, &text[url.len()..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Block, blocks};
+
+    fn markup(block: &Block) -> &str {
+        match block {
+            Block::Heading { markup, .. }
+            | Block::Paragraph { markup }
+            | Block::Item { markup, .. } => markup,
+            Block::Code { text } => text,
+            Block::Rule => "",
+        }
+    }
+
+    #[test]
+    fn the_shape_github_generates_survives_as_headings_and_items() {
+        let rendered = blocks(concat!(
+            "## What's Changed\n",
+            "* fix(ui): a fix by @zbndev in https://github.com/zbndev/tidemark/pull/69\n",
+            "\n",
+            "**Full Changelog**: https://github.com/zbndev/tidemark/compare/v0.1.0...v0.2.0\n",
+        ));
+
+        assert_eq!(
+            rendered[0],
+            Block::Heading {
+                level: 2,
+                markup: "What's Changed".into(),
+            }
+        );
+        assert_eq!(
+            rendered[1],
+            Block::Item {
+                depth: 0,
+                marker: "•".into(),
+                markup: concat!(
+                    "fix(ui): a fix by @zbndev in ",
+                    "<a href=\"https://github.com/zbndev/tidemark/pull/69\">",
+                    "https://github.com/zbndev/tidemark/pull/69</a>",
+                )
+                .into(),
+            },
+            "a bare pull-request URL is a link, or the whole preview is dead text"
+        );
+        assert!(
+            markup(&rendered[2]).starts_with("<b>Full Changelog</b>: <a href=\""),
+            "got {:?}",
+            rendered[2]
+        );
+    }
+
+    #[test]
+    fn emphasis_code_and_links_become_pango_markup() {
+        let rendered = blocks("*Cards* keep `MIN_WIDTH`, see [the PR](https://example.com/a).");
+
+        assert_eq!(
+            markup(&rendered[0]),
+            concat!(
+                "<i>Cards</i> keep <tt>MIN_WIDTH</tt>, see ",
+                "<a href=\"https://example.com/a\">the PR</a>.",
+            )
+        );
+    }
+
+    #[test]
+    fn raw_html_is_dropped_and_everything_else_is_escaped() {
+        let rendered = blocks("Use <b>&amp;</b> in \"quotes\" <!-- and a comment -->\n");
+
+        assert_eq!(
+            markup(&rendered[0]),
+            "Use &amp; in &quot;quotes&quot;",
+            "tags and comments go, their text stays, and what reaches Pango is escaped: a \
+             label whose markup does not parse loses all of its contents"
+        );
+    }
+
+    #[test]
+    fn ordered_and_nested_lists_keep_their_markers_and_depth() {
+        let rendered = blocks(concat!(
+            "1. first\n",
+            "2. second\n",
+            "   - nested\n",
+            "\n",
+            "```\ncargo test\n```\n",
+            "\n---\n",
+        ));
+
+        assert_eq!(
+            rendered,
+            vec![
+                Block::Item {
+                    depth: 0,
+                    marker: "1.".into(),
+                    markup: "first".into(),
+                },
+                Block::Item {
+                    depth: 0,
+                    marker: "2.".into(),
+                    markup: "second".into(),
+                },
+                Block::Item {
+                    depth: 1,
+                    marker: "•".into(),
+                    markup: "nested".into(),
+                },
+                Block::Code {
+                    text: "cargo test".into(),
+                },
+                Block::Rule,
+            ]
+        );
+    }
+
+    #[test]
+    fn a_url_keeps_its_own_brackets_and_drops_the_sentences() {
+        let rendered = blocks("See https://example.com/a_(b), then https://example.com/c.\n");
+
+        assert_eq!(
+            markup(&rendered[0]),
+            concat!(
+                "See <a href=\"https://example.com/a_(b)\">https://example.com/a_(b)</a>, ",
+                "then <a href=\"https://example.com/c\">https://example.com/c</a>.",
+            )
+        );
+    }
+
+    #[test]
+    fn a_word_ending_in_a_scheme_is_not_a_link() {
+        let rendered = blocks("nothttps://example.com is not a link\n");
+
+        assert_eq!(markup(&rendered[0]), "nothttps://example.com is not a link");
+    }
+
+    #[test]
+    fn empty_notes_render_nothing_rather_than_a_blank_block() {
+        assert!(blocks("").is_empty());
+        assert!(blocks("\n\n   \n").is_empty());
+    }
+}

--- a/crates/tidemark/src/release_notes.rs
+++ b/crates/tidemark/src/release_notes.rs
@@ -40,6 +40,17 @@ pub(crate) fn present(parent: &impl IsA<gtk::Widget>, version: &str, notes: &str
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .child(&body(notes))
+        // The notes are content, not chrome: `view` puts them on the surface a document is
+        // read on — a step darker than the dialog in a dark theme, a step lighter in a
+        // light one — so the block reads as one thing inside the dialog rather than as the
+        // dialog's own text. `release-notes` only rounds its corners; see `style::STYLE`.
+        .css_classes(["view", "release-notes"])
+        // Scrolled content is painted to the viewport's square edges, so the rounded
+        // corners the class gives the surface have to be clipped to as well.
+        .overflow(gtk::Overflow::Hidden)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(6)
         .build();
 
     let cancel = gtk::Button::with_label("Cancel");
@@ -83,6 +94,11 @@ pub(crate) fn present(parent: &impl IsA<gtk::Widget>, version: &str, notes: &str
         });
     });
 
+    // Focus starts on a button, not in the notes. GTK selects the whole of a selectable
+    // label the moment it takes focus, so the dialog would open with its first line
+    // highlighted; Cancel rather than Download, because the key that then works by itself
+    // must not be the one that opens a browser.
+    dialog.set_focus(Some(&cancel));
     dialog.present(Some(parent));
 }
 
@@ -91,10 +107,10 @@ fn body(notes: &str) -> gtk::Box {
     let content = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(10)
-        .margin_start(18)
-        .margin_end(18)
-        .margin_top(6)
-        .margin_bottom(18)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(12)
+        .margin_bottom(12)
         .build();
     for block in markdown::blocks(notes) {
         content.append(&widget(&block));
@@ -206,5 +222,12 @@ mod tests {
         assert_eq!(heading_class(1), "title-2");
         assert_eq!(heading_class(2), "title-3");
         assert_eq!(heading_class(6), "heading");
+    }
+
+    #[test]
+    fn the_notes_surface_is_rounded_by_the_stylesheet_it_names() {
+        // The dialog asks for `release-notes`; a stylesheet that stopped defining it would
+        // leave a square block of notes inside a rounded dialog, and nothing would fail.
+        assert!(crate::style::STYLE.contains(".release-notes {\n    border-radius:"));
     }
 }

--- a/crates/tidemark/src/release_notes.rs
+++ b/crates/tidemark/src/release_notes.rs
@@ -40,18 +40,22 @@ pub(crate) fn present(parent: &impl IsA<gtk::Widget>, version: &str, notes: &str
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .child(&body(notes))
-        // The notes are content, not chrome: `view` puts them on the surface a document is
-        // read on — a step darker than the dialog in a dark theme, a step lighter in a
-        // light one — so the block reads as one thing inside the dialog rather than as the
-        // dialog's own text. `release-notes` only rounds its corners; see `style::STYLE`.
-        .css_classes(["view", "release-notes"])
-        // Scrolled content is painted to the viewport's square edges, so the rounded
-        // corners the class gives the surface have to be clipped to as well.
-        .overflow(gtk::Overflow::Hidden)
+        .build();
+
+    // The container is the box around the scroll, not the scroll itself: it draws the
+    // recessed surface and the rounded corners, while the scroll clips its own square
+    // viewport inside it. Rounding the scroll instead needs `Overflow::Hidden`, and that
+    // clip lands on the text — the first line loses its top pixels to it. A box rather
+    // than a `GtkFrame`, whose separate `border` node would draw the theme's border
+    // beneath ours.
+    let framed = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .css_classes(["release-notes"])
         .margin_start(12)
         .margin_end(12)
         .margin_top(6)
         .build();
+    framed.append(&scroll);
 
     let cancel = gtk::Button::with_label("Cancel");
     let download = gtk::Button::builder()
@@ -69,7 +73,7 @@ pub(crate) fn present(parent: &impl IsA<gtk::Widget>, version: &str, notes: &str
     actions.append(&cancel);
     actions.append(&download);
 
-    let toolbar = adw::ToolbarView::builder().content(&scroll).build();
+    let toolbar = adw::ToolbarView::builder().content(&framed).build();
     toolbar.add_top_bar(&adw::HeaderBar::new());
     toolbar.add_bottom_bar(&actions);
     dialog.set_child(Some(&toolbar));
@@ -225,9 +229,14 @@ mod tests {
     }
 
     #[test]
-    fn the_notes_surface_is_rounded_by_the_stylesheet_it_names() {
-        // The dialog asks for `release-notes`; a stylesheet that stopped defining it would
-        // leave a square block of notes inside a rounded dialog, and nothing would fail.
-        assert!(crate::style::STYLE.contains(".release-notes {\n    border-radius:"));
+    fn the_notes_sit_on_a_surface_darker_than_the_dialog_in_either_theme() {
+        // The container asks for `release-notes`, and what makes it a container is the
+        // shade: a stylesheet that stopped defining it, or that reached for libadwaita's
+        // `view` — white in a light theme, and so invisible against the dialog — would
+        // leave a plain block of text and nothing would fail.
+        assert!(
+            crate::style::STYLE
+                .contains(".release-notes {\n    background-color: shade(@window_bg_color,")
+        );
     }
 }

--- a/crates/tidemark/src/release_notes.rs
+++ b/crates/tidemark/src/release_notes.rs
@@ -1,0 +1,210 @@
+//! The changelog preview behind the header's update button.
+//!
+//! The daemon found a newer release and published its notes; this shows them before anyone
+//! leaves for a browser. The dialog is deliberately a preview and not an updater: Tidemark
+//! is installed by a package manager, an installer or a distribution, and the button that
+//! ends the dialog goes to the release page rather than pretending this process can replace
+//! itself.
+//!
+//! Every label here is Pango markup produced by [`crate::markdown`], which escapes the
+//! release body before adding any markup of its own.
+
+use adw::prelude::*;
+use gtk::glib;
+
+use crate::markdown::{self, Block};
+use crate::update;
+
+/// How wide and tall the dialog opens. A changelog is read in lines, not in paragraphs of
+/// prose, so it is given a comfortable measure rather than the width of its longest URL.
+const WIDTH: i32 = 560;
+const HEIGHT: i32 = 620;
+/// How far one level of list nesting is indented.
+const INDENT: i32 = 18;
+
+/// Shows `notes` for `version` over `parent`.
+///
+/// `notes` is Markdown as its publisher wrote it. An empty body is not this dialog's
+/// problem to present: the caller opens the release page instead, because a dialog whose
+/// only content is "no notes" is a click that told the reader nothing.
+pub(crate) fn present(parent: &impl IsA<gtk::Widget>, version: &str, notes: &str) {
+    let dialog = adw::Dialog::builder()
+        .title(format!("Tidemark {version}"))
+        .content_width(WIDTH)
+        .content_height(HEIGHT)
+        .build();
+
+    let scroll = gtk::ScrolledWindow::builder()
+        // Never horizontally: the notes wrap to the dialog's width, including inside the
+        // long URLs GitHub's generated notes are made of.
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .child(&body(notes))
+        .build();
+
+    let cancel = gtk::Button::with_label("Cancel");
+    let download = gtk::Button::builder()
+        .label("Download on GitHub")
+        .css_classes(["suggested-action"])
+        .build();
+    let actions = gtk::Box::builder()
+        .spacing(8)
+        .halign(gtk::Align::End)
+        .margin_start(18)
+        .margin_end(18)
+        .margin_top(6)
+        .margin_bottom(12)
+        .build();
+    actions.append(&cancel);
+    actions.append(&download);
+
+    let toolbar = adw::ToolbarView::builder().content(&scroll).build();
+    toolbar.add_top_bar(&adw::HeaderBar::new());
+    toolbar.add_bottom_bar(&actions);
+    dialog.set_child(Some(&toolbar));
+
+    let closing = dialog.clone();
+    cancel.connect_clicked(move |_| {
+        closing.close();
+    });
+    let url = update::release_url(version);
+    let closing = dialog.clone();
+    download.connect_clicked(move |button| {
+        // The window under the dialog, not the dialog: it is about to close, and a launcher
+        // parented to a widget on its way out has nothing to be modal to.
+        let window = button.root().and_downcast::<gtk::Window>();
+        let url = url.clone();
+        closing.close();
+        glib::spawn_future_local(async move {
+            let launcher = gtk::UriLauncher::new(&url);
+            if let Err(error) = launcher.launch_future(window.as_ref()).await {
+                tracing::warn!(%error, "could not open the Tidemark release page");
+            }
+        });
+    });
+
+    dialog.present(Some(parent));
+}
+
+/// The notes as widgets: one per block, in reading order.
+fn body(notes: &str) -> gtk::Box {
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(10)
+        .margin_start(18)
+        .margin_end(18)
+        .margin_top(6)
+        .margin_bottom(18)
+        .build();
+    for block in markdown::blocks(notes) {
+        content.append(&widget(&block));
+    }
+    content
+}
+
+/// One block's widget.
+fn widget(block: &Block) -> gtk::Widget {
+    match block {
+        Block::Heading { level, markup } => {
+            let heading = label(markup);
+            heading.add_css_class(heading_class(*level));
+            // A heading belongs to what follows it, so the air goes above.
+            heading.set_margin_top(8);
+            heading.upcast()
+        }
+        Block::Paragraph { markup } => label(markup).upcast(),
+        Block::Item {
+            depth,
+            marker,
+            markup,
+        } => {
+            let row = gtk::Box::builder()
+                .spacing(8)
+                .margin_start(4 + INDENT * i32::try_from(*depth).unwrap_or(0))
+                .build();
+            let bullet = gtk::Label::builder()
+                .label(marker)
+                .valign(gtk::Align::Start)
+                .css_classes(["dim-label"])
+                .build();
+            let text = label(markup);
+            text.set_hexpand(true);
+            row.append(&bullet);
+            row.append(&text);
+            row.upcast()
+        }
+        // Code is the one thing here that is not markup: it is shown exactly as written,
+        // in a monospaced face, on its own surface.
+        Block::Code { text } => {
+            let code = gtk::Label::builder()
+                .label(text)
+                .wrap(true)
+                .wrap_mode(gtk::pango::WrapMode::WordChar)
+                .xalign(0.0)
+                .selectable(true)
+                .margin_start(10)
+                .margin_end(10)
+                .margin_top(8)
+                .margin_bottom(8)
+                .css_classes(["monospace"])
+                .build();
+            gtk::Frame::builder()
+                .child(&code)
+                .css_classes(["card"])
+                .build()
+                .upcast()
+        }
+        Block::Rule => gtk::Separator::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .margin_top(4)
+            .margin_bottom(4)
+            .build()
+            .upcast(),
+    }
+}
+
+/// A label carrying Pango markup, wrapping to whatever width it is given.
+///
+/// `WordChar` rather than `Word`: a pull-request URL is one word, and a label that cannot
+/// break inside it would set the dialog's width to the length of the longest link.
+/// Selectable, because a changelog is something people copy lines out of.
+fn label(markup: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .label(markup)
+        .use_markup(true)
+        .wrap(true)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
+        .xalign(0.0)
+        .halign(gtk::Align::Fill)
+        .valign(gtk::Align::Start)
+        .selectable(true)
+        .build()
+}
+
+/// The libadwaita style for a heading of this depth.
+///
+/// The dialog's own title already carries the version, so a release body opening with `#`
+/// is a section heading here rather than the page's title: the scale starts one step down
+/// from where a document would start it, and everything past the third level shares the
+/// smallest style there is.
+fn heading_class(level: u8) -> &'static str {
+    match level {
+        1 => "title-2",
+        2 => "title-3",
+        3 => "title-4",
+        _ => "heading",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::heading_class;
+
+    #[test]
+    fn headings_start_one_step_below_a_documents_title_and_bottom_out() {
+        // The dialog's title bar already says which release this is.
+        assert_eq!(heading_class(1), "title-2");
+        assert_eq!(heading_class(2), "title-3");
+        assert_eq!(heading_class(6), "heading");
+    }
+}

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -235,6 +235,14 @@ pub(crate) const STYLE: &str = "
 .credential-choice {
     padding: 8px;
 }
+
+/* The release notes scroll on a `view` surface inset from the dialog's edges, so the
+   surface needs corners of its own: a square block inside a rounded dialog reads as a
+   drawing mistake. The radius is libadwaita's own card radius, and the overflow clip is
+   what keeps the first line of notes from painting outside it. */
+.release-notes {
+    border-radius: 12px;
+}
 ";
 
 /// Adds the stylesheet to the display, above the theme and below the user's own overrides.

--- a/crates/tidemark/src/style.rs
+++ b/crates/tidemark/src/style.rs
@@ -236,11 +236,15 @@ pub(crate) const STYLE: &str = "
     padding: 8px;
 }
 
-/* The release notes scroll on a `view` surface inset from the dialog's edges, so the
-   surface needs corners of its own: a square block inside a rounded dialog reads as a
-   drawing mistake. The radius is libadwaita's own card radius, and the overflow clip is
-   what keeps the first line of notes from painting outside it. */
+/* The release notes are read inside the dialog rather than off its own background, so they
+   sit on a surface that is a step *darker* in both themes. libadwaita's `view` class is
+   the wrong tool for that: in a light theme it is white, which is lighter than the dialog
+   and all but invisible. Shading the window colour is derived rather than picked, so it
+   follows a recoloured theme, and the hairline keeps the container's edge legible where
+   the shade alone is subtle. */
 .release-notes {
+    background-color: shade(@window_bg_color, 0.93);
+    border: 1px solid alpha(currentColor, 0.12);
     border-radius: 12px;
 }
 ";

--- a/crates/tidemark/src/update.rs
+++ b/crates/tidemark/src/update.rs
@@ -10,6 +10,24 @@ pub(crate) fn update_tooltip(version: &str) -> Option<String> {
     (!version.is_empty()).then(|| format!("Tidemark {version} is available"))
 }
 
+/// Where the release notes dialog's download button goes.
+///
+/// A published release has its own page, and that is the one to land on: the list makes a
+/// reader find the release they were just reading about. The version comes from the daemon
+/// and is `X.X.X` by the time it is published, but this builds a URL, so anything else
+/// falls back to the list rather than being pasted into a path.
+pub(crate) fn release_url(version: &str) -> String {
+    let canonical = !version.is_empty()
+        && version
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'.');
+    if canonical {
+        format!("{RELEASES_URL}/tag/v{version}")
+    } else {
+        RELEASES_URL.to_owned()
+    }
+}
+
 /// Remembers which daemon release this client has already offered to restart into.
 #[derive(Debug)]
 pub struct UpdateNotice {
@@ -115,7 +133,7 @@ fn restart_sibling(command: &Command) -> io::Result<Command> {
 mod tests {
     use std::ffi::OsStr;
 
-    use super::{UpdateNotice, restart_command, update_tooltip};
+    use super::{UpdateNotice, release_url, restart_command, update_tooltip};
 
     #[test]
     fn an_empty_update_has_no_button_copy() {
@@ -128,6 +146,26 @@ mod tests {
             update_tooltip("0.12.3").as_deref(),
             Some("Tidemark 0.12.3 is available")
         );
+    }
+
+    #[test]
+    fn the_download_button_goes_to_the_release_being_previewed() {
+        assert_eq!(
+            release_url("0.12.3"),
+            "https://github.com/zbndev/tidemark/releases/tag/v0.12.3"
+        );
+    }
+
+    #[test]
+    fn a_version_that_is_not_one_falls_back_to_the_release_list() {
+        // Nothing but the daemon's own canonical version reaches a URL path.
+        for version in ["", "latest", "0.1.0/../..", "0.1.0?x=y"] {
+            assert_eq!(
+                release_url(version),
+                "https://github.com/zbndev/tidemark/releases",
+                "accepted {version:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tidemark/src/window.rs
+++ b/crates/tidemark/src/window.rs
@@ -29,6 +29,7 @@ use crate::grid::CardGrid;
 use crate::model;
 use crate::preferences::PreferencesDialog;
 use crate::provider_settings::{self, ProviderSettings};
+use crate::release_notes;
 use crate::tray::{self, Tray};
 use crate::update::{self, UpdateNotice};
 
@@ -105,6 +106,10 @@ pub struct MainWindow {
     /// page. `None` while nothing is answering on the bus.
     daemon_version: RefCell<Option<String>>,
     update_notice: RefCell<UpdateNotice>,
+    /// The newer release the header button currently offers. Empty while it is hidden,
+    /// which is also what the button's dialog is told when a daemon went away between the
+    /// announcement and the click.
+    available: RefCell<String>,
     preferences: RefCell<AppPreferences>,
     data_info: RefCell<DataInfo>,
     minimize_on_close: Cell<bool>,
@@ -217,6 +222,7 @@ impl MainWindow {
             daemon: RefCell::new(None),
             daemon_version: RefCell::new(None),
             update_notice: RefCell::new(UpdateNotice::new(env!("CARGO_PKG_VERSION"))),
+            available: RefCell::new(String::new()),
             preferences: RefCell::new(AppPreferences::default()),
             data_info: RefCell::new(DataInfo {
                 config_path: String::new(),
@@ -912,19 +918,40 @@ impl MainWindow {
         });
     }
 
-    /// Opens the fixed release list; the daemon-provided value controls visibility only.
+    /// Previews the release before anyone leaves for a browser: the notes come from the
+    /// daemon that found the release, rendered by [`crate::release_notes`].
+    ///
+    /// A release with no notes — or a daemon that went away, or one too old to know the
+    /// call — opens the release page directly, which is all this button ever did before
+    /// there was anything to preview.
     fn connect_update_button(self: &Rc<Self>) {
         let weak: Weak<Self> = Rc::downgrade(self);
         self.release.connect_clicked(move |_| {
             let Some(main) = weak.upgrade() else {
                 return;
             };
+            let version = main.available.borrow().clone();
+            let proxy = main.daemon.borrow().clone();
             let parent = main.window.clone();
             glib::spawn_future_local(async move {
-                let launcher = gtk::UriLauncher::new(update::RELEASES_URL);
-                if let Err(error) = launcher.launch_future(Some(&parent)).await {
-                    tracing::warn!(%error, "could not open the Tidemark releases page");
+                let notes = match proxy {
+                    Some(proxy) => proxy.get_release_notes().await.unwrap_or_else(|error| {
+                        tracing::info!(
+                            %error,
+                            "the daemon did not answer GetReleaseNotes; opening the release page"
+                        );
+                        String::new()
+                    }),
+                    None => String::new(),
+                };
+                if notes.trim().is_empty() {
+                    let launcher = gtk::UriLauncher::new(&update::release_url(&version));
+                    if let Err(error) = launcher.launch_future(Some(&parent)).await {
+                        tracing::warn!(%error, "could not open the Tidemark release page");
+                    }
+                    return;
                 }
+                release_notes::present(&parent, &version, &notes);
             });
         });
     }
@@ -933,6 +960,7 @@ impl MainWindow {
         let tooltip = update::update_tooltip(version);
         self.release.set_tooltip_text(tooltip.as_deref());
         self.release.set_visible(tooltip.is_some());
+        self.available.replace(version.to_owned());
     }
 
     /// Polls every account now. The header button and the tray menu both mean this, and

--- a/crates/tidemarkd/src/main.rs
+++ b/crates/tidemarkd/src/main.rs
@@ -98,7 +98,7 @@ async fn wait_for_release_check(
 #[cfg(feature = "update-check")]
 async fn publish_result(
     published: &PublishedUpdate,
-    result: Result<Option<String>, update::CheckError>,
+    result: Result<Option<service::Release>, update::CheckError>,
 ) -> Result<Option<String>, update::CheckError> {
     Ok(published.publish(result?).await)
 }
@@ -533,7 +533,9 @@ mod tests {
         let published = PublishedUpdate::default();
         published.set_enabled(true).await;
         assert_eq!(
-            published.publish(Some("0.2.0".into())).await,
+            published
+                .publish(Some(service::Release::new("0.2.0", "")))
+                .await,
             Some("0.2.0".into())
         );
 
@@ -548,13 +550,13 @@ mod tests {
         let published = PublishedUpdate::default();
         published.set_enabled(true).await;
         assert_eq!(
-            publish_result(&published, Ok(Some("0.3.0".into())))
+            publish_result(&published, Ok(Some(service::Release::new("0.3.0", ""))))
                 .await
                 .unwrap(),
             Some("0.3.0".into())
         );
         assert_eq!(
-            publish_result(&published, Ok(Some("0.3.0".into())))
+            publish_result(&published, Ok(Some(service::Release::new("0.3.0", ""))))
                 .await
                 .unwrap(),
             None
@@ -584,7 +586,9 @@ mod tests {
         let published = PublishedUpdate::default();
         published.set_enabled(true).await;
         assert_eq!(
-            published.publish(Some("0.2.0".into())).await,
+            published
+                .publish(Some(service::Release::new("0.2.0", "")))
+                .await,
             Some("0.2.0".into())
         );
 
@@ -594,7 +598,7 @@ mod tests {
         assert!(published.set_enabled(false).await);
 
         assert_eq!(
-            publish_result(&published, Ok(Some("0.3.0".into())))
+            publish_result(&published, Ok(Some(service::Release::new("0.3.0", ""))))
                 .await
                 .expect("the check itself succeeded"),
             None

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -132,16 +132,55 @@ impl Published {
 #[derive(Debug, Clone, Default)]
 pub struct PublishedUpdate(Arc<RwLock<UpdateState>>);
 
+/// A published release this daemon is older than, with the release notes GitHub carries
+/// beside the tag.
+///
+/// The notes are Markdown, unrendered: rendering belongs to whichever client shows it,
+/// and a daemon reformatting them would be inventing presentation for a surface it cannot
+/// see. A release published without notes is an empty string rather than an absent field,
+/// so the wire has one shape and a client has one fallback.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Release {
+    pub version: String,
+    pub notes: String,
+}
+
+impl Release {
+    pub fn new(version: impl Into<String>, notes: impl Into<String>) -> Self {
+        Self {
+            version: version.into(),
+            notes: notes.into(),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct UpdateState {
     enabled: bool,
-    release: Option<String>,
+    release: Option<Release>,
 }
 
 impl PublishedUpdate {
     /// The D-Bus representation: an empty string means no newer release is known.
     pub async fn get(&self) -> String {
-        self.0.read().await.release.clone().unwrap_or_default()
+        self.0
+            .read()
+            .await
+            .release
+            .as_ref()
+            .map(|release| release.version.clone())
+            .unwrap_or_default()
+    }
+
+    /// The known release's notes, empty when there is no release or it carried none.
+    pub async fn notes(&self) -> String {
+        self.0
+            .read()
+            .await
+            .release
+            .as_ref()
+            .map(|release| release.notes.clone())
+            .unwrap_or_default()
     }
 
     /// Switches release checks on or off. Disabling forgets any known release in the
@@ -156,13 +195,28 @@ impl PublishedUpdate {
     /// Applies one finished check and returns the signal payload only when clients need
     /// one. A result that reaches this after checks were disabled is dropped here, under
     /// the same lock the disable took.
-    pub async fn publish(&self, next: Option<String>) -> Option<String> {
+    ///
+    /// The version decides whether clients are told, not the notes: GitHub's release body
+    /// is editable after publication, and an author fixing a typo in it is not news for a
+    /// window that is already showing the button. The newer notes are still stored, so the
+    /// next client to ask for them gets the corrected text.
+    pub async fn publish(&self, next: Option<Release>) -> Option<String> {
         let mut held = self.0.write().await;
-        if !held.enabled || held.release == next {
+        if !held.enabled {
             return None;
         }
+        let announce = held
+            .release
+            .as_ref()
+            .map(|release| release.version.as_str())
+            != next.as_ref().map(|release| release.version.as_str());
         held.release = next;
-        Some(held.release.clone().unwrap_or_default())
+        announce.then(|| {
+            held.release
+                .as_ref()
+                .map(|release| release.version.clone())
+                .unwrap_or_default()
+        })
     }
 }
 
@@ -947,6 +1001,16 @@ impl Daemon {
     /// The newer published application release, or an empty string when none is known.
     async fn get_update(&self) -> String {
         self.update.get().await
+    }
+
+    /// The known release's notes as GitHub published them — Markdown, unrendered — or an
+    /// empty string when no newer release is known or that release carried none.
+    ///
+    /// Separate from `GetUpdate` and asked for on demand: a client needs the version to
+    /// decide whether to offer anything at all, and the notes only once a user asks to
+    /// read them.
+    async fn get_release_notes(&self) -> String {
+        self.update.notes().await
     }
 
     /// Application-wide preferences persisted in `config.toml`.
@@ -1936,18 +2000,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_publication_changes_only_when_the_value_changes() {
+    async fn update_publication_changes_only_when_the_version_changes() {
         let update = PublishedUpdate::default();
         assert_eq!(update.get().await, "");
         update.set_enabled(true).await;
         assert_eq!(
-            update.publish(Some("0.2.0".into())).await,
+            update
+                .publish(Some(Release::new("0.2.0", "the notes")))
+                .await,
             Some("0.2.0".into())
         );
-        assert_eq!(update.publish(Some("0.2.0".into())).await, None);
+        assert_eq!(
+            update
+                .publish(Some(Release::new("0.2.0", "the notes")))
+                .await,
+            None
+        );
         assert_eq!(update.get().await, "0.2.0");
+        assert_eq!(update.notes().await, "the notes");
+
+        // The author edited the release body: clients already showing 0.2.0 are not told
+        // again, and the next one to read the notes gets the corrected text.
+        assert_eq!(
+            update
+                .publish(Some(Release::new("0.2.0", "the fixed notes")))
+                .await,
+            None
+        );
+        assert_eq!(update.notes().await, "the fixed notes");
+
         assert_eq!(update.publish(None).await, Some(String::new()));
         assert_eq!(update.get().await, "");
+        assert_eq!(update.notes().await, "");
     }
 
     #[tokio::test]
@@ -1955,15 +2039,18 @@ mod tests {
         let update = PublishedUpdate::default();
         update.set_enabled(true).await;
         assert_eq!(
-            update.publish(Some("0.2.0".into())).await,
+            update
+                .publish(Some(Release::new("0.2.0", "the notes")))
+                .await,
             Some("0.2.0".into())
         );
 
         // Disabling both latches the flag and forgets the release in one write...
         assert!(update.set_enabled(false).await);
         assert_eq!(update.get().await, "");
+        assert_eq!(update.notes().await, "");
         // ...and a result that was already in flight lands nowhere.
-        assert_eq!(update.publish(Some("0.3.0".into())).await, None);
+        assert_eq!(update.publish(Some(Release::new("0.3.0", ""))).await, None);
         assert_eq!(update.get().await, "");
 
         // Re-enabling starts from nothing until a check succeeds again.
@@ -4076,7 +4163,9 @@ mod tests {
         let published_update = PublishedUpdate::default();
         published_update.set_enabled(true).await;
         assert_eq!(
-            published_update.publish(Some("0.2.0".into())).await,
+            published_update
+                .publish(Some(Release::new("0.2.0", "## What's Changed\n* a fix")))
+                .await,
             Some("0.2.0".into())
         );
         let (commands, mut command_queue) = mpsc::channel(4);
@@ -4143,6 +4232,22 @@ mod tests {
             .deserialize()
             .expect("the available version is a string");
         assert_eq!(update, "0.2.0");
+
+        let reply = client
+            .call_method(
+                Some(TEST_BUS_NAME),
+                ids::OBJECT_PATH,
+                Some(ids::DAEMON_INTERFACE),
+                "GetReleaseNotes",
+                &(),
+            )
+            .await
+            .expect("GetReleaseNotes answers");
+        let notes: String = reply
+            .body()
+            .deserialize()
+            .expect("the release notes are a string");
+        assert_eq!(notes, "## What's Changed\n* a fix");
 
         call("Refresh", "zai")
             .await

--- a/crates/tidemarkd/src/update.rs
+++ b/crates/tidemarkd/src/update.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use reqwest::header::{ACCEPT, HeaderMap, HeaderName, HeaderValue};
 use semver::Version;
 
+use crate::service::Release;
+
 pub(crate) const INITIAL_DELAY: Duration = Duration::from_secs(60);
 pub(crate) const INTERVAL: Duration = Duration::from_secs(60 * 60);
 const MAX_BODY: usize = 64 * 1024;
@@ -24,6 +26,8 @@ pub(crate) enum CheckError {
     Version,
 }
 
+/// The published shape of a release lives with the state that publishes it: this module
+/// only fills it in.
 #[derive(Debug)]
 pub(crate) struct Checker {
     client: reqwest::Client,
@@ -66,7 +70,7 @@ impl Checker {
         })
     }
 
-    pub(crate) async fn check(&self) -> Result<Option<String>, CheckError> {
+    pub(crate) async fn check(&self) -> Result<Option<Release>, CheckError> {
         let mut response = self
             .client
             .get(&self.endpoint)
@@ -90,7 +94,16 @@ impl Checker {
             .get("tag_name")
             .and_then(serde_json::Value::as_str)
             .ok_or(CheckError::Version)?;
-        newer(tag, &self.current)
+        // The body is optional on GitHub's side and absent on a release published without
+        // notes, which is not a reason to fail a check that already knows the version.
+        let notes = response
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        Ok(
+            newer(tag, &self.current)?
+                .map(|version| Release::new(version, notes.trim().to_owned())),
+        )
     }
 }
 
@@ -154,7 +167,7 @@ mod tests {
         format!("http://{address}/latest")
     }
 
-    async fn check_response(status: &str, body: &[u8]) -> Result<Option<String>, CheckError> {
+    async fn check_response(status: &str, body: &[u8]) -> Result<Option<Release>, CheckError> {
         let endpoint = serve_once(status, body).await;
         Checker::at(endpoint, "0.1.0").unwrap().check().await
     }
@@ -188,12 +201,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_latest_tag_is_read_from_a_small_success_response() {
+    async fn the_latest_tag_and_its_notes_are_read_from_a_small_success_response() {
+        let body = serde_json::json!({
+            "tag_name": "v0.2.0",
+            "body": "## What's Changed\n* a fix\n",
+        })
+        .to_string();
+
         assert_eq!(
-            check_response("200 OK", br#"{"tag_name":"v0.2.0"}"#)
+            check_response("200 OK", body.as_bytes()).await.unwrap(),
+            Some(Release {
+                version: "0.2.0".into(),
+                notes: "## What's Changed\n* a fix".into(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_release_published_without_notes_is_still_available() {
+        assert_eq!(
+            check_response("200 OK", br#"{"tag_name":"v0.2.0","body":null}"#)
                 .await
                 .unwrap(),
-            Some("0.2.0".into())
+            Some(Release {
+                version: "0.2.0".into(),
+                notes: String::new(),
+            })
         );
     }
 


### PR DESCRIPTION
## Problem

When the daemon finds a newer release, the header button opened `https://github.com/zbndev/tidemark/releases` — the whole list, in a browser, for a release the window already knew about.

## Change

**Daemon** — the release check already parses GitHub's `releases/latest` JSON, so it now keeps `body` beside `tag_name`:

- `update::Checker::check` returns `Option<service::Release { version, notes }>`; a release published without notes is an empty string, not a failed check.
- `PublishedUpdate` stores the release and serves `GetReleaseNotes -> String`. **The version decides whether clients are told**, not the notes: an author fixing a typo in a release body updates the stored notes without re-announcing `UpdateChanged`.
- Notes are published unrendered. Rendering belongs to whichever client shows them.

**Client** — `src/markdown.rs` turns the notes into blocks of Pango markup (CommonMark via `pulldown-cmark`, parser only):

- Bare `http(s)` URLs become links — GitHub's generated notes are mostly bare PR URLs, which CommonMark leaves as dead text. Text runs are buffered before linkifying, because a parser splits text at every position emphasis *could* have started (`example.com/a_b` arrives in three pieces).
- Raw HTML is dropped, its text kept: Pango drops a whole label whose markup does not parse. Everything reaching a label is escaped.
- `src/release_notes.rs` shows the blocks in an `AdwDialog` (scrolling, `WordChar` wrap so a long URL does not set the width) with **Cancel** and **Download on GitHub**, the latter going to `releases/tag/v<version>` rather than the list.
- Empty notes, a daemon that went away, or one too old to know the call: the release page opens directly, exactly as the button behaved before.

`examples/mock-daemon.rs` serves a fixture release body in GitHub's shape, so the dialog can be looked at without the network.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean. `./scripts/check-layering.sh`: ok (the parser is not network, disk or core).
- `cargo test --workspace`: 25 test binaries, 0 failures. New tests cover notes parsed from a success response, a release published without notes, version-only announcement with notes still updated, `GetReleaseNotes` over a real session bus, the Markdown→markup rules (headings/items/links/escaping/nesting/URL boundaries), and the release URL fallback.
- Live end-to-end, with throwaway probes since removed: `Checker::at(ENDPOINT, "0.0.1")` against the real API returned `Release { version: "0.5.1", notes: "What's new in 0.5.1\r\n---\r\n## ✨ Added\r\n- Codex business account support (#60)…" }`, and the renderer turned that exact body into `Heading(2) "What's new in 0.5.1"`, `Heading(2) "✨ Added"`, two `Item`s, and `Paragraph "<b>Full Changelog</b>: <a href=…>"` — CRLF, setext heading and emoji included.

## What to check by hand

Either drive it from the mock (instant, no network):

```sh
systemctl --user stop tidemarkd
cargo run -p tidemark --example mock-daemon
cargo run -p tidemark            # another terminal; the button is already offered
```

or against the real release, with a lowered daemon version — the check compares `tidemarkd`'s own `CARGO_PKG_VERSION` to GitHub's latest, so set `[workspace.package] version = "0.4.0"` in the root `Cargo.toml`, then `cargo run -p tidemarkd` and `cargo run -p tidemark`; the first check lands 60 s after the daemon starts.
