### PR TITLE
feat(account): name an account in any script, not in a slug

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,9 +41,14 @@ conventional fallback and is what desktop files, D-Bus, and Flatpak all expect t
   what can be added; it does not say what the daemon currently polls.
 - **Configured account** — a catalog provider the user has added. v1 creates its single
   `default` account and persists the provider slug in `config.toml`.
-- **Account** — one set of credentials for a provider. v1 shows exactly one per provider,
-  but every key in storage carries an account id so multi-account is a UI change, not a
-  migration.
+- **Account** — one set of credentials for a provider. Every key in storage carries an
+  account id, which is also the name the card shows above the provider's own: it is the
+  name the user typed, in any script — letters, digits, spaces, hyphens and underscores,
+  beginning and ending on a letter or a digit, case kept. Nothing transliterates it, and
+  nothing downstream needs it to be ASCII: it is a TOML value in `accounts`, a quoted key
+  where a plugin's per-account table needs one, a bound SQLite parameter, a Secret Service
+  attribute and a D-Bus string. `default` is the provider's own structural first account
+  and stays unlabelled.
 - **Window** — one rate-limit period a provider reports: `{id, title, used_percent,
   resets_at, length}`. A provider returns however many it wants; the set can change
   between responses. Windows are first-class, not display strings — the pace mark and the

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ notifications stay current. Native GTK4 + libadwaita — no Electron, no embedde
 - **Every window.** Five-hour, weekly, monthly — whatever the provider
   exposes, each with its own reset time.
 - **Several accounts per provider.** A work and a personal Claude, two Z.ai keys — grouped
-  behind an expand toggle.
+  behind an expand toggle, each named whatever you call it, in any script (`Работа`,
+  `Team Lead`), shown above the provider's own name on the card.
 - **A pace mark on every bar.** Fill to the left of the mark means the quota likely lasts until
   the reset; fill to the right means it does not.
 - **Warnings at 70% and 90%,** plus a notification when a window resets. Off by default,

--- a/crates/tidemark-core/src/config.rs
+++ b/crates/tidemark-core/src/config.rs
@@ -2233,6 +2233,34 @@ mod tests {
         );
     }
 
+    /// An account id is a name the user typed, so it may be a word in any script — and
+    /// this is the one place it becomes a TOML *key* rather than a value. A key that is
+    /// not bare ASCII has to be written quoted, or the file the daemon writes is a file it
+    /// cannot parse.
+    #[test]
+    fn an_account_named_in_another_script_is_written_as_a_quoted_table_key() {
+        let (path, mut config) = seeded("endpoint-unicode", "");
+        let endpoint = Endpoint {
+            url: "https://a.test/u".into(),
+            allow_insecure_http: false,
+        };
+        config
+            .set_plugin_endpoint("com.acme.quota", "Личный аккаунт", &endpoint)
+            .expect("writes");
+        let text = std::fs::read_to_string(&path).expect("readable");
+        assert!(
+            text.contains("[provider.\"com.acme.quota\".account.\"Личный аккаунт\"]"),
+            "a key with a space and no ASCII in it has to be quoted: {text}"
+        );
+        let reloaded = Config::at(path).expect("reloads");
+        assert_eq!(
+            reloaded
+                .plugin_endpoint("com.acme.quota", "Личный аккаунт")
+                .unwrap(),
+            Some(endpoint)
+        );
+    }
+
     #[test]
     fn an_endpoint_write_preserves_the_rest_of_the_file_and_its_decoration() {
         let (path, mut config) = seeded(

--- a/crates/tidemark-types/AGENTS.md
+++ b/crates/tidemark-types/AGENTS.md
@@ -15,6 +15,7 @@ Domain vocabulary and compatible IPC dictionaries; score 9, a distinct public-co
 
 ## CONVENTIONS
 - `Snapshot` represents a provider reading; `ProviderStatus` also carries account state and its last good reading.
+- An account id is the name the user typed and the card shows: `valid_account_id` allows letters and digits in any script, plus spaces, hyphens and underscores, with alphanumeric edges and case kept. Never transliterate it, never lowercase it, never assume ASCII.
 - Wire structures derive dictionary serialization and encode as `a{sv}`, not positional D-Bus structs.
 - Optional values are omitted dictionary keys; JSON uses the same shapes rather than a parallel schema.
 - Extend payloads so older dictionaries with missing fields still decode.

--- a/crates/tidemark-types/src/lib.rs
+++ b/crates/tidemark-types/src/lib.rs
@@ -32,7 +32,7 @@ pub use wire::{
     AuthCandidate, AuthCandidateState, AuthMode, AuthSelection, AuthSelector, CredentialKind,
     DataInfo, ExternalLogin, HistoryPoint, OptionChoice, PluginEndpoint, PluginInfo, Preferences,
     ProviderDefinition, ProviderOption, ProviderState, ProviderStatus, Remedy, WindowStatus,
-    account_slug_suggestion, valid_account_slug,
+    account_id_suggestion, valid_account_id,
 };
 
 /// Identity constants. Changing any of these is a breaking change for installed units,

--- a/crates/tidemark-types/src/wire.rs
+++ b/crates/tidemark-types/src/wire.rs
@@ -831,42 +831,72 @@ impl ProviderStatus {
 }
 
 /// Whether a string can serve as an account id in `config.toml`, the Secret Service and
-/// the history: lowercase letters, digits and hyphens, non-empty, and not starting or
-/// ending with a hyphen.
+/// the history: letters, digits, spaces, hyphens and underscores, beginning and ending on
+/// a letter or a digit.
+///
+/// Letters and digits in **any script**, because the id is also the name the card shows
+/// above the provider: an account called `Работа` is named that on the card, not
+/// transliterated, and not refused. Nothing here restricts the id to ASCII, because
+/// nothing downstream needs it to be — the id is a TOML *value* in `accounts`, a quoted
+/// key where a plugin's per-account table needs one, a bound SQLite parameter, a Secret
+/// Service attribute and a D-Bus string, all of which hold arbitrary UTF-8.
+///
+/// What is excluded is everything that would make two ids that look the same behave
+/// differently, or make one unprintable: control characters, tabs and newlines, the
+/// invisible edges a trailing space would leave, and punctuation that reads as structure
+/// (`/`, `.`, quotes) in a path, a file or a shell.
+///
+/// Case is **kept**, and so ids differ by case: `Work` and `work` are two accounts, the
+/// same way `work` and `work-2` are. They are two cards with two names, which is what
+/// someone who typed both would expect; what is not allowed is one account whose name
+/// cannot be read back as it was typed.
 ///
 /// Wire vocabulary because both halves of the bus speak it: the daemon refuses an id the
 /// config cannot hold, and a client typing a new account's name wants to disable its own
 /// confirm button for the same ids rather than learn each refusal by round trip.
-pub fn valid_account_slug(account: &str) -> bool {
-    !account.is_empty()
-        && !account.starts_with('-')
-        && !account.ends_with('-')
-        && account
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+pub fn valid_account_id(account: &str) -> bool {
+    let mut characters = account.chars();
+    let edges_are_letters = characters.next().is_some_and(char::is_alphanumeric)
+        && characters.next_back().is_none_or(char::is_alphanumeric);
+    edges_are_letters && account.chars().all(account_id_character)
 }
 
-/// The account id a display name suggests: lowercased, everything the config cannot hold
-/// becomes a hyphen, a run of those becomes one, and the edges are trimmed away.
+/// Whether one character may appear inside an account id.
+fn account_id_character(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, ' ' | '-' | '_')
+}
+
+/// The account id a display name suggests: everything the config cannot hold becomes a
+/// hyphen, a run of those becomes one, and the edges are trimmed away.
+///
+/// Case, spaces and script are kept, so nearly every name suggests itself — the
+/// suggestion exists for the punctuation that has to go somewhere, not to transliterate a
+/// name into ASCII.
 ///
 /// This is the live preview while a name is typed. It never suggests an id
-/// [`valid_account_slug`] refuses — only the empty string, which is a name that has not
+/// [`valid_account_id`] refuses — only the empty string, which is a name that has not
 /// been typed yet.
-pub fn account_slug_suggestion(name: &str) -> String {
+pub fn account_id_suggestion(name: &str) -> String {
     let mut suggestion = String::new();
     let mut hyphen_pending = false;
     for character in name.chars() {
-        if character.is_ascii_alphanumeric() {
-            if hyphen_pending && !suggestion.is_empty() {
+        if account_id_character(character) {
+            // `Team (QA)` is `Team QA`, not `Team -QA`: the hyphen stands in for what was
+            // dropped only where there is no separator there already.
+            if hyphen_pending && suggestion.ends_with(char::is_alphanumeric) {
                 suggestion.push('-');
             }
             hyphen_pending = false;
-            suggestion.push(character.to_ascii_lowercase());
+            suggestion.push(character);
         } else {
             hyphen_pending = true;
         }
     }
+    // An id begins and ends on a letter or a digit: a name typed with a trailing space, or
+    // wrapped in dashes, suggests the name inside them rather than nothing.
     suggestion
+        .trim_matches(|character: char| !character.is_alphanumeric())
+        .to_owned()
 }
 
 #[cfg(test)]
@@ -1128,49 +1158,79 @@ mod tests {
     }
 
     #[test]
-    fn an_account_slug_is_lowercase_letters_digits_and_inner_hyphens() {
-        for slug in ["work", "w", "work-2", "w-o-r-k"] {
-            assert!(
-                valid_account_slug(slug),
-                "{slug:?} is an id the config can hold"
-            );
+    fn an_account_id_is_a_name_in_any_script_with_readable_edges() {
+        for id in [
+            "work",
+            "w",
+            "work-2",
+            "Work",
+            "Работа",
+            "Личный аккаунт",
+            "team_lead",
+            "工作",
+        ] {
+            assert!(valid_account_id(id), "{id:?} is an id the config can hold");
         }
-        // The refusals the daemon answered with before the rule moved here; kept beside
-        // the rule so the two cannot drift apart again.
-        for slug in ["", "Work", "work-", "-work", "two words", "work_1", "wörk"] {
+        // An id that cannot be read back as it was typed, or that reads as structure
+        // somewhere it is stored: the edges are invisible, and the punctuation is not.
+        for id in [
+            "",
+            " ",
+            "work-",
+            "-work",
+            "work ",
+            " work",
+            "_work",
+            "work/2",
+            "work.2",
+            "\"work\"",
+            "work\ttwo",
+            "work\n",
+        ] {
             assert!(
-                !valid_account_slug(slug),
-                "{slug:?} is not an id the config can hold"
+                !valid_account_id(id),
+                "{id:?} is not an id the config can hold"
             );
         }
     }
 
     #[test]
-    fn a_name_suggests_the_slug_the_config_holds() {
-        assert_eq!(account_slug_suggestion("My Work"), "my-work");
-        // Leading, trailing and repeated separators all collapse to one inner hyphen.
-        assert_eq!(account_slug_suggestion("  Team   Lead  "), "team-lead");
-        assert_eq!(account_slug_suggestion("-My--Work-"), "my-work");
-        assert_eq!(account_slug_suggestion("work_1"), "work-1");
+    fn a_name_suggests_itself_unless_it_carries_punctuation() {
+        // Case, spaces and script survive: the id is the name the card shows.
+        assert_eq!(account_id_suggestion("My Work"), "My Work");
+        assert_eq!(account_id_suggestion("Работа"), "Работа");
+        assert_eq!(account_id_suggestion("work_1"), "work_1");
+        // Edges an id cannot have are trimmed rather than refused.
+        assert_eq!(account_id_suggestion("  Team   Lead  "), "Team   Lead");
+        assert_eq!(account_id_suggestion("-My--Work-"), "My--Work");
         // What the config cannot hold becomes a hyphen rather than being dropped, so a
         // name never suggests an id silently different from what was typed.
-        assert_eq!(account_slug_suggestion("wörk"), "w-rk");
-        assert_eq!(account_slug_suggestion("Team (QA)"), "team-qa");
+        assert_eq!(account_id_suggestion("Team (QA)"), "Team QA");
+        assert_eq!(account_id_suggestion("Q&A"), "Q-A");
     }
 
     #[test]
     fn a_name_with_nothing_the_config_holds_suggests_nothing() {
-        assert_eq!(account_slug_suggestion(""), "");
-        assert_eq!(account_slug_suggestion("   "), "");
-        assert_eq!(account_slug_suggestion("—😀"), "");
+        assert_eq!(account_id_suggestion(""), "");
+        assert_eq!(account_id_suggestion("   "), "");
+        assert_eq!(account_id_suggestion("—😀"), "");
     }
 
     #[test]
-    fn a_suggestion_is_always_a_slug_the_config_holds_or_empty() {
-        for name in ["", "My Work", "Q&A Team", "Ünternehmen", "—", "😀"] {
-            let suggested = account_slug_suggestion(name);
+    fn a_suggestion_is_always_an_id_the_config_holds_or_empty() {
+        for name in [
+            "",
+            "My Work",
+            "Q&A Team",
+            "Ünternehmen",
+            "Работа/2",
+            "—",
+            "😀",
+            "work.",
+        ] {
+            let suggested = account_id_suggestion(name);
             assert!(
-                suggested.is_empty() || valid_account_slug(&suggested),
+                suggested.is_empty() || valid_account_id(&suggested),
                 "{name:?} suggested {suggested:?}, which the config cannot hold"
             );
         }

--- a/crates/tidemark/src/provider_settings/mod.rs
+++ b/crates/tidemark/src/provider_settings/mod.rs
@@ -14,7 +14,7 @@ use adw::prelude::*;
 use gtk::glib;
 use tidemark_types::{
     AccountId, CredentialKind, PluginInfo, ProviderDefinition, ProviderId, ProviderStatus,
-    account_slug_suggestion, valid_account_slug,
+    account_id_suggestion, valid_account_id,
 };
 
 use self::detail::ProviderDetail;
@@ -997,8 +997,8 @@ pub(super) fn multi_account_capable(definition: &ProviderDefinition) -> bool {
 /// Whether a typed name can be confirmed: it must suggest an id the config can hold, and
 /// a rename must suggest one the account does not already have.
 pub(super) fn name_suggests_usable(name: &str, current: Option<&str>) -> bool {
-    let slug = account_slug_suggestion(name);
-    valid_account_slug(&slug) && current.is_none_or(|held| held != slug)
+    let id = account_id_suggestion(name);
+    valid_account_id(&id) && current.is_none_or(|held| held != id)
 }
 
 /// The name-to-id entry dialog the provider row's "+" and the account label's pen share.
@@ -1038,8 +1038,8 @@ pub(super) async fn name_dialog(
         let dialog = dialog.clone();
         move || {
             let name = entry.text().to_string();
-            let slug = account_slug_suggestion(&name);
-            preview.set_text(&format!("Account id: {slug}"));
+            let id = account_id_suggestion(&name);
+            preview.set_text(&format!("Account id: {id}"));
             dialog.set_response_enabled("accept", name_suggests_usable(&name, current.as_deref()));
         }
     };
@@ -1058,7 +1058,7 @@ pub(super) async fn name_dialog(
     dialog.set_extra_child(Some(&content));
 
     (dialog.choose_future(Some(parent)).await == "accept")
-        .then(|| account_slug_suggestion(&entry.text()))
+        .then(|| account_id_suggestion(&entry.text()))
 }
 
 /// What confirming a plugin's account form would create.
@@ -1221,10 +1221,12 @@ mod tests {
         assert!(!name_suggests_usable("", None));
         assert!(!name_suggests_usable("   ", None));
         assert!(name_suggests_usable("My Work", None));
+        // Any script, because the id is the name the card shows.
+        assert!(name_suggests_usable("Работа", None));
         // A rename to the id the account already has is the daemon's no-op refusal, and
         // the confirm button is where the user should hear that from.
-        assert!(!name_suggests_usable("My Work", Some("my-work")));
-        assert!(name_suggests_usable("My Team", Some("my-work")));
+        assert!(!name_suggests_usable("My Work", Some("My Work")));
+        assert!(name_suggests_usable("My Team", Some("My Work")));
     }
 
     #[test]

--- a/crates/tidemark/src/provider_settings/plugins.rs
+++ b/crates/tidemark/src/provider_settings/plugins.rs
@@ -12,7 +12,7 @@
 
 use adw::prelude::*;
 use gtk::gio;
-use tidemark_types::{PluginInfo, account_slug_suggestion};
+use tidemark_types::{PluginInfo, account_id_suggestion};
 
 use super::{name_suggests_usable, reason};
 use crate::bus::DaemonProxy;
@@ -187,7 +187,7 @@ pub(super) async fn account_dialog(
             let typed = endpoint.text().to_string();
             let named = if ask_for_name {
                 let text = name.text().to_string();
-                name_preview.set_text(&format!("Account id: {}", account_slug_suggestion(&text)));
+                name_preview.set_text(&format!("Account id: {}", account_id_suggestion(&text)));
                 name_suggests_usable(&text, None)
             } else {
                 true
@@ -235,7 +235,7 @@ pub(super) async fn account_dialog(
     refresh();
 
     (dialog.choose_future(Some(parent)).await == "accept").then(|| AccountForm {
-        slug: ask_for_name.then(|| account_slug_suggestion(&name.text())),
+        slug: ask_for_name.then(|| account_id_suggestion(&name.text())),
         endpoint: endpoint.text().trim().to_owned(),
         allow_insecure_http: insecure.is_active(),
         key: key.text().trim().to_owned(),

--- a/crates/tidemarkd/src/engine.rs
+++ b/crates/tidemarkd/src/engine.rs
@@ -334,8 +334,8 @@ pub struct Account {
 /// account's name reads it too; this is the daemon-side spelling of it, shared by the
 /// engine and the D-Bus service so a call rejected here is rejected for the same reason
 /// there.
-pub(crate) fn valid_account_slug(account: &str) -> bool {
-    tidemark_types::valid_account_slug(account)
+pub(crate) fn valid_account_id(account: &str) -> bool {
+    tidemark_types::valid_account_id(account)
 }
 
 /// Everything about an account that is fixed at registration, kept together so both
@@ -671,8 +671,8 @@ impl Engine {
     }
     /// Adds one account to a configured provider without restarting the loop.
     pub async fn add_account(&mut self, provider: &str, account: &str) -> Result<(), String> {
-        if !valid_account_slug(account) {
-            return Err(format!("account {account:?} is not a valid lowercase slug"));
+        if !valid_account_id(account) {
+            return Err(format!("account {account:?} is not a valid account id"));
         }
 
         let mut config = Config::at(self.config_path.clone()).map_err(|error| error.to_string())?;
@@ -1049,8 +1049,8 @@ impl Engine {
         if new == account {
             return Err(format!("account {provider}/{new} is already named that"));
         }
-        if !valid_account_slug(new) {
-            return Err(format!("account {new:?} is not a valid lowercase slug"));
+        if !valid_account_id(new) {
+            return Err(format!("account {new:?} is not a valid account id"));
         }
         let Some(index) = self.accounts.iter().position(|configured| {
             configured.provider.as_str() == provider && configured.account.as_str() == account
@@ -3960,6 +3960,67 @@ svg = '''
         let _ = std::fs::remove_file(config_path);
     }
 
+    /// The account id is also the name the card shows above the provider, so it is whatever
+    /// the user typed — including a script with no ASCII in it at all. Everything it is a
+    /// key for has to survive that: the config file it is written to and read back from,
+    /// the credential slot, and the history rows.
+    #[tokio::test]
+    async fn an_account_named_in_another_script_is_stored_and_read_back_as_typed() {
+        let config_path = std::env::temp_dir().join(format!(
+            "tidemark-engine-unicode-{}.toml",
+            std::process::id()
+        ));
+        let (mut harness, secrets) = stored_harness(config_path.clone(), &["default", "work"]);
+        secrets.insert(Kind::Key, "kimi", "work", "work-key");
+        let mut reading = snapshot(50.0, 3600);
+        reading.provider = ProviderId::new("kimi");
+        reading.account = AccountId::new("work");
+        harness
+            .engine
+            .history
+            .ingest(&reading)
+            .expect("history written");
+
+        harness
+            .engine
+            .rename_account("kimi", "work", "Личный аккаунт")
+            .await
+            .expect("renamed");
+
+        assert_eq!(
+            Config::at(config_path.clone())
+                .expect("parses")
+                .accounts("kimi")
+                .expect("accounts readable"),
+            ["default", "Личный аккаунт"],
+            "the daemon has to read back the file it just wrote"
+        );
+        assert_eq!(
+            secrets.held(),
+            vec![(
+                "key".to_owned(),
+                "kimi".to_owned(),
+                "Личный аккаунт".to_owned(),
+                "work-key".to_owned()
+            )]
+        );
+        assert_eq!(
+            harness
+                .engine
+                .history
+                .points("kimi", "Личный аккаунт", &reading.windows[0].key, 1)
+                .expect("points read")
+                .len(),
+            1
+        );
+        assert_eq!(
+            harness.engine.accounts()[1].status.account_label.as_deref(),
+            Some("Личный аккаунт"),
+            "the caption over the provider's name is the name as typed"
+        );
+        let _ = std::fs::remove_file(config_path);
+    }
+
     #[tokio::test]
     async fn a_rename_publishes_the_retired_id_first_and_replaces_it_with_the_new_one() {
         let config_path = std::env::temp_dir().join(format!(
@@ -4045,7 +4106,7 @@ svg = '''
         for (account, new) in [
             ("default", "team"),
             ("work", "work"),
-            ("work", "Team"),
+            ("work", "-team"),
             ("work", "default"),
             ("missing", "team"),
         ] {

--- a/crates/tidemarkd/src/service.rs
+++ b/crates/tidemarkd/src/service.rs
@@ -880,10 +880,10 @@ impl Daemon {
                 "provider {provider} is not supported by this build"
             )));
         }
-        if !crate::engine::valid_account_slug(account) {
+        if !crate::engine::valid_account_id(account) {
             return Err(fdo::Error::InvalidArgs(format!(
-                "account {account:?} is not a valid account id: lowercase letters, digits \
-                 and hyphens"
+                "account {account:?} is not a valid account id: letters, digits, spaces, \
+                 hyphens and underscores, beginning and ending on a letter or a digit"
             )));
         }
         if self
@@ -929,9 +929,10 @@ impl Daemon {
                 "account {provider}/{new} is already named that"
             )));
         }
-        if !crate::engine::valid_account_slug(new) {
+        if !crate::engine::valid_account_id(new) {
             return Err(fdo::Error::InvalidArgs(format!(
-                "account {new:?} is not a valid account id: lowercase letters, digits \n                 and hyphens"
+                "account {new:?} is not a valid account id: letters, digits, spaces, \
+                 hyphens and underscores, beginning and ending on a letter or a digit"
             )));
         }
         if self.configured.read().await.contains(&key(provider, new)) {
@@ -2518,14 +2519,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn adding_a_malformed_account_slug_is_an_invalid_argument() {
+    async fn a_malformed_account_id_is_an_invalid_argument() {
         let (daemon, _secrets, mut commands) = daemon_over_catalog(Vec::new(), catalog()).await;
 
-        for slug in ["", "Work", "work-", "-work", "two words", "work_1", "wörk"] {
-            let error = daemon.add_account("zai", slug).await.unwrap_err();
+        for id in [
+            "", " ", "work-", "-work", "work ", "work/2", "work.2", "work\n",
+        ] {
+            let error = daemon.add_account("zai", id).await.unwrap_err();
             assert!(
                 matches!(error, fdo::Error::InvalidArgs(_)),
-                "{slug:?} is not an id the config can hold"
+                "{id:?} is not an id the config can hold"
             );
         }
         assert!(matches!(
@@ -3307,7 +3310,7 @@ mod tests {
             ("zai", "missing", "team"),
             ("zai", "default", "team"),
             ("zai", "work", "work"),
-            ("zai", "work", "Team"),
+            ("zai", "work", "team "),
             ("zai", "work", "default"),
         ] {
             let error = daemon


### PR DESCRIPTION
## Problem

The account id is what a card shows above the provider's own name, and it was restricted to ASCII `[a-z0-9-]`. A Cyrillic name suggested an empty id, so the confirm button in the name dialog never enabled: there was no way to call an account `Работа`.

## Change

- `tidemark_types::valid_account_id` (was `valid_account_slug`): letters and digits in **any script**, plus spaces, hyphens and underscores, beginning and ending on a letter or a digit, case kept. Still refused: empty, invisible edges (` work`, `work `, `-work`), control characters, and punctuation that reads as structure where the id is stored (`/`, `.`, quotes).
- `account_id_suggestion` (was `account_slug_suggestion`): keeps case, spaces and script, so a name suggests itself unless it carries punctuation — which still becomes a hyphen rather than being dropped (`Team (QA)` → `Team QA`, `Q&A` → `Q-A`).
- Daemon argument errors name the new rule; docs (`CONTEXT.md`, `README.md`, `tidemark-types/AGENTS.md`) state it.

No storage change was needed: the id is a TOML value in `accounts`, a quoted key where a plugin's per-account table needs one, a bound SQLite parameter, a Secret Service attribute and a D-Bus string — all of which already hold arbitrary UTF-8. Existing ids are untouched; validation only runs on add and rename.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (0 failed), `scripts/check-layering.sh`.

New tests: a Cyrillic rename migrating config + credential + history rows (`tidemarkd engine`), a Unicode account written as a **quoted** TOML table key and read back (`tidemark-core config`), and the rule itself (`tidemark-types wire`).

End-to-end against the real binaries on an isolated bus with no service directories (so the installed daemon could not be activated onto the real home):

```
$ tidemarkctl account add zai Работа                 exit=0
$ tidemarkctl account add zai "Личный аккаунт"       exit=0
$ tidemarkctl account add zai "work "
  InvalidArgs: account "work " is not a valid account id: letters, digits,
  spaces, hyphens and underscores, beginning and ending on a letter or a digit
$ tidemarkctl usage --format json | grep account
  "account": "default" / "account": "Работа" / "account": "Личный аккаунт"
$ cat config.toml
  [provider.zai]
  accounts = ["default", "Работа", "Личный аккаунт"]
```

The bundled Rubik covers U+0400–04FF (176 codepoints), so the caption renders in the app's own font rather than a fallback.

## What to check by hand

Add a second account to a configured provider, type a Cyrillic name, and confirm the caption above the provider's name on the card reads exactly what was typed.